### PR TITLE
feat: implement full playlist feature with DnD reorder, add/remove, s…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "better-sqlite3": "^12.6.2",
         "react-virtualized": "^9.22.6",
         "react-window": "^2.2.5"
@@ -28,6 +31,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@electron/get": {
@@ -3224,7 +3280,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "wait-on": "^9.0.3"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "better-sqlite3": "^12.6.2",
     "react-virtualized": "^9.22.6",
     "react-window": "^2.2.5"

--- a/renderer/package-lock.json
+++ b/renderer/package-lock.json
@@ -8,6 +8,9 @@
       "name": "renderer",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-window": "^1.8.10"
@@ -313,6 +316,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2747,6 +2803,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/renderer/package.json
+++ b/renderer/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-window": "^1.8.10"

--- a/renderer/src/MusicLibrary.css
+++ b/renderer/src/MusicLibrary.css
@@ -199,3 +199,85 @@
 .context-menu-item--has-submenu:hover .context-submenu {
   display: block;
 }
+
+/* ── Playlist header bar ───────────────────────────────────────────────── */
+.playlist-header-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  background: #1a1a1a;
+  border-bottom: 1px solid #2a2a2a;
+  font-size: 13px;
+}
+
+.playlist-header-name {
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.playlist-header-meta {
+  color: #888;
+  font-size: 12px;
+}
+
+.btn-save-order {
+  margin-left: auto;
+  background: none;
+  border: 1px solid #555;
+  color: #ccc;
+  font-size: 12px;
+  padding: 3px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-save-order:hover { border-color: #888; color: #fff; }
+
+/* ── Playlist DnD list ─────────────────────────────────────────────────── */
+.playlist-dnd-list {
+  overflow-y: auto;
+  height: 600px;
+}
+
+.drag-handle {
+  cursor: grab;
+  color: #555;
+  font-size: 14px;
+}
+
+.drag-handle:active { cursor: grabbing; }
+
+.row-drag-overlay {
+  background: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 4px;
+  opacity: 0.9;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+
+/* ── Playlist empty state ──────────────────────────────────────────────── */
+.playlist-empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 300px;
+  color: #555;
+  font-size: 14px;
+  text-align: center;
+  line-height: 1.8;
+}
+
+/* ── Context menu additions ────────────────────────────────────────────── */
+.context-menu-item--checked {
+  color: #4caf50;
+}
+
+.ctx-color-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 5px;
+  vertical-align: middle;
+}

--- a/renderer/src/Sidebar.css
+++ b/renderer/src/Sidebar.css
@@ -114,7 +114,111 @@
     border-color: #10c44f;
 }
 
-/* Custom thin scrollbar */
+.playlists-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 4px 4px 12px;
+    margin-bottom: 4px;
+}
+
+.new-playlist-btn {
+    background: none;
+    border: none;
+    color: #888;
+    font-size: 18px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0 4px;
+    border-radius: 4px;
+}
+
+.new-playlist-btn:hover { color: #fff; }
+
+.playlist-item {
+    padding: 6px 8px;
+    gap: 6px;
+}
+
+.playlist-color-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.playlist-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 13px;
+    margin-left: 0;
+}
+
+.playlist-count {
+    font-size: 11px;
+    color: #666;
+    flex-shrink: 0;
+}
+
+.playlists-empty {
+    font-size: 12px;
+    color: #555;
+    padding: 8px 12px;
+    font-style: italic;
+}
+
+.playlist-new-form {
+    padding: 2px 4px;
+}
+
+.playlist-rename-input {
+    width: 100%;
+    background: #2a2a2a;
+    border: 1px solid #444;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 13px;
+    padding: 4px 8px;
+    outline: none;
+    box-sizing: border-box;
+}
+
+.playlist-rename-input:focus { border-color: #666; }
+
+/* Color swatches in context submenu */
+.color-swatch {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    cursor: pointer;
+    margin: 2px;
+    display: inline-block;
+    flex-shrink: 0;
+    border: 2px solid transparent;
+}
+
+.color-swatch:hover { border-color: #fff; }
+
+.color-swatch--none {
+    background: #333 !important;
+    color: #888;
+    font-size: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+}
+
+/* Override submenu layout for color picker */
+.context-submenu:has(.color-swatch) {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 6px;
+    min-width: 110px;
+    max-width: 130px;
+}
 .scrollable-playlists::-webkit-scrollbar {
     width: 4px;
 }

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -1,80 +1,221 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import './Sidebar.css';
 
-const musicItems = [
+const MUSIC_ITEMS = [
   { id: 'music', name: 'Music', icon: '🎵' },
-  { id: 'radio', name: 'Radio', icon: '📻' },
-  { id: 'download', name: 'Download', icon: '🔍' },
 ];
 
-const playlistItems = Array.from({ length: 45 }, (_, i) => ({
-  id: `pl${i + 1}`,
-  name: `Playlist ${i + 1}`,
-}));
+const PRESET_COLORS = ['#e63946','#f4a261','#2a9d8f','#457b9d','#9b5de5','#f15bb5','#00bbf9','#adb5bd'];
 
 function Sidebar({ selectedMenuItemId, onMenuSelect }) {
+  const [playlists, setPlaylists] = useState([]);
   const [importProgress, setImportProgress] = useState({ total: 0, completed: 0 });
+  const [newPlaylistName, setNewPlaylistName] = useState('');
+  const [creatingPlaylist, setCreatingPlaylist] = useState(false);
+  const [playlistMenu, setPlaylistMenu] = useState(null); // { id, x, y }
+  const [renamingId, setRenamingId] = useState(null);
+  const [renameValue, setRenameValue] = useState('');
+  const newInputRef = useRef(null);
+  const renameInputRef = useRef(null);
+
+  const loadPlaylists = useCallback(async () => {
+    const list = await window.api.getPlaylists();
+    setPlaylists(list);
+  }, []);
+
+  useEffect(() => {
+    loadPlaylists();
+    const unsub = window.api.onPlaylistsUpdated(loadPlaylists);
+    return unsub;
+  }, [loadPlaylists]);
+
+  // Focus new playlist input when it appears
+  useEffect(() => {
+    if (creatingPlaylist) newInputRef.current?.focus();
+  }, [creatingPlaylist]);
+
+  useEffect(() => {
+    if (renamingId !== null) renameInputRef.current?.focus();
+  }, [renamingId]);
+
+  // Close playlist context menu on outside click
+  useEffect(() => {
+    if (!playlistMenu) return;
+    const close = () => setPlaylistMenu(null);
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [playlistMenu]);
 
   const handleImport = async () => {
     const files = await window.api.selectAudioFiles();
     if (!files.length) return;
-
     setImportProgress({ total: files.length, completed: 0 });
     await window.api.importAudioFiles(files);
     setImportProgress({ total: 0, completed: 0 });
   };
 
-  const renderMenuSection = (items, sectionTitle, scrollable = false) => (
-    <div className={`menu-section ${scrollable ? 'scrollable' : ''}`}>
-      {items.length > 0 && (
-        <>
-          {sectionTitle && (
-            <div className="section-title">{sectionTitle}</div>
-          )}
-          {items.map(item => (
+  const handleCreatePlaylist = async (e) => {
+    e.preventDefault();
+    const name = newPlaylistName.trim();
+    if (!name) { setCreatingPlaylist(false); return; }
+    await window.api.createPlaylist(name, null);
+    setNewPlaylistName('');
+    setCreatingPlaylist(false);
+  };
+
+  const handleRenameSubmit = async (e) => {
+    e.preventDefault();
+    const name = renameValue.trim();
+    if (name) await window.api.renamePlaylist(renamingId, name);
+    setRenamingId(null);
+  };
+
+  const handleDeletePlaylist = async (id) => {
+    setPlaylistMenu(null);
+    if (!window.confirm('Delete this playlist? Tracks will stay in your library.')) return;
+    if (selectedMenuItemId === String(id)) onMenuSelect('music');
+    await window.api.deletePlaylist(id);
+  };
+
+  const handleColorPick = async (id, color) => {
+    setPlaylistMenu(null);
+    await window.api.updatePlaylistColor(id, color);
+  };
+
+  const formatDuration = (secs) => {
+    const h = Math.floor(secs / 3600);
+    const m = Math.floor((secs % 3600) / 60);
+    if (h > 0) return `${h}h ${m}m`;
+    return `${m}m`;
+  };
+
+  return (
+    <div className="sidebar">
+      <div className="fixed-top-section">
+        <div className="menu-section">
+          {MUSIC_ITEMS.map(item => (
             <div
               key={item.id}
               className={`menu-item ${selectedMenuItemId === item.id ? 'active' : ''}`}
               onClick={() => onMenuSelect(item.id)}
             >
-              {item.icon && <span className="menu-icon">{item.icon}</span>}
+              <span className="menu-icon">{item.icon}</span>
               <span className="menu-text">{item.name}</span>
             </div>
           ))}
-        </>
-      )}
-    </div>
-  );
-
-  return (
-    <div className="sidebar">
-      {/* Fixed top section */}
-      <div className="fixed-top-section">
-        {renderMenuSection(musicItems, null, false)}
-        <div className="menu-separator"></div>
+        </div>
+        <div className="menu-separator" />
+        <div className="playlists-header">
+          <span className="section-title" style={{ padding: 0 }}>PLAYLISTS</span>
+          <button className="new-playlist-btn" onClick={() => setCreatingPlaylist(true)} title="New playlist">＋</button>
+        </div>
       </div>
 
-      {/* Scrollable playlists */}
       <div className="scrollable-playlists">
-        {renderMenuSection(playlistItems, 'PLAYLISTS', true)}
+        {creatingPlaylist && (
+          <form className="playlist-new-form" onSubmit={handleCreatePlaylist}>
+            <input
+              ref={newInputRef}
+              className="playlist-rename-input"
+              value={newPlaylistName}
+              onChange={e => setNewPlaylistName(e.target.value)}
+              placeholder="Playlist name"
+              onBlur={handleCreatePlaylist}
+              onKeyDown={e => e.key === 'Escape' && setCreatingPlaylist(false)}
+            />
+          </form>
+        )}
+
+        {playlists.length === 0 && !creatingPlaylist && (
+          <div className="playlists-empty">No playlists yet</div>
+        )}
+
+        {playlists.map(pl => (
+          <div key={pl.id}>
+            {renamingId === pl.id ? (
+              <form className="playlist-new-form" onSubmit={handleRenameSubmit}>
+                <input
+                  ref={renameInputRef}
+                  className="playlist-rename-input"
+                  value={renameValue}
+                  onChange={e => setRenameValue(e.target.value)}
+                  onBlur={handleRenameSubmit}
+                  onKeyDown={e => e.key === 'Escape' && setRenamingId(null)}
+                />
+              </form>
+            ) : (
+              <div
+                className={`menu-item playlist-item ${selectedMenuItemId === String(pl.id) ? 'active' : ''}`}
+                onClick={() => onMenuSelect(String(pl.id))}
+                onContextMenu={e => {
+                  e.preventDefault();
+                  setPlaylistMenu({ id: pl.id, x: e.clientX, y: e.clientY });
+                }}
+              >
+                {pl.color && <span className="playlist-color-dot" style={{ background: pl.color }} />}
+                <span className="menu-text playlist-name">{pl.name}</span>
+                <span className="playlist-count">{pl.track_count}</span>
+              </div>
+            )}
+          </div>
+        ))}
       </div>
 
-      {/* Fixed bottom section - ALWAYS stays at bottom */}
       <div className="fixed-bottom-section">
         {importProgress.total > 0 && (
           <div className="import-progress">
-            Importing {importProgress.completed} / {importProgress.total}...
+            Importing {importProgress.completed} / {importProgress.total}…
           </div>
         )}
-        <button
-          className="import-button"
-          onClick={handleImport}
-        >
+        <button className="import-button" onClick={handleImport}>
           Import Audio Files
         </button>
       </div>
+
+      {/* Playlist context menu */}
+      {playlistMenu && (
+        <div
+          className="context-menu"
+          style={{ top: playlistMenu.y, left: playlistMenu.x }}
+          onMouseDown={e => e.stopPropagation()}
+        >
+          <div className="context-menu-item" onClick={() => {
+            const pl = playlists.find(p => p.id === playlistMenu.id);
+            setRenameValue(pl?.name ?? '');
+            setRenamingId(playlistMenu.id);
+            setPlaylistMenu(null);
+          }}>
+            ✏️ Rename
+          </div>
+          <div className="context-menu-item context-menu-item--has-submenu">
+            🎨 Color
+            <div className="context-submenu">
+              {PRESET_COLORS.map(c => (
+                <div
+                  key={c}
+                  className="color-swatch"
+                  style={{ background: c }}
+                  onClick={() => handleColorPick(playlistMenu.id, c)}
+                />
+              ))}
+              <div
+                className="color-swatch color-swatch--none"
+                onClick={() => handleColorPick(playlistMenu.id, null)}
+              >✕</div>
+            </div>
+          </div>
+          <div className="context-menu-separator" />
+          <div
+            className="context-menu-item context-menu-item--danger"
+            onClick={() => handleDeletePlaylist(playlistMenu.id)}
+          >
+            🗑️ Delete playlist
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
 export default Sidebar;
+

--- a/renderer/vite.config.js
+++ b/renderer/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   base: './',
   plugins: [react()],
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
 })

--- a/src/audio/importManager.js
+++ b/src/audio/importManager.js
@@ -48,11 +48,11 @@ export function spawnAnalysis(trackId, filePath) {
       return;
     }
     console.log(`Analysis finished for track ID ${trackId}:`, result);
-    updateTrack(trackId, result);
+    updateTrack(trackId, { ...result, bpm_override: null }); // clear any manual BPM override
 
     // Notify renderer
     if (global.mainWindow) {
-      global.mainWindow.webContents.send('track-updated', { trackId, analysis: result });
+      global.mainWindow.webContents.send('track-updated', { trackId, analysis: { ...result, bpm_override: null } });
     }
   });
 }

--- a/src/db/migrations.js
+++ b/src/db/migrations.js
@@ -69,18 +69,56 @@ export function initDB() {
   db.prepare(`
     CREATE TABLE IF NOT EXISTS playlists (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      name TEXT NOT NULL
+      name TEXT NOT NULL,
+      color TEXT,
+      created_at INTEGER
     )
   `).run();
 
   db.prepare(`
     CREATE TABLE IF NOT EXISTS playlist_tracks (
-      playlist_id INTEGER NOT NULL,
-      track_id INTEGER NOT NULL,
-      track_order INTEGER NOT NULL,
+      playlist_id INTEGER NOT NULL REFERENCES playlists(id) ON DELETE CASCADE,
+      track_id INTEGER NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+      position INTEGER NOT NULL DEFAULT 0,
+      date_added INTEGER,
       PRIMARY KEY (playlist_id, track_id)
     )
   `).run();
+
+  // Migrate existing playlist tables
+  for (const col of [
+    'ALTER TABLE playlists ADD COLUMN color TEXT',
+    'ALTER TABLE playlists ADD COLUMN created_at INTEGER',
+    'ALTER TABLE playlist_tracks ADD COLUMN position INTEGER NOT NULL DEFAULT 0',
+    'ALTER TABLE playlist_tracks ADD COLUMN date_added INTEGER',
+  ]) {
+    try { db.prepare(col).run(); } catch { /* column already exists */ }
+  }
+
+  // Drop legacy track_order column by recreating playlist_tracks without it.
+  // track_order existed in old schema as NOT NULL with no default, breaking inserts.
+  const hasTrackOrder = db.prepare(
+    `SELECT 1 FROM pragma_table_info('playlist_tracks') WHERE name = 'track_order'`
+  ).get();
+  if (hasTrackOrder) {
+    db.transaction(() => {
+      db.prepare(`ALTER TABLE playlist_tracks RENAME TO playlist_tracks_old`).run();
+      db.prepare(`
+        CREATE TABLE playlist_tracks (
+          playlist_id INTEGER NOT NULL REFERENCES playlists(id) ON DELETE CASCADE,
+          track_id    INTEGER NOT NULL REFERENCES tracks(id)   ON DELETE CASCADE,
+          position    INTEGER NOT NULL DEFAULT 0,
+          date_added  INTEGER,
+          PRIMARY KEY (playlist_id, track_id)
+        )
+      `).run();
+      db.prepare(`
+        INSERT INTO playlist_tracks (playlist_id, track_id, position, date_added)
+        SELECT playlist_id, track_id, position, date_added FROM playlist_tracks_old
+      `).run();
+      db.prepare(`DROP TABLE playlist_tracks_old`).run();
+    })();
+  }
 
   db.prepare(`
     CREATE TABLE IF NOT EXISTS settings (

--- a/src/db/playlistRepository.js
+++ b/src/db/playlistRepository.js
@@ -1,54 +1,140 @@
 // src/db/playlistRepository.js
 import db from './database.js';
 
-// Create a new playlist
-export function createPlaylist(name) {
-  const stmt = db.prepare(`INSERT INTO playlists (name) VALUES (?)`);
-  return stmt.run(name).lastInsertRowid;
+export function createPlaylist(name, color = null) {
+  const info = db.prepare(
+    `INSERT INTO playlists (name, color, created_at) VALUES (?, ?, ?)`
+  ).run(name, color, Date.now());
+  return info.lastInsertRowid;
 }
 
-// Get playlist info
+export function getPlaylists() {
+  return db.prepare(`
+    SELECT
+      p.id,
+      p.name,
+      p.color,
+      p.created_at,
+      COUNT(pt.track_id)                          AS track_count,
+      COALESCE(SUM(t.duration), 0)                AS total_duration
+    FROM playlists p
+    LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
+    LEFT JOIN tracks t ON t.id = pt.track_id
+    GROUP BY p.id
+    ORDER BY p.created_at ASC
+  `).all();
+}
+
 export function getPlaylist(id) {
-  return db.prepare(`SELECT * FROM playlists WHERE id = ?`).get(id);
+  return db.prepare(`
+    SELECT
+      p.id, p.name, p.color, p.created_at,
+      COUNT(pt.track_id)           AS track_count,
+      COALESCE(SUM(t.duration), 0) AS total_duration
+    FROM playlists p
+    LEFT JOIN playlist_tracks pt ON pt.playlist_id = p.id
+    LEFT JOIN tracks t ON t.id = pt.track_id
+    WHERE p.id = ?
+    GROUP BY p.id
+  `).get(id);
 }
 
-// Delete playlist
+export function renamePlaylist(id, name) {
+  db.prepare(`UPDATE playlists SET name = ? WHERE id = ?`).run(name, id);
+}
+
+export function updatePlaylistColor(id, color) {
+  db.prepare(`UPDATE playlists SET color = ? WHERE id = ?`).run(color, id);
+}
+
 export function deletePlaylist(id) {
+  // playlist_tracks rows cascade via FK
   db.prepare(`DELETE FROM playlists WHERE id = ?`).run(id);
 }
 
-// Add track to playlist with specific order
-export function addTrackToPlaylist(playlistId, trackId, trackOrder) {
-  db.prepare(`
-    INSERT INTO playlist_tracks (playlist_id, track_id, track_order)
-    VALUES (?, ?, ?)
-  `).run(playlistId, trackId, trackOrder);
+// Returns the next available position in a playlist
+function nextPosition(playlistId) {
+  const row = db.prepare(
+    `SELECT COALESCE(MAX(position), -1) + 1 AS pos FROM playlist_tracks WHERE playlist_id = ?`
+  ).get(playlistId);
+  return row.pos;
 }
 
-// Get tracks in a playlist, ordered by track_order
+export function addTrackToPlaylist(playlistId, trackId) {
+  const pos = nextPosition(playlistId);
+  db.prepare(`
+    INSERT OR IGNORE INTO playlist_tracks (playlist_id, track_id, position, date_added)
+    VALUES (?, ?, ?, ?)
+  `).run(playlistId, trackId, pos, Date.now());
+}
+
+export function addTracksToPlaylist(playlistId, trackIds) {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO playlist_tracks (playlist_id, track_id, position, date_added)
+    VALUES (?, ?, ?, ?)
+  `);
+  db.transaction(() => {
+    let pos = nextPosition(playlistId);
+    for (const trackId of trackIds) {
+      insert.run(playlistId, trackId, pos++, Date.now());
+    }
+  })();
+}
+
+export function removeTrackFromPlaylist(playlistId, trackId) {
+  db.transaction(() => {
+    const row = db.prepare(
+      `SELECT position FROM playlist_tracks WHERE playlist_id = ? AND track_id = ?`
+    ).get(playlistId, trackId);
+    if (!row) return;
+    db.prepare(`DELETE FROM playlist_tracks WHERE playlist_id = ? AND track_id = ?`)
+      .run(playlistId, trackId);
+    // Compact positions above the removed one
+    db.prepare(`
+      UPDATE playlist_tracks SET position = position - 1
+      WHERE playlist_id = ? AND position > ?
+    `).run(playlistId, row.position);
+  })();
+}
+
+// Rewrite all positions from an ordered array of track IDs
+export function reorderPlaylistTracks(playlistId, orderedTrackIds) {
+  const stmt = db.prepare(
+    `UPDATE playlist_tracks SET position = ? WHERE playlist_id = ? AND track_id = ?`
+  );
+  db.transaction(() => {
+    orderedTrackIds.forEach((trackId, index) => {
+      stmt.run(index, playlistId, trackId);
+    });
+  })();
+}
+
+export function isTrackInPlaylist(playlistId, trackId) {
+  return !!db.prepare(
+    `SELECT 1 FROM playlist_tracks WHERE playlist_id = ? AND track_id = ?`
+  ).get(playlistId, trackId);
+}
+
+// Returns [{id, name, color, isMember}] for all playlists, for a given track
+export function getPlaylistsForTrack(trackId) {
+  return db.prepare(`
+    SELECT
+      p.id, p.name, p.color,
+      EXISTS (
+        SELECT 1 FROM playlist_tracks pt2
+        WHERE pt2.playlist_id = p.id AND pt2.track_id = ?
+      ) AS is_member
+    FROM playlists p
+    ORDER BY p.created_at ASC
+  `).all(trackId);
+}
+
 export function getPlaylistTracks(playlistId) {
   return db.prepare(`
     SELECT t.*
     FROM playlist_tracks pt
     JOIN tracks t ON t.id = pt.track_id
     WHERE pt.playlist_id = ?
-    ORDER BY pt.track_order ASC
+    ORDER BY pt.position ASC
   `).all(playlistId);
-}
-
-// Update track order in a playlist
-export function updateTrackOrder(playlistId, trackId, newOrder) {
-  db.prepare(`
-    UPDATE playlist_tracks
-    SET track_order = ?
-    WHERE playlist_id = ? AND track_id = ?
-  `).run(newOrder, playlistId, trackId);
-}
-
-// Remove track from playlist
-export function removeTrackFromPlaylist(playlistId, trackId) {
-  db.prepare(`
-    DELETE FROM playlist_tracks
-    WHERE playlist_id = ? AND track_id = ?
-  `).run(playlistId, trackId);
 }

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,21 +1,38 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('api', {
-  createPlaylist: (name) => ipcRenderer.invoke('create-playlist', name),
-  addTrack: (track) => ipcRenderer.invoke('add-track', track),
-  addTrackToPlaylist: (playlistId, trackId, order) =>
-    ipcRenderer.invoke('add-track-to-playlist', playlistId, trackId, order),
-  getPlaylistTracks: (playlistId) => ipcRenderer.invoke('get-playlist-tracks', playlistId),
-  selectAudioFiles: () => ipcRenderer.invoke('select-audio-files'),
-  importAudioFiles: (files) => ipcRenderer.invoke('import-audio-files', files),
+  // Track library
   getTracks: (params) => ipcRenderer.invoke('get-tracks', params),
   getTrackIds: (params) => ipcRenderer.invoke('get-track-ids', params),
-  getSetting: (key, def) => ipcRenderer.invoke('get-setting', key, def),
-  setSetting: (key, value) => ipcRenderer.invoke('set-setting', key, value),
-  normalizeLibrary: (payload) => ipcRenderer.invoke('normalize-library', payload),
   reanalyzeTrack: (trackId) => ipcRenderer.invoke('reanalyze-track', trackId),
   removeTrack: (trackId) => ipcRenderer.invoke('remove-track', trackId),
   adjustBpm: (payload) => ipcRenderer.invoke('adjust-bpm', payload),
+
+  // Import
+  selectAudioFiles: () => ipcRenderer.invoke('select-audio-files'),
+  importAudioFiles: (files) => ipcRenderer.invoke('import-audio-files', files),
+
+  // Playlists
+  getPlaylists: () => ipcRenderer.invoke('get-playlists'),
+  getPlaylist: (id) => ipcRenderer.invoke('get-playlist', id),
+  createPlaylist: (name, color) => ipcRenderer.invoke('create-playlist', { name, color }),
+  renamePlaylist: (id, name) => ipcRenderer.invoke('rename-playlist', { id, name }),
+  updatePlaylistColor: (id, color) => ipcRenderer.invoke('update-playlist-color', { id, color }),
+  deletePlaylist: (id) => ipcRenderer.invoke('delete-playlist', id),
+  addTracksToPlaylist: (playlistId, trackIds) =>
+    ipcRenderer.invoke('add-tracks-to-playlist', { playlistId, trackIds }),
+  removeTrackFromPlaylist: (playlistId, trackId) =>
+    ipcRenderer.invoke('remove-track-from-playlist', { playlistId, trackId }),
+  reorderPlaylist: (playlistId, orderedTrackIds) =>
+    ipcRenderer.invoke('reorder-playlist', { playlistId, orderedTrackIds }),
+  getPlaylistsForTrack: (trackId) => ipcRenderer.invoke('get-playlists-for-track', trackId),
+
+  // Settings
+  getSetting: (key, def) => ipcRenderer.invoke('get-setting', key, def),
+  setSetting: (key, value) => ipcRenderer.invoke('set-setting', key, value),
+  normalizeLibrary: (payload) => ipcRenderer.invoke('normalize-library', payload),
+
+  // Events
   onTrackUpdated: (callback) => {
     const handler = (_, data) => callback(data);
     ipcRenderer.on('track-updated', handler);
@@ -25,6 +42,11 @@ contextBridge.exposeInMainWorld('api', {
     const handler = () => callback();
     ipcRenderer.on('library-updated', handler);
     return () => ipcRenderer.removeListener('library-updated', handler);
+  },
+  onPlaylistsUpdated: (callback) => {
+    const handler = () => callback();
+    ipcRenderer.on('playlists-updated', handler);
+    return () => ipcRenderer.removeListener('playlists-updated', handler);
   },
   onOpenSettings: (callback) => {
     const handler = () => callback();


### PR DESCRIPTION
…idebar

- Add playlists and playlist_tracks DB schema with position, date_added, color, created_at; migrate existing DBs including dropping legacy track_order column that broke INSERT OR IGNORE
- Implement playlistRepository with getPlaylists (count+duration), addTracksToPlaylist (INSERT OR IGNORE, auto-position), removeTrackFromPlaylist (compact positions), reorderPlaylistTracks, getPlaylistsForTrack
- Wire all playlist IPC handlers in main.js; emit playlists-updated on mutations; getTracks/getTrackIds filter by playlistId via JOIN
- Expose all playlist APIs in preload.js
- Sidebar: load real playlists from DB with color dot, track count, inline create, right-click rename/delete/color picker; subscribe to playlists-updated
- MusicLibrary: add dnd-kit DnD for playlist view (SortableRow at module level to avoid remount), playlist header bar, empty state, Add to Playlist submenu with membership checkmarks, Remove from Playlist, Save Order button
- Fix DnD reorder: move IPC call outside state updater (pure updater), use sortedTracksRef for index lookup, SortableContext items uses sortedTracks
- Auto-reset sort to position order on DnD, Save Order, and view switch
- Fix BPM sort to use bpm_override ?? bpm as sort value
- Clear bpm_override on re-analyze so fresh analysis replaces manual override
- Install @dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities in renderer; add resolve.dedupe for react/react-dom to prevent duplicate React instances