### PR TITLE
fix(ci): node 22, author email, fix postinstall for electron-builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       # ── Download mixxx-analyzer standalone binary ─────────────────────────

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-renderer": "cd renderer && npm run build",
     "build": "npm run build-renderer",
     "electron-prod": "NODE_ENV=production electron .",
-    "postinstall": "electron-rebuild",
+    "postinstall": "electron-builder install-app-deps",
     "dist": "npm run build-renderer && electron-builder",
     "dist:linux": "npm run build-renderer && electron-builder --linux",
     "dist:win": "npm run build-renderer && electron-builder --win",
@@ -98,7 +98,10 @@
     "url": "git+https://github.com/Radexito/djman.git"
   },
   "keywords": [],
-  "author": "",
+  "author": {
+    "name": "Radexito",
+    "email": "ceo@rwtechworks.pl"
+  },
   "license": "ISC",
   "type": "module",
   "bugs": {


### PR DESCRIPTION
- Bump Node to 22 (required by @electron/rebuild >=22.12.0)
- Add author email ceo@rwtechworks.pl (required by deb packager)
- Fix postinstall: use 'electron-builder install-app-deps' instead of electron-rebuild