### PR TITLE
fix: correct renderer path in packaged app

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -93,7 +93,7 @@ function createWindow() {
     mainWindow.loadURL('http://localhost:5173');
     mainWindow.webContents.openDevTools();
   } else {
-    mainWindow.loadFile(path.join(__dirname, 'renderer/dist/index.html'));
+    mainWindow.loadFile(path.join(__dirname, '../renderer/dist/index.html'));
     // Block DevTools keyboard shortcut in production
     mainWindow.webContents.on('before-input-event', (event, input) => {
       if (input.key === 'F12' || (input.control && input.shift && input.key === 'I')) {


### PR DESCRIPTION
__dirname in packaged build resolves to app.asar/src/, so renderer/dist must be accessed with ../renderer/dist/index.html