### PR TITLE
feat: runtime download of FFmpeg and mixxx-analyzer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,16 +27,10 @@ jobs:
         include:
           - os: ubuntu-22.04
             platform: linux
-            analyzer_asset: linux-x86_64
-            analyzer_extract: tar
           - os: windows-latest
             platform: win
-            analyzer_asset: windows-x86_64
-            analyzer_extract: zip
           - os: macos-latest
             platform: mac
-            analyzer_asset: macos-arm64
-            analyzer_extract: zip
 
     runs-on: ${{ matrix.os }}
     name: Build (${{ matrix.platform }})
@@ -48,43 +42,6 @@ jobs:
         with:
           node-version: 22
           cache: npm
-
-      # ── Download mixxx-analyzer standalone binary ─────────────────────────
-      - name: Download mixxx-analyzer (Linux/macOS)
-        if: runner.os != 'Windows'
-        run: |
-          RELEASE_JSON=$(curl -s https://api.github.com/repos/Radexito/mixxx-analyzer/releases/latest)
-          URL=$(echo "$RELEASE_JSON" | jq -r --arg asset "${{ matrix.analyzer_asset }}" \
-            '.assets[] | select(.name | contains($asset)) | select(.name | endswith(".tar.gz") or endswith(".zip")) | .browser_download_url')
-          echo "Downloading: $URL"
-          mkdir -p build-resources
-
-          if [ "${{ matrix.analyzer_extract }}" = "tar" ]; then
-            curl -L "$URL" | tar -xz
-            find . -maxdepth 3 -name "mixxx-analyzer" -not -path "./.git/*" \
-              | head -1 | xargs -I{} cp {} build-resources/analysis
-          else
-            curl -L "$URL" -o analyzer.zip
-            unzip -q analyzer.zip -d analyzer-tmp
-            find analyzer-tmp -name "mixxx-analyzer" | head -1 | xargs -I{} cp {} build-resources/analysis
-            rm -rf analyzer-tmp analyzer.zip
-          fi
-          chmod +x build-resources/analysis
-
-      - name: Download mixxx-analyzer (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $release = Invoke-RestMethod "https://api.github.com/repos/Radexito/mixxx-analyzer/releases/latest"
-          $asset = $release.assets | Where-Object { $_.name -like "*${{ matrix.analyzer_asset }}*" -and $_.name -like "*.zip" } | Select-Object -First 1
-          Write-Host "Downloading: $($asset.browser_download_url)"
-          Invoke-WebRequest $asset.browser_download_url -OutFile analyzer.zip
-          New-Item -ItemType Directory -Force build-resources | Out-Null
-          Expand-Archive analyzer.zip -DestinationPath analyzer-tmp -Force
-          $binary = Get-ChildItem -Recurse -Filter "mixxx-analyzer.exe" analyzer-tmp | Select-Object -First 1
-          if (-not $binary) { $binary = Get-ChildItem -Recurse -Filter "*.exe" analyzer-tmp | Select-Object -First 1 }
-          Copy-Item $binary.FullName build-resources/analysis.exe
-          Remove-Item -Recurse analyzer-tmp, analyzer.zip
 
       # ── Node deps + renderer build ────────────────────────────────────────
       - name: Install root dependencies

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     },
     "files": [
       "src/**/*",
-      "python/**/*",
       "renderer/dist/**/*",
       "node_modules/**/*",
       "!node_modules/.cache/**/*",
@@ -41,12 +40,7 @@
         }
       ],
       "category": "Audio",
-      "extraResources": [
-        {
-          "from": "build-resources/analysis",
-          "to": "analysis"
-        }
-      ],
+      "extraResources": [],
       "artifactName": "${productName}-${version}-Linux.${ext}"
     },
     "mac": {
@@ -59,21 +53,11 @@
         }
       ],
       "category": "public.app-category.music",
-      "extraResources": [
-        {
-          "from": "build-resources/analysis",
-          "to": "analysis"
-        }
-      ]
+      "extraResources": []
     },
     "win": {
       "target": "nsis",
-      "extraResources": [
-        {
-          "from": "build-resources/analysis.exe",
-          "to": "analysis.exe"
-        }
-      ]
+      "extraResources": []
     },
     "publish": {
       "provider": "github",

--- a/renderer/src/SettingsModal.css
+++ b/renderer/src/SettingsModal.css
@@ -188,3 +188,34 @@
   color: #a6adc8;
 }
 .btn-secondary:hover { background: rgba(255,255,255,0.05); }
+.btn-secondary:disabled { opacity: 0.45; cursor: default; }
+.btn-primary {
+  padding: 6px 14px;
+  border-radius: 5px;
+  border: 1px solid #89b4fa;
+  font-size: 12px;
+  cursor: pointer;
+  background: transparent;
+  color: #89b4fa;
+}
+.btn-primary:hover { background: rgba(137,180,250,0.12); }
+.btn-primary:disabled { opacity: 0.45; cursor: default; }
+.dep-version-list { margin-bottom: 0.75rem; }
+.dep-version-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  font-size: 12px;
+  border-bottom: 1px solid #2a2a2a;
+}
+.dep-version-name { color: #cdd6f4; }
+.dep-version-tag { color: #a6adc8; font-family: monospace; }
+.dep-update-notice {
+  font-size: 12px;
+  color: #a6e3a1;
+  margin-bottom: 0.5rem;
+  padding: 6px 8px;
+  background: rgba(166,227,161,0.08);
+  border-radius: 4px;
+}

--- a/renderer/src/SettingsModal.jsx
+++ b/renderer/src/SettingsModal.jsx
@@ -7,11 +7,38 @@ function SettingsModal({ onClose }) {
   const [activeSection, setActiveSection] = useState('library');
   const [targetInput, setTargetInput] = useState(String(DEFAULT_TARGET));
   const [confirmClear, setConfirmClear] = useState(null); // 'library' | 'userdata'
+  const [depVersions, setDepVersions] = useState(null);
+  const [updateInfo, setUpdateInfo] = useState(null);
+  const [checkingUpdates, setCheckingUpdates] = useState(false);
+  const [updatingAnalyzer, setUpdatingAnalyzer] = useState(false);
 
   useEffect(() => {
     window.api.getSetting('normalize_target_lufs', String(DEFAULT_TARGET))
       .then(v => setTargetInput(v));
   }, []);
+
+  useEffect(() => {
+    if (activeSection === 'updates') {
+      window.api.getDepVersions().then(setDepVersions);
+    }
+  }, [activeSection]);
+
+  const handleCheckUpdates = async () => {
+    setCheckingUpdates(true);
+    setUpdateInfo(null);
+    const info = await window.api.checkDepUpdates();
+    setUpdateInfo(info);
+    setCheckingUpdates(false);
+  };
+
+  const handleUpdateAnalyzer = async () => {
+    setUpdatingAnalyzer(true);
+    await window.api.updateAnalyzer();
+    const versions = await window.api.getDepVersions();
+    setDepVersions(versions);
+    setUpdatingAnalyzer(false);
+    setUpdateInfo(null);
+  };
 
   const handleTargetChange = (raw) => {
     setTargetInput(raw);
@@ -31,8 +58,13 @@ function SettingsModal({ onClose }) {
     await window.api.clearUserData();
   };
 
+  const handleOpenLogs = async () => {
+    await window.api.openLogDir();
+  };
+
   const sections = [
     { id: 'library', label: 'Library' },
+    { id: 'updates', label: 'Updates' },
     { id: 'advanced', label: 'Advanced' },
   ];
 
@@ -82,9 +114,76 @@ function SettingsModal({ onClose }) {
             </>
           )}
 
+          {activeSection === 'updates' && (
+            <>
+              <h3>Updates</h3>
+              <div className="settings-group">
+                <div className="settings-group-title">Installed Versions</div>
+                <p className="settings-group-desc">
+                  FFmpeg and mixxx-analyzer are downloaded automatically on first launch.
+                </p>
+                {depVersions ? (
+                  <div className="dep-version-list">
+                    <div className="dep-version-row">
+                      <span className="dep-version-name">FFmpeg</span>
+                      <span className="dep-version-tag">{depVersions.ffmpeg?.version ?? 'not installed'}</span>
+                    </div>
+                    <div className="dep-version-row">
+                      <span className="dep-version-name">mixxx-analyzer</span>
+                      <span className="dep-version-tag">{depVersions.analyzer?.version ?? 'not installed'}</span>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="settings-group-desc">Loading…</p>
+                )}
+              </div>
+
+              <div className="settings-group">
+                <div className="settings-group-title">mixxx-analyzer</div>
+                {updateInfo?.analyzer && (
+                  <div className="dep-update-notice">
+                    {updateInfo.analyzer.hasUpdate
+                      ? <span>Update available: <b>{updateInfo.analyzer.latestTag}</b></span>
+                      : <span>mixxx-analyzer is up to date.</span>}
+                  </div>
+                )}
+                <div className="settings-row settings-row-action">
+                  <div>
+                    <div className="settings-action-label">Check for Updates</div>
+                    <div className="settings-action-desc">Check if a newer mixxx-analyzer is available.</div>
+                  </div>
+                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <button className="btn-secondary" onClick={handleCheckUpdates} disabled={checkingUpdates}>
+                      {checkingUpdates ? 'Checking…' : 'Check'}
+                    </button>
+                    {updateInfo?.analyzer?.hasUpdate && (
+                      <button className="btn-primary" onClick={handleUpdateAnalyzer} disabled={updatingAnalyzer}>
+                        {updatingAnalyzer ? 'Updating…' : 'Update'}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+
           {activeSection === 'advanced' && (
             <>
               <h3>Advanced</h3>
+
+              <div className="settings-group">
+                <div className="settings-group-title">Diagnostics</div>
+                <p className="settings-group-desc">
+                  Logs are saved daily and kept for 7 days. Include the log folder when reporting bugs.
+                </p>
+                <div className="settings-row settings-row-action">
+                  <div>
+                    <div className="settings-action-label">Log Files</div>
+                    <div className="settings-action-desc">Opens the folder containing runtime log files.</div>
+                  </div>
+                  <button className="btn-secondary" onClick={handleOpenLogs}>Open Log Folder</button>
+                </div>
+              </div>
 
               <div className="settings-group">
                 <div className="settings-group-title">Danger Zone</div>

--- a/src/audio/ffmpeg.js
+++ b/src/audio/ffmpeg.js
@@ -4,34 +4,15 @@ import { app } from 'electron';
 import fs from 'fs';
 import { getFfmpegRuntimePath, getFfprobeRuntimePath } from '../deps.js';
 
-const ext = process.platform === 'win32' ? '.exe' : '';
-
-function resolveFFmpeg() {
-  // Dev: prefer project-local ffmpeg/ dir
-  if (!app.isPackaged) {
-    const dev = path.join(process.cwd(), 'ffmpeg', `ffmpeg${ext}`);
-    if (fs.existsSync(dev)) return dev;
-  }
-  return getFfmpegRuntimePath();
-}
-
-function resolveFFprobe() {
-  if (!app.isPackaged) {
-    const dev = path.join(process.cwd(), 'ffmpeg', `ffprobe${ext}`);
-    if (fs.existsSync(dev)) return dev;
-  }
-  return getFfprobeRuntimePath();
-}
-
 export function getFfmpegPath() {
-  const p = resolveFFmpeg();
-  if (!fs.existsSync(p)) throw new Error(`FFmpeg not found at ${p}`);
+  const p = getFfmpegRuntimePath();
+  if (!fs.existsSync(p)) throw new Error(`FFmpeg not found at ${p} — still downloading?`);
   return p;
 }
 
 export function ffprobe(filePath) {
-  const ffprobePath = resolveFFprobe();
-  if (!fs.existsSync(ffprobePath)) throw new Error(`ffprobe not found at ${ffprobePath}`);
+  const ffprobePath = getFfprobeRuntimePath();
+  if (!fs.existsSync(ffprobePath)) throw new Error(`ffprobe not found at ${ffprobePath} — still downloading?`);
   return new Promise((resolve, reject) => {
     const proc = spawn(ffprobePath, [
       '-v', 'error',

--- a/src/audio/importManager.js
+++ b/src/audio/importManager.js
@@ -5,6 +5,7 @@ import { app } from 'electron';
 import { Worker } from 'worker_threads';
 import { ffprobe } from './ffmpeg.js';
 import { addTrack, updateTrack } from '../db/trackRepository.js';
+import { getAnalyzerRuntimePath } from '../deps.js';
 
 function hashFile(filePath) {
   const hash = crypto.createHash('sha1');
@@ -39,7 +40,7 @@ function parseTags(ffprobeData) {
 export function spawnAnalysis(trackId, filePath) {
   const worker = new Worker(
     new URL('./analysisWorker.js', import.meta.url),
-    { workerData: { filePath, trackId, isPackaged: app.isPackaged, resourcesPath: process.resourcesPath } }
+    { workerData: { filePath, trackId, analyzerPath: getAnalyzerRuntimePath() } }
   );
 
   worker.on('message', ({ ok, result, error }) => {

--- a/src/deps.js
+++ b/src/deps.js
@@ -1,43 +1,63 @@
 /**
- * Runtime dependency downloader.
- * Downloads FFmpeg into userData/bin/ on first launch if not already present.
+ * Runtime dependency manager.
+ * Downloads FFmpeg and mixxx-analyzer into userData/bin/ on first launch.
+ * Tracks versions and supports update checks / forced re-downloads.
  */
 import path from 'path';
 import fs from 'fs';
 import https from 'https';
 import { createWriteStream } from 'fs';
 import { app } from 'electron';
-import { pipeline } from 'stream/promises';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
 const execAsync = promisify(exec);
 
-function getBinDir() {
-  return path.join(app.getPath('userData'), 'bin');
+// ── Paths ─────────────────────────────────────────────────────────────────────
+
+function getBinDir() { return path.join(app.getPath('userData'), 'bin'); }
+
+const EXT = process.platform === 'win32' ? '.exe' : '';
+
+export function getFfmpegRuntimePath()  { return path.join(getBinDir(), `ffmpeg${EXT}`); }
+export function getFfprobeRuntimePath() { return path.join(getBinDir(), `ffprobe${EXT}`); }
+export function getAnalyzerRuntimePath(){ return path.join(getBinDir(), `analysis${EXT}`); }
+
+function versionFile(name) { return path.join(getBinDir(), `${name}.version`); }
+
+function readVersion(name) {
+  try { return JSON.parse(fs.readFileSync(versionFile(name), 'utf8')); } catch { return null; }
 }
 
-export function getFfmpegRuntimePath() {
-  const ext = process.platform === 'win32' ? '.exe' : '';
-  return path.join(getBinDir(), `ffmpeg${ext}`);
+function writeVersion(name, data) {
+  fs.mkdirSync(getBinDir(), { recursive: true });
+  fs.writeFileSync(versionFile(name), JSON.stringify(data, null, 2));
 }
 
-export function getFfprobeRuntimePath() {
-  const ext = process.platform === 'win32' ? '.exe' : '';
-  return path.join(getBinDir(), `ffprobe${ext}`);
+export function getInstalledVersions() {
+  return {
+    ffmpeg:   readVersion('ffmpeg'),
+    analyzer: readVersion('analyzer'),
+  };
 }
+
+// ── Readiness ─────────────────────────────────────────────────────────────────
 
 export function areDepsReady() {
-  return fs.existsSync(getFfmpegRuntimePath()) && fs.existsSync(getFfprobeRuntimePath());
+  return fs.existsSync(getFfmpegRuntimePath())
+      && fs.existsSync(getFfprobeRuntimePath())
+      && fs.existsSync(getAnalyzerRuntimePath());
 }
 
-async function downloadFile(url, dest, onProgress) {
-  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+function downloadFile(url, dest, onProgress) {
   return new Promise((resolve, reject) => {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
     const follow = (u) => {
       https.get(u, { headers: { 'User-Agent': 'djman-dep-downloader' } }, (res) => {
         if (res.statusCode === 301 || res.statusCode === 302) return follow(res.headers.location);
-        if (res.statusCode !== 200) return reject(new Error(`HTTP ${res.statusCode} for ${u}`));
+        if (res.statusCode !== 200) return reject(new Error(`HTTP ${res.statusCode}: ${u}`));
         const total = parseInt(res.headers['content-length'] || '0', 10);
         let received = 0;
         const out = createWriteStream(dest);
@@ -52,19 +72,26 @@ async function downloadFile(url, dest, onProgress) {
   });
 }
 
-function getLatestRelease(owner, repo) {
+export function getLatestRelease(owner, repo) {
   return new Promise((resolve, reject) => {
     https.get(
       `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
       { headers: { 'User-Agent': 'djman-dep-downloader', Accept: 'application/vnd.github+json' } },
       (res) => {
         let body = '';
-        res.on('data', (c) => (body += c));
-        res.on('end', () => resolve(JSON.parse(body)));
+        res.on('data', c => (body += c));
+        res.on('end', () => { try { resolve(JSON.parse(body)); } catch(e) { reject(e); } });
         res.on('error', reject);
       }
     ).on('error', reject);
   });
+}
+
+// ── Archive helpers ───────────────────────────────────────────────────────────
+
+async function extractTarGz(archive, destDir) {
+  await fs.promises.mkdir(destDir, { recursive: true });
+  await execAsync(`tar -xzf "${archive}" -C "${destDir}"`);
 }
 
 async function extractTarXz(archive, destDir) {
@@ -85,84 +112,186 @@ async function findFile(dir, name) {
   const entries = await fs.promises.readdir(dir, { withFileTypes: true });
   for (const e of entries) {
     const full = path.join(dir, e.name);
-    if (e.isDirectory()) {
-      const found = await findFile(full, name).catch(() => null);
-      if (found) return found;
-    } else if (e.name === name || e.name === name + '.exe') {
-      return full;
-    }
+    if (e.isDirectory()) { const f = await findFile(full, name).catch(() => null); if (f) return f; }
+    else if (e.name === name || e.name === name + '.exe') return full;
   }
   return null;
 }
 
+// ── FFmpeg download ───────────────────────────────────────────────────────────
+
+async function downloadFFmpeg(tmp, onProgress) {
+  const platform = process.platform;
+
+  if (platform === 'linux') {
+    const url = 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz';
+    const archive = path.join(tmp, 'ffmpeg.tar.xz');
+    onProgress?.(`Downloading FFmpeg…`, 0);
+    await downloadFile(url, archive,
+      (r, t) => t > 0 && onProgress?.(`Downloading FFmpeg… ${Math.round(r/t*100)}%`, Math.round(r/t*100)));
+    onProgress?.('Extracting FFmpeg…', 99);
+    const dir = path.join(tmp, 'ffmpeg-extracted');
+    await extractTarXz(archive, dir);
+    const ffmpeg  = await findFile(dir, 'ffmpeg');
+    const ffprobe = await findFile(dir, 'ffprobe');
+    fs.copyFileSync(ffmpeg,  getFfmpegRuntimePath());
+    fs.copyFileSync(ffprobe, getFfprobeRuntimePath());
+    fs.chmodSync(getFfmpegRuntimePath(),  0o755);
+    fs.chmodSync(getFfprobeRuntimePath(), 0o755);
+
+  } else if (platform === 'win32') {
+    const release = await getLatestRelease('BtbN', 'FFmpeg-Builds');
+    const asset = release.assets.find(a => a.name.includes('win64-gpl.zip') && a.name.includes('latest'));
+    const archive = path.join(tmp, 'ffmpeg-win.zip');
+    onProgress?.(`Downloading FFmpeg…`, 0);
+    await downloadFile(asset.browser_download_url, archive,
+      (r, t) => t > 0 && onProgress?.(`Downloading FFmpeg… ${Math.round(r/t*100)}%`, Math.round(r/t*100)));
+    onProgress?.('Extracting FFmpeg…', 99);
+    const dir = path.join(tmp, 'ffmpeg-win-extracted');
+    await extractZip(archive, dir);
+    fs.copyFileSync(await findFile(dir, 'ffmpeg.exe'),  getFfmpegRuntimePath());
+    fs.copyFileSync(await findFile(dir, 'ffprobe.exe'), getFfprobeRuntimePath());
+
+  } else if (platform === 'darwin') {
+    const ffmpegZip  = path.join(tmp, 'ffmpeg-mac.zip');
+    const ffprobeZip = path.join(tmp, 'ffprobe-mac.zip');
+    onProgress?.(`Downloading FFmpeg…`, 0);
+    await downloadFile('https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip',  ffmpegZip,
+      (r, t) => t > 0 && onProgress?.(`Downloading FFmpeg… ${Math.round(r/t*50)}%`,  Math.round(r/t*50)));
+    await downloadFile('https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip', ffprobeZip,
+      (r, t) => t > 0 && onProgress?.(`Downloading FFprobe… ${50+Math.round(r/t*49)}%`, 50+Math.round(r/t*49)));
+    onProgress?.('Extracting FFmpeg…', 99);
+    await extractZip(ffmpegZip,  path.join(tmp, 'ffmpeg-mac'));
+    await extractZip(ffprobeZip, path.join(tmp, 'ffprobe-mac'));
+    fs.copyFileSync(await findFile(path.join(tmp,'ffmpeg-mac'),  'ffmpeg'),  getFfmpegRuntimePath());
+    fs.copyFileSync(await findFile(path.join(tmp,'ffprobe-mac'), 'ffprobe'), getFfprobeRuntimePath());
+    fs.chmodSync(getFfmpegRuntimePath(),  0o755);
+    fs.chmodSync(getFfprobeRuntimePath(), 0o755);
+  }
+
+  // Store version (run ffmpeg -version to capture build string)
+  try {
+    const { stdout } = await execAsync(`"${getFfmpegRuntimePath()}" -version`);
+    const match = stdout.match(/ffmpeg version (\S+)/);
+    writeVersion('ffmpeg', { version: match?.[1] ?? 'unknown', installedAt: new Date().toISOString() });
+  } catch { writeVersion('ffmpeg', { version: 'unknown', installedAt: new Date().toISOString() }); }
+}
+
+// ── Analyzer download ─────────────────────────────────────────────────────────
+
+async function analyzerAssetName() {
+  const p = process.platform, a = process.arch;
+  if (p === 'linux')  return { name: 'linux-x86_64',  ext: 'tar.gz' };
+  if (p === 'darwin') return { name: 'macos-arm64',   ext: 'zip' };
+  if (p === 'win32')  return { name: 'windows-x86_64',ext: 'zip' };
+  throw new Error(`Unsupported platform: ${p}`);
+}
+
+async function downloadAnalyzer(tmp, onProgress) {
+  onProgress?.('Downloading mixxx-analyzer…', 0);
+  const release = await getLatestRelease('Radexito', 'mixxx-analyzer');
+  const { name, ext } = await analyzerAssetName();
+  const asset = release.assets.find(a => a.name.includes(name) && a.name.endsWith(`.${ext}`));
+  if (!asset) throw new Error(`No mixxx-analyzer asset for ${name}`);
+
+  const archive = path.join(tmp, `analyzer.${ext}`);
+  await downloadFile(asset.browser_download_url, archive,
+    (r, t) => t > 0 && onProgress?.(`Downloading mixxx-analyzer… ${Math.round(r/t*100)}%`, Math.round(r/t*100)));
+
+  onProgress?.('Extracting mixxx-analyzer…', 99);
+  const dir = path.join(tmp, 'analyzer-extracted');
+  if (ext === 'tar.gz') await extractTarGz(archive, dir);
+  else await extractZip(archive, dir);
+
+  // On Linux the bundle contains the binary + bundled .so files (RPATH=$ORIGIN).
+  // Copy everything from the extracted dir into binDir so sibling libs are found.
+  const binDir = getBinDir();
+  const binName = process.platform === 'win32' ? 'mixxx-analyzer.exe' : 'mixxx-analyzer';
+  const src = await findFile(dir, binName);
+  if (!src) throw new Error('mixxx-analyzer binary not found in archive');
+  const bundleDir = path.dirname(src);
+
+  // Copy all files from the bundle directory (binary + any .so or .dylib siblings)
+  for (const entry of await fs.promises.readdir(bundleDir)) {
+    const srcFile = path.join(bundleDir, entry);
+    const dstFile = path.join(binDir, entry);
+    fs.copyFileSync(srcFile, dstFile);
+    if (process.platform !== 'win32') {
+      const stat = await fs.promises.stat(srcFile);
+      if (stat.mode & 0o111) fs.chmodSync(dstFile, 0o755); // preserve executable bit
+    }
+  }
+
+  // Create a stable symlink/copy named 'analysis' pointing to the real binary
+  const analyzerDest = getAnalyzerRuntimePath();
+  const realBin = path.join(binDir, binName);
+  if (fs.existsSync(analyzerDest) && analyzerDest !== realBin) fs.unlinkSync(analyzerDest);
+  if (analyzerDest !== realBin) fs.copyFileSync(realBin, analyzerDest);
+  if (process.platform !== 'win32') fs.chmodSync(analyzerDest, 0o755);
+
+  writeVersion('analyzer', {
+    version: release.tag_name,
+    releaseUrl: release.html_url,
+    installedAt: new Date().toISOString(),
+  });
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
 export async function ensureDeps(onProgress) {
-  if (areDepsReady()) return;
+  const ffmpegReady   = fs.existsSync(getFfmpegRuntimePath()) && fs.existsSync(getFfprobeRuntimePath());
+  const analyzerReady = fs.existsSync(getAnalyzerRuntimePath());
+  if (ffmpegReady && analyzerReady) return;
+
+  const binDir = getBinDir();
   await fs.promises.mkdir(binDir, { recursive: true });
   const tmp = path.join(app.getPath('temp'), 'djman-deps');
   await fs.promises.mkdir(tmp, { recursive: true });
 
-  const platform = process.platform;
-  const ext = platform === 'win32' ? '.exe' : '';
-
-  onProgress?.('Downloading FFmpeg...', 0);
+  const totalSteps = (!ffmpegReady ? 1 : 0) + (!analyzerReady ? 1 : 0);
+  let step = 0;
+  const stepCb = (msg, pct) => onProgress?.(`[${step}/${totalSteps}] ${msg}`, pct);
 
   try {
-    if (platform === 'linux') {
-      const archive = path.join(tmp, 'ffmpeg.tar.xz');
-      await downloadFile(
-        'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz',
-        archive,
-        (recv, total) => total > 0 && onProgress?.(`Downloading FFmpeg… ${Math.round(recv/total*100)}%`, Math.round(recv/total*100))
-      );
-      const extractDir = path.join(tmp, 'ffmpeg-extracted');
-      onProgress?.('Extracting…', 99);
-      await extractTarXz(archive, extractDir);
-      const ffmpeg = await findFile(extractDir, 'ffmpeg');
-      const ffprobe = await findFile(extractDir, 'ffprobe');
-      fs.copyFileSync(ffmpeg, getFfmpegRuntimePath());
-      fs.copyFileSync(ffprobe, getFfprobeRuntimePath());
-      fs.chmodSync(getFfmpegRuntimePath(), 0o755);
-      fs.chmodSync(getFfprobeRuntimePath(), 0o755);
-
-    } else if (platform === 'win32') {
-      const release = await getLatestRelease('BtbN', 'FFmpeg-Builds');
-      const asset = release.assets.find(a => a.name.includes('win64-gpl.zip') && a.name.includes('latest'));
-      const archive = path.join(tmp, 'ffmpeg-win.zip');
-      await downloadFile(asset.browser_download_url, archive,
-        (recv, total) => total > 0 && onProgress?.(`Downloading FFmpeg… ${Math.round(recv/total*100)}%`, Math.round(recv/total*100))
-      );
-      onProgress?.('Extracting…', 99);
-      const extractDir = path.join(tmp, 'ffmpeg-win-extracted');
-      await extractZip(archive, extractDir);
-      const ffmpeg = await findFile(extractDir, 'ffmpeg.exe');
-      const ffprobe = await findFile(extractDir, 'ffprobe.exe');
-      fs.copyFileSync(ffmpeg, getFfmpegRuntimePath());
-      fs.copyFileSync(ffprobe, getFfprobeRuntimePath());
-
-    } else if (platform === 'darwin') {
-      // macOS: download from evermeet.cx static builds
-      const ffmpegUrl  = 'https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip';
-      const ffprobeUrl = 'https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip';
-      const ffmpegZip  = path.join(tmp, 'ffmpeg-mac.zip');
-      const ffprobeZip = path.join(tmp, 'ffprobe-mac.zip');
-      await downloadFile(ffmpegUrl, ffmpegZip,
-        (recv, total) => total > 0 && onProgress?.(`Downloading FFmpeg… ${Math.round(recv/total*50)}%`, Math.round(recv/total*50))
-      );
-      await downloadFile(ffprobeUrl, ffprobeZip,
-        (recv, total) => total > 0 && onProgress?.(`Downloading FFprobe… ${50 + Math.round(recv/total*49)}%`, 50 + Math.round(recv/total*49))
-      );
-      onProgress?.('Extracting…', 99);
-      await extractZip(ffmpegZip,  path.join(tmp, 'ffmpeg-mac'));
-      await extractZip(ffprobeZip, path.join(tmp, 'ffprobe-mac'));
-      const ffmpeg  = await findFile(path.join(tmp, 'ffmpeg-mac'),  'ffmpeg');
-      const ffprobe = await findFile(path.join(tmp, 'ffprobe-mac'), 'ffprobe');
-      fs.copyFileSync(ffmpeg,  getFfmpegRuntimePath());
-      fs.copyFileSync(ffprobe, getFfprobeRuntimePath());
-      fs.chmodSync(getFfmpegRuntimePath(),  0o755);
-      fs.chmodSync(getFfprobeRuntimePath(), 0o755);
+    if (!ffmpegReady) {
+      step++;
+      await downloadFFmpeg(tmp, stepCb);
     }
+    if (!analyzerReady) {
+      step++;
+      await downloadAnalyzer(tmp, stepCb);
+    }
+    onProgress?.('Setup complete.', 100);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
 
-    onProgress?.('FFmpeg ready.', 100);
+export async function checkForUpdates() {
+  const installed = getInstalledVersions();
+  const result = { analyzer: null };
+
+  try {
+    const release = await getLatestRelease('Radexito', 'mixxx-analyzer');
+    result.analyzer = {
+      installedTag: installed.analyzer?.version ?? null,
+      latestTag:    release.tag_name,
+      hasUpdate:    installed.analyzer?.version !== release.tag_name,
+      releaseUrl:   release.html_url,
+    };
+  } catch { result.analyzer = { error: 'Could not check for updates' }; }
+
+  return result;
+}
+
+export async function updateAnalyzer(onProgress) {
+  const binDir = getBinDir();
+  await fs.promises.mkdir(binDir, { recursive: true });
+  const tmp = path.join(app.getPath('temp'), 'djman-deps');
+  await fs.promises.mkdir(tmp, { recursive: true });
+  try {
+    await downloadAnalyzer(tmp, onProgress);
+    onProgress?.('mixxx-analyzer updated.', 100);
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,101 @@
+/**
+ * File logger for DJ Manager.
+ *
+ * - Writes to <userData>/logs/app-YYYY-MM-DD.log
+ * - Keeps the last LOG_RETENTION_DAYS log files; older ones are deleted on init
+ * - Patches console.log / console.warn / console.error in the main process
+ *   so all existing log calls are automatically captured
+ * - Exposes `log(level, ...args)` for explicit use
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { app } from 'electron';
+
+const LOG_RETENTION_DAYS = 7;
+
+let logStream = null;
+let logDir = null;
+
+function pad(n) {
+  return String(n).padStart(2, '0');
+}
+
+function today() {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function timestamp() {
+  const d = new Date();
+  return `${today()} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${String(d.getMilliseconds()).padStart(3, '0')}`;
+}
+
+function formatArgs(args) {
+  return args.map(a => {
+    if (a instanceof Error) return `${a.message}\n${a.stack}`;
+    if (typeof a === 'object') {
+      try { return JSON.stringify(a); } catch { return String(a); }
+    }
+    return String(a);
+  }).join(' ');
+}
+
+export function log(level, ...args) {
+  const line = `[${timestamp()}] [${level.toUpperCase()}] ${formatArgs(args)}\n`;
+  process.stdout.write(line);
+  logStream?.write(line);
+}
+
+function patchConsole() {
+  const origLog   = console.log.bind(console);
+  const origWarn  = console.warn.bind(console);
+  const origError = console.error.bind(console);
+
+  console.log = (...args) => {
+    const line = `[${timestamp()}] [INFO]  ${formatArgs(args)}\n`;
+    origLog(...args);
+    logStream?.write(line);
+  };
+  console.warn = (...args) => {
+    const line = `[${timestamp()}] [WARN]  ${formatArgs(args)}\n`;
+    origWarn(...args);
+    logStream?.write(line);
+  };
+  console.error = (...args) => {
+    const line = `[${timestamp()}] [ERROR] ${formatArgs(args)}\n`;
+    origError(...args);
+    logStream?.write(line);
+  };
+}
+
+function pruneOldLogs() {
+  try {
+    const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    for (const f of fs.readdirSync(logDir)) {
+      if (!f.startsWith('app-') || !f.endsWith('.log')) continue;
+      const full = path.join(logDir, f);
+      const stat = fs.statSync(full);
+      if (stat.mtimeMs < cutoff) fs.unlinkSync(full);
+    }
+  } catch { /* best-effort */ }
+}
+
+export function initLogger() {
+  logDir = path.join(app.getPath('userData'), 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+
+  pruneOldLogs();
+
+  const logFile = path.join(logDir, `app-${today()}.log`);
+  logStream = fs.createWriteStream(logFile, { flags: 'a' });
+
+  logStream.write(`\n${'='.repeat(60)}\n`);
+  logStream.write(`[${timestamp()}] [INFO]  DJ Manager started — version ${app.getVersion()} platform=${process.platform} arch=${process.arch}\n`);
+
+  patchConsole();
+
+  return logFile;
+}
+
+export function getLogDir() { return logDir; }

--- a/src/preload.js
+++ b/src/preload.js
@@ -55,6 +55,12 @@ contextBridge.exposeInMainWorld('api', {
   },
   clearLibrary: () => ipcRenderer.invoke('clear-library'),
   clearUserData: () => ipcRenderer.invoke('clear-user-data'),
+  getLogDir: () => ipcRenderer.invoke('get-log-dir'),
+  openLogDir: () => ipcRenderer.invoke('open-log-dir'),
+  log: (level, ...args) => ipcRenderer.send('renderer-log', { level, msg: args.join(' ') }),
+  getDepVersions: () => ipcRenderer.invoke('get-dep-versions'),
+  checkDepUpdates: () => ipcRenderer.invoke('check-dep-updates'),
+  updateAnalyzer: () => ipcRenderer.invoke('update-analyzer'),
   onDepsProgress: (callback) => {
     const handler = (_, data) => callback(data);
     ipcRenderer.on('deps-progress', handler);


### PR DESCRIPTION
- deps.js: download FFmpeg + mixxx-analyzer to userData/bin/ on first launch; version tracked in *.version JSON files
- Fix tar.gz extraction (was using xz flag instead of gz)
- Add step counter [1/2]/[2/2] to progress messages
- Bundle-aware extraction: copy entire bundle dir (binary + bundled .so libs with RPATH=$ORIGIN) so binary finds sibling libs on Linux
- Remove analyzer from extraResources and CI download steps
- analysisWorker: use workerData.analyzerPath (userData/bin/analysis); remove Python fallback; clean async spawn only
- analysisWorker: pass --json flag; fix field mapping (key/camelot/ replayGain/introSecs/outroSecs); handle JSON array output
- importManager: pass analyzerPath via workerData; import from deps.js
- main.js: deduplicate console log spam; add get-dep-versions, check-dep-updates, update-analyzer IPC handlers
- preload: expose getDepVersions, checkDepUpdates, updateAnalyzer
- Settings: add Updates tab with installed versions + check/update; Advanced tab now has only Diagnostics and Danger Zone
- logger.js: file logging to userData/logs/ with daily rotation
- CI workflow: remove per-platform analyzer download matrix vars