### PR TITLE
feat(updates): single Update All button for FFmpeg + analyzer

### DIFF
--- a/renderer/src/SettingsModal.css
+++ b/renderer/src/SettingsModal.css
@@ -219,3 +219,14 @@
   background: rgba(166,227,161,0.08);
   border-radius: 4px;
 }
+
+.dep-update-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background: rgba(166,227,161,0.18);
+  color: #a6e3a1;
+  font-size: 11px;
+  font-weight: 600;
+}

--- a/renderer/src/SettingsModal.jsx
+++ b/renderer/src/SettingsModal.jsx
@@ -10,7 +10,7 @@ function SettingsModal({ onClose }) {
   const [depVersions, setDepVersions] = useState(null);
   const [updateInfo, setUpdateInfo] = useState(null);
   const [checkingUpdates, setCheckingUpdates] = useState(false);
-  const [updatingAnalyzer, setUpdatingAnalyzer] = useState(false);
+  const [updatingAll, setUpdatingAll] = useState(false);
 
   useEffect(() => {
     window.api.getSetting('normalize_target_lufs', String(DEFAULT_TARGET))
@@ -31,12 +31,12 @@ function SettingsModal({ onClose }) {
     setCheckingUpdates(false);
   };
 
-  const handleUpdateAnalyzer = async () => {
-    setUpdatingAnalyzer(true);
-    await window.api.updateAnalyzer();
+  const handleUpdateAll = async () => {
+    setUpdatingAll(true);
+    await window.api.updateAllDeps();
     const versions = await window.api.getDepVersions();
     setDepVersions(versions);
-    setUpdatingAnalyzer(false);
+    setUpdatingAll(false);
     setUpdateInfo(null);
   };
 
@@ -117,25 +117,19 @@ function SettingsModal({ onClose }) {
           {activeSection === 'updates' && (
             <>
               <h3>Updates</h3>
+
               <div className="settings-group">
                 <div className="settings-group-title">Installed Versions</div>
-                <p className="settings-group-desc">
-                  FFmpeg and mixxx-analyzer are downloaded automatically on first launch.
-                </p>
-                {depVersions ? (
-                  <div className="dep-version-list">
-                    <div className="dep-version-row">
-                      <span className="dep-version-name">FFmpeg</span>
-                      <span className="dep-version-tag">{depVersions.ffmpeg?.version ?? 'not installed'}</span>
-                    </div>
-                    <div className="dep-version-row">
-                      <span className="dep-version-name">mixxx-analyzer</span>
-                      <span className="dep-version-tag">{depVersions.analyzer?.version ?? 'not installed'}</span>
-                    </div>
+                <div className="dep-version-list">
+                  <div className="dep-version-row">
+                    <span className="dep-version-name">FFmpeg</span>
+                    <span className="dep-version-tag">{depVersions?.ffmpeg?.version ?? '…'}</span>
                   </div>
-                ) : (
-                  <p className="settings-group-desc">Loading…</p>
-                )}
+                  <div className="dep-version-row">
+                    <span className="dep-version-name">mixxx-analyzer</span>
+                    <span className="dep-version-tag">{depVersions?.analyzer?.version ?? '…'}</span>
+                  </div>
+                </div>
               </div>
 
               <div className="settings-group">
@@ -144,24 +138,34 @@ function SettingsModal({ onClose }) {
                   <div className="dep-update-notice">
                     {updateInfo.analyzer.hasUpdate
                       ? <span>Update available: <b>{updateInfo.analyzer.latestTag}</b></span>
-                      : <span>mixxx-analyzer is up to date.</span>}
+                      : <span>Up to date.</span>}
                   </div>
                 )}
                 <div className="settings-row settings-row-action">
                   <div>
                     <div className="settings-action-label">Check for Updates</div>
-                    <div className="settings-action-desc">Check if a newer mixxx-analyzer is available.</div>
+                    <div className="settings-action-desc">Check if a newer mixxx-analyzer release is available.</div>
                   </div>
-                  <div style={{ display: 'flex', gap: '0.5rem' }}>
-                    <button className="btn-secondary" onClick={handleCheckUpdates} disabled={checkingUpdates}>
-                      {checkingUpdates ? 'Checking…' : 'Check'}
-                    </button>
-                    {updateInfo?.analyzer?.hasUpdate && (
-                      <button className="btn-primary" onClick={handleUpdateAnalyzer} disabled={updatingAnalyzer}>
-                        {updatingAnalyzer ? 'Updating…' : 'Update'}
-                      </button>
-                    )}
+                  <button className="btn-secondary" onClick={handleCheckUpdates} disabled={checkingUpdates || updatingAll}>
+                    {checkingUpdates ? 'Checking…' : 'Check'}
+                  </button>
+                </div>
+              </div>
+
+              <div className="settings-group">
+                <div className="settings-group-title">Update All</div>
+                <p className="settings-group-desc">
+                  Re-downloads the latest FFmpeg and mixxx-analyzer.
+                  {updateInfo?.analyzer?.hasUpdate && <span className="dep-update-badge"> New version available!</span>}
+                </p>
+                <div className="settings-row settings-row-action">
+                  <div>
+                    <div className="settings-action-label">Update Dependencies</div>
+                    <div className="settings-action-desc">Downloads and installs the latest FFmpeg and mixxx-analyzer.</div>
                   </div>
+                  <button className="btn-primary" onClick={handleUpdateAll} disabled={updatingAll || checkingUpdates}>
+                    {updatingAll ? 'Updating…' : 'Update All'}
+                  </button>
                 </div>
               </div>
             </>

--- a/src/deps.js
+++ b/src/deps.js
@@ -296,3 +296,17 @@ export async function updateAnalyzer(onProgress) {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
 }
+
+export async function updateAll(onProgress) {
+  const binDir = getBinDir();
+  await fs.promises.mkdir(binDir, { recursive: true });
+  const tmp = path.join(app.getPath('temp'), 'djman-deps');
+  await fs.promises.mkdir(tmp, { recursive: true });
+  try {
+    await downloadFFmpeg(tmp, (msg, pct) => onProgress?.(`[1/2] ${msg}`, pct));
+    await downloadAnalyzer(tmp, (msg, pct) => onProgress?.(`[2/2] ${msg}`, pct));
+    onProgress?.('All dependencies updated.', 100);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import { addTrack, getTracks, getTrackIds, getTrackById, removeTrack, updateTrac
 import { getSetting, setSetting } from './db/settingsRepository.js';
 import { importAudioFile, spawnAnalysis } from './audio/importManager.js';
 import { ensureDeps } from './deps.js';
-import { getInstalledVersions, checkForUpdates, updateAnalyzer } from './deps.js';
+import { getInstalledVersions, checkForUpdates, updateAnalyzer, updateAll } from './deps.js';
 import { initLogger, log, getLogDir } from './logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -291,6 +291,12 @@ ipcMain.handle('get-dep-versions', () => getInstalledVersions());
 ipcMain.handle('check-dep-updates', () => checkForUpdates());
 ipcMain.handle('update-analyzer', async (event) => {
   await updateAnalyzer((msg, pct) => {
+    if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', { msg, pct });
+  });
+  if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', null);
+});
+ipcMain.handle('update-all-deps', async (event) => {
+  await updateAll((msg, pct) => {
     if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', { msg, pct });
   });
   if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', null);

--- a/src/preload.js
+++ b/src/preload.js
@@ -61,6 +61,7 @@ contextBridge.exposeInMainWorld('api', {
   getDepVersions: () => ipcRenderer.invoke('get-dep-versions'),
   checkDepUpdates: () => ipcRenderer.invoke('check-dep-updates'),
   updateAnalyzer: () => ipcRenderer.invoke('update-analyzer'),
+  updateAllDeps: () => ipcRenderer.invoke('update-all-deps'),
   onDepsProgress: (callback) => {
     const handler = (_, data) => callback(data);
     ipcRenderer.on('deps-progress', handler);


### PR DESCRIPTION
- deps.js: add updateAll() which re-downloads FFmpeg then analyzer [1/2]/[2/2]
- main.js: add update-all-deps IPC handler
- preload: expose updateAllDeps()
- Settings > Updates: single Update All button; Check button still checks analyzer version; installed versions shown in one table