### PR TITLE
feat: M3U export copies tracks + uses relative paths (closes #26)

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -26,6 +26,12 @@ contextBridge.exposeInMainWorld('api', {
   reorderPlaylist: (playlistId, orderedTrackIds) =>
     ipcRenderer.invoke('reorder-playlist', { playlistId, orderedTrackIds }),
   getPlaylistsForTrack: (trackId) => ipcRenderer.invoke('get-playlists-for-track', trackId),
+  exportPlaylistAsM3U: (playlistId) => ipcRenderer.invoke('export-playlist-m3u', playlistId),
+  onExportM3UProgress: (cb) => {
+    const handler = (_, data) => cb(data);
+    ipcRenderer.on('export-m3u-progress', handler);
+    return () => ipcRenderer.removeListener('export-m3u-progress', handler);
+  },
 
   // Settings
   getSetting: (key, def) => ipcRenderer.invoke('get-setting', key, def),


### PR DESCRIPTION
Closes #26
   Part of #19

   ## What this does

   Right-click any playlist in the sidebar → **Export as M3U…**

   1. Folder picker opens — choose any destination (USB root, Desktop, etc.)
   2. Creates `<Playlist Name>/` subfolder at the destination
   3. Copies every track with clean filenames: `01 - Artist - Title.ext`
   4. Writes `<Playlist Name>.m3u` with relative paths — the folder is fully self-contained and portable on any media player or CDJ
   5. Export progress shown in the sidebar status bar while copying
   6. Completion alert with the destination path

   ## Files changed
   - `src/main.js` — `export-playlist-m3u` IPC handler (folder dialog, file copy, M3U write, progress events)
   - `src/preload.js` — expose `exportPlaylistAsM3U` + `onExportM3UProgress`
   - `renderer/src/Sidebar.jsx` — Export as M3U… context menu item, progress state + banner

  Direct link: https://github.com/Radexito/djman/pull/new/feat/m3u-export (https://github.com/Radexito/djman/pull/new/feat/m3u-export)
