### PR TITLE
 fix: clear library also removes playlists (#54)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,15 +29,30 @@ FFmpeg and the audio analyser download automatically on first launch — no manu
 
 ## What it does
 
-**Library** — Import audio files once; DJ Manager manages storage and keeps everything organised. Search, sort, and filter by BPM, key, title, duration, and more. Use the advanced query syntax to stack filters — e.g. `GENRE is Psytrance AND BPM IN RANGE 140-145` or `KEY matches 8A AND BPM > 130`.
+**Library** — Import audio files once; DJ Manager copies them into managed storage and deduplicates by content hash. Sort and filter by any column. Select multiple tracks with click, Shift+click, Ctrl+click, or Ctrl+A.
 
-**Analysis** — Every track is analysed automatically for BPM, musical key (displayed in Camelot notation for harmonic mixing), loudness (LUFS), replay gain, and intro/outro markers. Re-analyse any track with a right-click.
+**Advanced search** — Type a query into the search bar to filter your library with precision. Filters can be stacked with `AND`:
 
-**Playlists** — Create colour-coded playlists, drag tracks in, reorder by drag-and-drop, and sort by any column. Track count and total duration shown at all times.
+```
+GENRE is Psytrance AND BPM IN RANGE 140-145
+KEY matches 8A AND BPM > 130
+ARTIST contains Burial AND YEAR > 2010
+TITLE contains intro AND LOUDNESS > -10
+```
 
-**Player** — Full playback with seekbar, shuffle, repeat, previous/next, hardware media key support, and per-track intro/outro zones shown visually on the seek bar. Double-click any track to play.
+Supported fields: `TITLE`, `ARTIST`, `ALBUM`, `GENRE`, `BPM`, `KEY`, `YEAR`, `LOUDNESS`.
+Supported operators vary by field — `is`, `is not`, `contains`, `in range`, `>`, `<` for numbers; `is`, `matches`, `adjacent`, `mode switch` for keys (Camelot notation: `8A`, `8B`, etc.).
+The search bar shows field and operator suggestions as you type, and completed filters appear as removable chips above the track list.
 
-**Settings** — Move your library to any location (e.g. an external drive). Update FFmpeg and the audio analyser from inside the app. Clear library or all user data from the Advanced tab.
+**Analysis** — Every track is analysed automatically on import for BPM, musical key (Camelot notation), loudness (LUFS), replay gain, and intro/outro markers. Right-click any track to re-analyse, or halve/double the detected BPM if the analyzer picked the wrong grid.
+
+**Find Similar** — Right-click a track to find others with a matching or adjacent Camelot key, or within a close BPM range. Results are applied as a live search filter.
+
+**Playlists** — Create colour-coded playlists in the sidebar, drag tracks in from the library, reorder by drag-and-drop, and sort by any column. Track count and total duration are shown at all times. Exporting a playlist to M3U is one click.
+
+**Player** — Full playback with seekbar, shuffle, repeat, previous/next, and hardware media key support. Intro and outro zones are shown visually on the seekbar so you know exactly when to mix. Double-click any track to play.
+
+**Settings** — Move your library to any location, including an external drive. Update FFmpeg and the audio analyser in-app without reinstalling. Clear the track library, all playlists, or all user data from the Advanced tab.
 
 ---
 
@@ -55,28 +70,7 @@ FFmpeg and mixxx-analyzer are downloaded automatically to `~/.config/djman/bin/`
 
 ---
 
-## What's been built
-
-| Feature                                                    | Status |
-| ---------------------------------------------------------- | ------ |
-| Import + managed library storage                           | ✅     |
-| FFmpeg metadata extraction                                 | ✅     |
-| BPM / key / loudness / intro+outro analysis                | ✅     |
-| Advanced query search (field filters, ranges, Camelot key) | ✅     |
-| Re-analyse, BPM halve/double via right-click Analysis menu | ✅     |
-| Find Similar tracks by key or BPM via context menu         | ✅     |
-| Multi-select (click, Shift, Ctrl, Ctrl+A)                  | ✅     |
-| Playlists (create, colour, reorder, drag-and-drop)         | ✅     |
-| Audio player with seekbar and intro/outro zones            | ✅     |
-| Hardware media keys                                        | ✅     |
-| Loudness normalisation (LUFS target)                       | ✅     |
-| Runtime dependency downloads (FFmpeg + analyser)           | ✅     |
-| In-app dependency updates                                  | ✅     |
-| Standalone builds for Linux / Windows / macOS              | ✅     |
-| Move library to custom location                            | ✅     |
-| App logging to `~/.config/djman/logs/`                     | ✅     |
-
-Issues tracking upcoming work are on the [**Issues**](https://github.com/Radexito/djman/issues) page.
+Upcoming work is tracked on the [**Issues**](https://github.com/Radexito/djman/issues) page.
 
 ---
 


### PR DESCRIPTION
## Summary
   
   Fixes #54 — clearing the library left playlist rows in the database, causing ghost empty playlists to persist in the sidebar.
   
   ## Changes
   
   ### Bug fix
   - Added `clearPlaylists()` to `playlistRepository.js` — `DELETE FROM playlists` (cascades to `playlist_tracks` via FK)
   - Updated `clear-library` IPC handler in `main.js` to call `clearPlaylists()` and send `playlists-updated` so the sidebar refreshes 
  immediately
   
   ### Tests
   - Added 3 tests to `playlistRepository.test.js` verifying the clear-library flow empties both tables
   
   ### Docs
   - Removed the static "What's been built" feature table from README
   - Expanded "What it does" with detailed per-feature descriptions
   - Added dedicated **Advanced search** section with query examples, field list, and operator reference