### PR TITLE
fix: set window title to 'DjManager - RWTechWorks.pl'

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>renderer</title>
+    <title>DjManager - RWTechWorks.pl</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -110,6 +110,7 @@ function createWindow() {
   });
 
   mainWindow = new BrowserWindow({
+    title: 'DjManager - RWTechWorks.pl',
     width: 1200,
     height: 800,
     webPreferences: {


### PR DESCRIPTION
## What
   Replaces the default "renderer" titlebar text with "DjManager - RWTechWorks.pl".
   
   ## Changes
   - `renderer/index.html` — updated `<title>` tag (this is what the OS titlebar displays once the page loads)
   - `src/main.js` — added `title` to `BrowserWindow` options (shown briefly before the page loads)
   
   ## Why both files
   Electron uses the HTML `<title>` tag once the page is loaded, overriding the `BrowserWindow` title. Both need to match to avoid a flash 
  of the wrong title on startup.
