### PR TITLE
feat: drag and drop tracks onto sidebar playlists to add them (#130)

### DIFF
--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -155,6 +155,7 @@ function LibraryRow({
   onDoubleClick,
   onContextMenu,
   onRatingChange,
+  onDragStart,
   visibleColumns,
   gridTemplate,
   minScrollWidth,
@@ -178,6 +179,8 @@ function LibraryRow({
       style={{ ...style, gridTemplateColumns: gridTemplate, minWidth: minScrollWidth }}
       className={`row ${index % 2 === 0 ? 'row-even' : 'row-odd'}${isSelected ? ' row--selected' : ''}${isPlaying ? ' row--playing' : ''}`}
       title={`${t.title} - ${t.artist || 'Unknown'}`}
+      draggable={true}
+      onDragStart={(e) => onDragStart(e, t)}
       onClick={(e) => onRowClick(e, t, index)}
       onDoubleClick={() => onDoubleClick(t, index)}
       onContextMenu={(e) => onContextMenu(e, t, index)}
@@ -236,6 +239,7 @@ function SortableRow({
   onDoubleClick,
   onContextMenu,
   onRatingChange,
+  onDragStart,
   visibleColumns,
   gridTemplate,
   minScrollWidth,
@@ -257,6 +261,14 @@ function SortableRow({
       style={style}
       className={`row ${index % 2 === 0 ? 'row-even' : 'row-odd'}${isSelected ? ' row--selected' : ''}${isPlaying ? ' row--playing' : ''}`}
       title={`${t.title} - ${t.artist || 'Unknown'}`}
+      draggable={true}
+      onDragStart={(e) => {
+        if (e.target.closest('.drag-handle')) {
+          e.preventDefault(); // let @dnd-kit handle reorder from the drag handle
+          return;
+        }
+        onDragStart(e, t);
+      }}
       onClick={(e) => onRowClick(e, t, index)}
       onDoubleClick={() => onDoubleClick(t, index)}
       onContextMenu={(e) => onContextMenu(e, t, index)}
@@ -848,6 +860,15 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
     [selectedPlaylist]
   );
 
+  const handleTrackDragStart = useCallback(
+    (e, track) => {
+      const ids = selectedIds.has(track.id) ? [...selectedIds] : [track.id];
+      e.dataTransfer.effectAllowed = 'copy';
+      e.dataTransfer.setData('application/dj-tracks', JSON.stringify(ids));
+    },
+    [selectedIds]
+  );
+
   const handleSaveOrder = useCallback(async () => {
     await window.api.reorderPlaylist(
       Number(selectedPlaylist),
@@ -1027,7 +1048,7 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
               <div className="playlist-empty-state">
                 No tracks in this playlist.
                 <br />
-                Right-click tracks in your library to add them.
+                Drag tracks from your library here, or right-click to add.
               </div>
             ) : (
               <DndContext
@@ -1052,6 +1073,7 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
                         onDoubleClick={handleDoubleClick}
                         onContextMenu={handleContextMenu}
                         onRatingChange={handleRatingChange}
+                        onDragStart={handleTrackDragStart}
                         visibleColumns={visibleColumns}
                         gridTemplate={gridTemplate}
                         minScrollWidth={minScrollWidth}
@@ -1095,6 +1117,7 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
                 onDoubleClick: handleDoubleClick,
                 onContextMenu: handleContextMenu,
                 onRatingChange: handleRatingChange,
+                onDragStart: handleTrackDragStart,
                 visibleColumns,
                 gridTemplate,
                 minScrollWidth,

--- a/renderer/src/Sidebar.css
+++ b/renderer/src/Sidebar.css
@@ -172,6 +172,12 @@
   font-style: italic;
 }
 
+.playlist-item--drag-over {
+  background-color: #1db95433 !important;
+  outline: 1px solid #1db954;
+  outline-offset: -1px;
+}
+
 .playlist-new-form {
   padding: 2px 4px;
 }

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -33,6 +33,7 @@ function Sidebar({
   const [playlistMenu, setPlaylistMenu] = useState(null); // { id, x, y }
   const [renamingId, setRenamingId] = useState(null);
   const [renameValue, setRenameValue] = useState('');
+  const [dragOverPlaylistId, setDragOverPlaylistId] = useState(null);
   const newInputRef = useRef(null);
   const renameInputRef = useRef(null);
 
@@ -142,6 +143,32 @@ function Sidebar({
     await window.api.updatePlaylistColor(id, color);
   };
 
+  const handleDragOver = (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  };
+
+  const handleDragEnter = (e, playlistId) => {
+    if (e.dataTransfer.types.includes('application/dj-tracks')) {
+      setDragOverPlaylistId(playlistId);
+    }
+  };
+
+  const handleDragLeave = (e) => {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setDragOverPlaylistId(null);
+    }
+  };
+
+  const handleDrop = async (e, playlistId) => {
+    e.preventDefault();
+    setDragOverPlaylistId(null);
+    const raw = e.dataTransfer.getData('application/dj-tracks');
+    if (!raw) return;
+    const trackIds = JSON.parse(raw);
+    await window.api.addTracksToPlaylist(playlistId, trackIds);
+  };
+
   return (
     <div className="sidebar">
       <div className="fixed-top-section">
@@ -214,12 +241,16 @@ function Sidebar({
               </form>
             ) : (
               <div
-                className={`menu-item playlist-item ${selectedMenuItemId === String(pl.id) ? 'active' : ''}`}
+                className={`menu-item playlist-item ${selectedMenuItemId === String(pl.id) ? 'active' : ''}${dragOverPlaylistId === pl.id ? ' playlist-item--drag-over' : ''}`}
                 onClick={() => onMenuSelect(String(pl.id))}
                 onContextMenu={(e) => {
                   e.preventDefault();
                   setPlaylistMenu({ id: pl.id, x: e.clientX, y: e.clientY });
                 }}
+                onDragOver={handleDragOver}
+                onDragEnter={(e) => handleDragEnter(e, pl.id)}
+                onDragLeave={handleDragLeave}
+                onDrop={(e) => handleDrop(e, pl.id)}
               >
                 {pl.color && (
                   <span className="playlist-color-dot" style={{ background: pl.color }} />


### PR DESCRIPTION
Tracks in both the library and playlist views are now draggable. Dropping one or more selected tracks onto a sidebar playlist item adds them to that playlist. The existing @dnd-kit reorder drag handle in the playlist view is unaffected.

Closes #130 