### PR TITLE
feat: add to new playlist from track context menu

### DIFF
--- a/renderer/src/MusicLibrary.css
+++ b/renderer/src/MusicLibrary.css
@@ -592,3 +592,37 @@
   border-color: #f4a261;
   color: #f4a261;
 }
+
+/* ── Add to new playlist inline input ── */
+.ctx-new-playlist-item {
+  padding: 6px 12px;
+  cursor: default;
+}
+
+.ctx-new-playlist-form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 12px;
+}
+
+.ctx-new-playlist-input {
+  background: #1a1a1a;
+  border: 1px solid #555;
+  border-radius: 4px;
+  color: #e0e0e0;
+  font-size: 12px;
+  padding: 5px 8px;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ctx-new-playlist-input:focus {
+  border-color: #1db954;
+}
+
+.ctx-new-playlist-error {
+  font-size: 11px;
+  color: #e06c6c;
+}

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -409,6 +409,10 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   const toastTimerRef = useRef(null);
   const [drillStack, setDrillStack] = useState([]); // overlay drill-down stack [{ id, label, content }]
   const [playlistSubmenu, setPlaylistSubmenu] = useState(null); // [{ id, name, color, is_member }]
+  const [newPlaylistInputActive, setNewPlaylistInputActive] = useState(false);
+  const [newPlaylistName, setNewPlaylistName] = useState('');
+  const [newPlaylistError, setNewPlaylistError] = useState('');
+  const newPlaylistInputRef = useRef(null);
   const [loadKey, setLoadKey] = useState(0);
   const [playlistInfo, setPlaylistInfo] = useState(null); // { name, total_duration, track_count }
   const [activeId, setActiveId] = useState(null); // DnD active drag id
@@ -638,6 +642,9 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
     const close = () => {
       setContextMenu(null);
       setDrillStack([]);
+      setNewPlaylistInputActive(false);
+      setNewPlaylistName('');
+      setNewPlaylistError('');
     };
     document.addEventListener('mousedown', close);
     return () => document.removeEventListener('mousedown', close);
@@ -938,6 +945,33 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
       console.error('addTracksToPlaylist failed:', err);
     }
   }, []);
+
+  const handleAddToNewPlaylist = useCallback(
+    async (e) => {
+      e?.preventDefault();
+      const name = newPlaylistName.trim();
+      if (!name) {
+        setNewPlaylistInputActive(false);
+        setNewPlaylistName('');
+        return;
+      }
+      const targetIds = contextMenu?.targetIds ?? [];
+      const result = await window.api.createPlaylist(name, null);
+      if (result?.error === 'duplicate') {
+        setNewPlaylistError('Name already exists');
+        newPlaylistInputRef.current?.focus();
+        return;
+      }
+      if (result?.id && targetIds.length) {
+        await window.api.addTracksToPlaylist(result.id, targetIds);
+      }
+      setNewPlaylistInputActive(false);
+      setNewPlaylistName('');
+      setNewPlaylistError('');
+      setContextMenu(null);
+    },
+    [contextMenu, newPlaylistName]
+  );
 
   const handleBpmAdjust = useCallback(
     async (factor) => {
@@ -1295,11 +1329,91 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
                     {/* ── Add to playlist ── */}
                     {playlistSubmenu !== null &&
                       (playlistSubmenu.length === 0 ? (
-                        <div className="context-menu-item context-menu-item--disabled">
-                          ➕ No playlists
-                        </div>
+                        <>
+                          {newPlaylistInputActive ? (
+                            <form
+                              className="ctx-new-playlist-form"
+                              onSubmit={handleAddToNewPlaylist}
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <input
+                                ref={newPlaylistInputRef}
+                                className="ctx-new-playlist-input"
+                                value={newPlaylistName}
+                                onChange={(e) => {
+                                  setNewPlaylistName(e.target.value);
+                                  setNewPlaylistError('');
+                                }}
+                                placeholder="Playlist name"
+                                autoFocus
+                                onBlur={handleAddToNewPlaylist}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Escape') {
+                                    setNewPlaylistInputActive(false);
+                                    setNewPlaylistName('');
+                                    setNewPlaylistError('');
+                                  }
+                                }}
+                              />
+                              {newPlaylistError && (
+                                <div className="ctx-new-playlist-error">{newPlaylistError}</div>
+                              )}
+                            </form>
+                          ) : (
+                            <div
+                              className="context-menu-item"
+                              onClick={() => {
+                                setNewPlaylistInputActive(true);
+                                setTimeout(() => newPlaylistInputRef.current?.focus(), 0);
+                              }}
+                            >
+                              ➕ Add to new playlist…
+                            </div>
+                          )}
+                        </>
                       ) : (
                         <SubItem id="add-to-playlist" label="➕ Add to playlist" scrollable>
+                          <div
+                            className="context-menu-item ctx-new-playlist-item"
+                            onClick={() => {
+                              setNewPlaylistInputActive(true);
+                              setTimeout(() => newPlaylistInputRef.current?.focus(), 0);
+                            }}
+                          >
+                            {newPlaylistInputActive ? (
+                              <form
+                                className="ctx-new-playlist-form"
+                                onSubmit={handleAddToNewPlaylist}
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <input
+                                  ref={newPlaylistInputRef}
+                                  className="ctx-new-playlist-input"
+                                  value={newPlaylistName}
+                                  onChange={(e) => {
+                                    setNewPlaylistName(e.target.value);
+                                    setNewPlaylistError('');
+                                  }}
+                                  placeholder="Playlist name"
+                                  autoFocus
+                                  onBlur={handleAddToNewPlaylist}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Escape') {
+                                      setNewPlaylistInputActive(false);
+                                      setNewPlaylistName('');
+                                      setNewPlaylistError('');
+                                    }
+                                  }}
+                                />
+                                {newPlaylistError && (
+                                  <div className="ctx-new-playlist-error">{newPlaylistError}</div>
+                                )}
+                              </form>
+                            ) : (
+                              '✚ New playlist…'
+                            )}
+                          </div>
+                          <div className="context-menu-separator" />
                           {playlistSubmenu.map((pl) => (
                             <div
                               key={pl.id}

--- a/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
+++ b/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
@@ -215,13 +215,14 @@ describe('context menu — submenu CSS classes', () => {
     expect(submenu.classList.contains('context-submenu--scrollable')).toBe(true);
   });
 
-  it('"Add to playlist" is NOT shown when there are no playlists', async () => {
+  it('shows "Add to new playlist" option directly when there are no playlists', async () => {
     window.api.getPlaylistsForTrack.mockResolvedValue([]);
     renderLibrary();
     await openContextMenu('Track One');
 
-    // Should show a disabled "No playlists" item, not the submenu
-    await waitFor(() => expect(screen.getByText(/➕ No playlists/)).toBeInTheDocument());
+    // When no playlists exist, a direct "Add to new playlist…" item is shown
+    await waitFor(() => expect(screen.getByText(/➕ Add to new playlist…/)).toBeInTheDocument());
+    // No submenu parent for "Add to playlist"
     expect(getSubmenuParent('➕ Add to playlist')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Adds an inline "Add to new playlist" option directly in the track context menu, so users can create a new playlist and add the selected track(s) without opening Settings or the sidebar.

## Changes
- When no playlists exist: a direct **➕ Add to new playlist…** item is shown
- When playlists exist: **✚ New playlist…** appears at the top of the "Add to playlist" submenu
- Inline name input with auto-focus, Enter to confirm, Escape to cancel
- Duplicate playlist name shows an inline error message
- Input state resets when the context menu closes (Escape / outside click)
- Updated context menu test to reflect new no-playlists behaviour

Closes #131