### PR TITLE
feat: auto-normalize on import setting

### DIFF
--- a/renderer/src/SettingsModal.css
+++ b/renderer/src/SettingsModal.css
@@ -410,3 +410,23 @@
   color: #888;
   font-size: 11px;
 }
+
+.settings-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-toggle-row input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  cursor: pointer;
+  accent-color: #1db954;
+}
+
+.settings-toggle-desc {
+  color: #aaa;
+  font-size: 12px;
+  line-height: 1.4;
+}

--- a/renderer/src/SettingsModal.jsx
+++ b/renderer/src/SettingsModal.jsx
@@ -16,6 +16,7 @@ const COOKIE_BROWSERS = [
 function SettingsModal({ onClose }) {
   const [activeSection, setActiveSection] = useState('library');
   const [targetInput, setTargetInput] = useState(String(DEFAULT_TARGET));
+  const [autoNormalizeOnImport, setAutoNormalizeOnImport] = useState(false);
   const [confirmClear, setConfirmClear] = useState(null); // 'library' | 'userdata'
   const [normalizing, setNormalizing] = useState(false);
   const [normalizeProgress, setNormalizeProgress] = useState(null); // { completed, total } | null
@@ -51,6 +52,9 @@ function SettingsModal({ onClose }) {
     window.api
       .getSetting('normalize_target_lufs', String(DEFAULT_TARGET))
       .then((v) => setTargetInput(v));
+    window.api
+      .getSetting('auto_normalize_on_import', 'false')
+      .then((v) => setAutoNormalizeOnImport(v === 'true'));
   }, []);
 
   useEffect(() => {
@@ -124,6 +128,11 @@ function SettingsModal({ onClose }) {
     } finally {
       setResettingNorm(false);
     }
+  };
+
+  const handleAutoNormalizeToggle = (checked) => {
+    setAutoNormalizeOnImport(checked);
+    window.api.setSetting('auto_normalize_on_import', String(checked));
   };
 
   const handleCookiesBrowserChange = (value) => {
@@ -258,6 +267,21 @@ function SettingsModal({ onClose }) {
                       onChange={(e) => handleTargetChange(e.target.value)}
                     />
                     <span className="settings-unit">LUFS</span>
+                  </div>
+                </div>
+                <div className="settings-row">
+                  <label htmlFor="auto-normalize-toggle">Auto-normalize on import</label>
+                  <div className="settings-toggle-row">
+                    <input
+                      id="auto-normalize-toggle"
+                      type="checkbox"
+                      checked={autoNormalizeOnImport}
+                      onChange={(e) => handleAutoNormalizeToggle(e.target.checked)}
+                    />
+                    <span className="settings-toggle-desc">
+                      Automatically normalize every imported track (MP3 import, YT-DLP, TIDAL) after
+                      its analysis finishes. Off by default.
+                    </span>
                   </div>
                 </div>
                 <div className="settings-row settings-row-action">

--- a/src/audio/importManager.js
+++ b/src/audio/importManager.js
@@ -156,7 +156,8 @@ export function spawnAnalysis(trackId, filePath) {
     updateTrack(trackId, update);
 
     // Include normalized_file_path from DB so renderer knows to switch playback to the normalized file
-    const normalized_file_path = getTrackById(trackId)?.normalized_file_path ?? null;
+    const trackAfterUpdate = getTrackById(trackId);
+    const normalized_file_path = trackAfterUpdate?.normalized_file_path ?? null;
     console.log(
       `[importManager] track-updated for ${trackId}: normalized_file_path=${normalized_file_path}`
     );
@@ -167,6 +168,29 @@ export function spawnAnalysis(trackId, filePath) {
         trackId,
         analysis: { ...update, normalized_file_path },
       });
+    }
+
+    // Auto-normalize on import: only when setting is enabled AND this is a fresh (non-normalized) track
+    const autoNormalize = getSetting('auto_normalize_on_import', 'false') === 'true';
+    const alreadyNormalized = trackAfterUpdate?.normalized_file_path != null;
+    if (autoNormalize && !alreadyNormalized && update.loudness != null) {
+      const targetLufs = Number(getSetting('normalize_target_lufs', '-9'));
+      normalizeAudioFile(trackAfterUpdate, targetLufs)
+        .then((normalizedPath) => {
+          const dbUpdate = { normalized_file_path: normalizedPath };
+          if (trackAfterUpdate.source_loudness == null) dbUpdate.source_loudness = update.loudness;
+          updateTrack(trackId, dbUpdate);
+          if (global.mainWindow) {
+            global.mainWindow.webContents.send('track-updated', {
+              trackId,
+              analysis: { normalized_file_path: normalizedPath, analyzed: 0 },
+            });
+          }
+          spawnAnalysis(trackId, normalizedPath);
+        })
+        .catch((err) => {
+          console.error(`[auto-normalize] failed for track ${trackId}:`, err.message);
+        });
     }
   });
 }


### PR DESCRIPTION
## Changes

### Auto-Normalize on Import
- New setting `auto_normalize_on_import` (default: off) in Settings → Normalization section
- When enabled, every imported track is automatically normalized after initial analysis completes
- Hook is in `spawnAnalysis` worker message handler — fires only when `normalized_file_path == null` AND `loudness != null` to prevent infinite re-normalize loops
- Works for all import sources: file import, yt-dlp, and upcoming tidal-dl

### Settings UI
- Checkbox toggle row in the Normalization section of SettingsModal
- Persisted via `set-setting` / `get-setting` IPC (key: `auto_normalize_on_import`)

## Tests
- All 333 main tests pass
- All 127 renderer tests pass
- Lint clean