### PR TITLE
fix: coerce both values to string in sort comparator

### DIFF
--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -498,7 +498,11 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
       // For BPM, prefer the override value
       const va = sortBy.key === 'bpm' ? (a.bpm_override ?? a.bpm ?? '') : (a[sortBy.key] ?? '');
       const vb = sortBy.key === 'bpm' ? (b.bpm_override ?? b.bpm ?? '') : (b[sortBy.key] ?? '');
-      if (typeof va === 'string') return sortBy.asc ? va.localeCompare(vb) : vb.localeCompare(va);
+      if (typeof va === 'string' || typeof vb === 'string') {
+        const sa = String(va ?? '');
+        const sb = String(vb ?? '');
+        return sortBy.asc ? sa.localeCompare(sb) : sb.localeCompare(sa);
+      }
       if (typeof va === 'number') return sortBy.asc ? va - vb : vb - va;
       return 0;
     });


### PR DESCRIPTION
Fixes #149

## Problem
Sorting the track list by BPM (or any column) crashed with `TypeError: vb.localeCompare is not a function` when one track had a numeric value and another fell back to `""` (empty string). The comparator only checked `typeof va === "string"` but never verified `vb` was also a string.

## Fix
If either value is a string, coerce both to `String()` before comparing with `localeCompare`. This handles all mixed-type cases cleanly.