### PR TITLE
feat: add TIDAL download tab powered by tidal-dl-ng

### DIFF
--- a/.dev-url
+++ b/.dev-url
@@ -1,1 +1,1 @@
-http://localhost:5174
+http://localhost:5175

--- a/.dev-url
+++ b/.dev-url
@@ -1,1 +1,1 @@
-http://localhost:5173
+http://localhost:5174

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import Sidebar from './Sidebar.jsx';
 import MusicLibrary from './MusicLibrary.jsx';
 import DownloadView from './DownloadView.jsx';
+import TidalDownloadView from './TidalDownloadView.jsx';
 import SettingsModal from './SettingsModal.jsx';
 import ExportModal from './ExportModal.jsx';
 import PlayerBar from './PlayerBar.jsx';
@@ -58,7 +59,12 @@ function App() {
               onGoToLibrary={() => setSelectedPlaylistId('music')}
               onGoToPlaylist={(id) => setSelectedPlaylistId(id)}
             />
-            {selectedPlaylistId !== 'download' && (
+            <TidalDownloadView
+              style={{ display: selectedPlaylistId === 'tidal' ? '' : 'none' }}
+              onGoToLibrary={() => setSelectedPlaylistId('music')}
+              onGoToPlaylist={(id) => setSelectedPlaylistId(id)}
+            />
+            {selectedPlaylistId !== 'download' && selectedPlaylistId !== 'tidal' && (
               <MusicLibrary
                 selectedPlaylist={selectedPlaylistId}
                 search={search}

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -9,6 +9,7 @@ import PlayerBar from './PlayerBar.jsx';
 import TopBar from './TopBar.jsx';
 import { PlayerProvider } from './PlayerContext.jsx';
 import { DownloadProvider } from './DownloadContext.jsx';
+import { TidalDownloadProvider } from './TidalDownloadContext.jsx';
 import './App.css';
 
 function App() {
@@ -37,67 +38,69 @@ function App() {
   return (
     <PlayerProvider>
       <DownloadProvider>
-        <div className="app-body">
-          <TopBar
-            search={search}
-            onSearchChange={setSearch}
-            onOpenSettings={() => setShowSettings(true)}
-          />
-          <div className="app-main">
-            <Sidebar
-              selectedMenuItemId={selectedPlaylistId}
-              onMenuSelect={setSelectedPlaylistId}
-              activePlaylistId={selectedPlaylistId}
-              onExportPlaylistRekordboxUsb={(id) =>
-                setExportState({ playlistId: id, mode: 'rekordbox' })
-              }
-              onExportPlaylistAll={(id) => setExportState({ playlistId: id, mode: 'all' })}
+        <TidalDownloadProvider>
+          <div className="app-body">
+            <TopBar
+              search={search}
+              onSearchChange={setSearch}
+              onOpenSettings={() => setShowSettings(true)}
             />
-            {/* Always mounted so state persists when switching tabs */}
-            <DownloadView
-              style={{ display: selectedPlaylistId === 'download' ? '' : 'none' }}
-              onGoToLibrary={() => setSelectedPlaylistId('music')}
-              onGoToPlaylist={(id) => setSelectedPlaylistId(id)}
-            />
-            <TidalDownloadView
-              style={{ display: selectedPlaylistId === 'tidal' ? '' : 'none' }}
-              onGoToLibrary={() => setSelectedPlaylistId('music')}
-              onGoToPlaylist={(id) => setSelectedPlaylistId(id)}
-            />
-            {selectedPlaylistId !== 'download' && selectedPlaylistId !== 'tidal' && (
-              <MusicLibrary
-                selectedPlaylist={selectedPlaylistId}
-                search={search}
-                onSearchChange={setSearch}
+            <div className="app-main">
+              <Sidebar
+                selectedMenuItemId={selectedPlaylistId}
+                onMenuSelect={setSelectedPlaylistId}
+                activePlaylistId={selectedPlaylistId}
+                onExportPlaylistRekordboxUsb={(id) =>
+                  setExportState({ playlistId: id, mode: 'rekordbox' })
+                }
+                onExportPlaylistAll={(id) => setExportState({ playlistId: id, mode: 'all' })}
               />
-            )}
-          </div>
-        </div>
-        <PlayerBar
-          onNavigateToPlaylist={setSelectedPlaylistId}
-          onArtistSearch={handleArtistSearch}
-        />
-        {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
-        {exportState != null && (
-          <ExportModal
-            playlistId={exportState.playlistId}
-            initialMode={exportState.mode}
-            onClose={() => setExportState(null)}
-          />
-        )}
-        {depsProgress && (
-          <div className="deps-overlay">
-            <div className="deps-box">
-              <div className="deps-title">First-time setup</div>
-              <div className="deps-msg">{depsProgress.msg}</div>
-              {depsProgress.pct >= 0 && depsProgress.pct < 100 && (
-                <div className="deps-bar-track">
-                  <div className="deps-bar-fill" style={{ width: `${depsProgress.pct}%` }} />
-                </div>
+              {/* Always mounted so state persists when switching tabs */}
+              <DownloadView
+                style={{ display: selectedPlaylistId === 'download' ? '' : 'none' }}
+                onGoToLibrary={() => setSelectedPlaylistId('music')}
+                onGoToPlaylist={(id) => setSelectedPlaylistId(id)}
+              />
+              <TidalDownloadView
+                style={{ display: selectedPlaylistId === 'tidal' ? '' : 'none' }}
+                onGoToLibrary={() => setSelectedPlaylistId('music')}
+                onGoToPlaylist={(id) => setSelectedPlaylistId(id)}
+              />
+              {selectedPlaylistId !== 'download' && selectedPlaylistId !== 'tidal' && (
+                <MusicLibrary
+                  selectedPlaylist={selectedPlaylistId}
+                  search={search}
+                  onSearchChange={setSearch}
+                />
               )}
             </div>
           </div>
-        )}
+          <PlayerBar
+            onNavigateToPlaylist={setSelectedPlaylistId}
+            onArtistSearch={handleArtistSearch}
+          />
+          {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
+          {exportState != null && (
+            <ExportModal
+              playlistId={exportState.playlistId}
+              initialMode={exportState.mode}
+              onClose={() => setExportState(null)}
+            />
+          )}
+          {depsProgress && (
+            <div className="deps-overlay">
+              <div className="deps-box">
+                <div className="deps-title">First-time setup</div>
+                <div className="deps-msg">{depsProgress.msg}</div>
+                {depsProgress.pct >= 0 && depsProgress.pct < 100 && (
+                  <div className="deps-bar-track">
+                    <div className="deps-bar-fill" style={{ width: `${depsProgress.pct}%` }} />
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </TidalDownloadProvider>
       </DownloadProvider>
     </PlayerProvider>
   );

--- a/renderer/src/SettingsModal.jsx
+++ b/renderer/src/SettingsModal.jsx
@@ -28,6 +28,7 @@ function SettingsModal({ onClose }) {
   const [updatingAll, setUpdatingAll] = useState(false);
   const [ytdlpVersionInput, setYtdlpVersionInput] = useState('');
   const [ytdlpUpdating, setYtdlpUpdating] = useState(false);
+  const [tidalUpdating, setTidalUpdating] = useState(false);
   const [cookiesBrowser, setCookiesBrowser] = useState('');
 
   // Library location
@@ -87,6 +88,14 @@ function SettingsModal({ onClose }) {
     setDepVersions(versions);
     setYtdlpUpdating(false);
     if (tag) setYtdlpVersionInput('');
+  };
+
+  const handleUpdateTidalDlNg = async () => {
+    setTidalUpdating(true);
+    await window.api.updateTidalDlNg();
+    const versions = await window.api.getDepVersions();
+    setDepVersions(versions);
+    setTidalUpdating(false);
   };
 
   const handleTargetChange = (raw) => {
@@ -440,7 +449,8 @@ function SettingsModal({ onClose }) {
               <div className="settings-group">
                 <div className="settings-group-title">Installed Versions</div>
                 <p className="settings-group-desc">
-                  FFmpeg, mixxx-analyzer, and yt-dlp are downloaded automatically on first launch.
+                  FFmpeg, mixxx-analyzer, yt-dlp, and tidal-dl-ng are downloaded automatically on
+                  first launch.
                 </p>
                 <div className="dep-version-list">
                   <div className="dep-version-row">
@@ -455,6 +465,12 @@ function SettingsModal({ onClose }) {
                     <span className="dep-version-name">yt-dlp</span>
                     <span className="dep-version-tag">{depVersions?.ytDlp?.version ?? '…'}</span>
                   </div>
+                  <div className="dep-version-row">
+                    <span className="dep-version-name">tidal-dl-ng</span>
+                    <span className="dep-version-tag">
+                      {depVersions?.tidalDlNg?.version ?? 'not installed'}
+                    </span>
+                  </div>
                 </div>
               </div>
 
@@ -464,13 +480,13 @@ function SettingsModal({ onClose }) {
                   <div>
                     <div className="settings-action-label">Update All Dependencies</div>
                     <div className="settings-action-desc">
-                      Re-downloads the latest FFmpeg, mixxx-analyzer, and yt-dlp.
+                      Re-downloads the latest FFmpeg, mixxx-analyzer, yt-dlp, and tidal-dl-ng.
                     </div>
                   </div>
                   <button
                     className="btn-primary"
                     onClick={handleUpdateAll}
-                    disabled={updatingAll || ytdlpUpdating}
+                    disabled={updatingAll || ytdlpUpdating || tidalUpdating}
                   >
                     {updatingAll ? 'Updating…' : 'Update All'}
                   </button>
@@ -486,9 +502,25 @@ function SettingsModal({ onClose }) {
                   <button
                     className="btn-secondary"
                     onClick={() => handleUpdateYtDlp(null)}
-                    disabled={updatingAll || ytdlpUpdating}
+                    disabled={updatingAll || ytdlpUpdating || tidalUpdating}
                   >
                     {ytdlpUpdating && !ytdlpVersionInput ? 'Updating…' : 'Update yt-dlp'}
+                  </button>
+                </div>
+
+                <div className="settings-row settings-row-action" style={{ marginTop: '0.75rem' }}>
+                  <div>
+                    <div className="settings-action-label">Update tidal-dl-ng</div>
+                    <div className="settings-action-desc">
+                      Upgrades tidal-dl-ng to the latest version via pip.
+                    </div>
+                  </div>
+                  <button
+                    className="btn-secondary"
+                    onClick={handleUpdateTidalDlNg}
+                    disabled={updatingAll || ytdlpUpdating || tidalUpdating}
+                  >
+                    {tidalUpdating ? 'Updating…' : 'Update tidal-dl-ng'}
                   </button>
                 </div>
               </div>

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useDownload } from './DownloadContext.jsx';
+import { useTidalDownload } from './TidalDownloadContext.jsx';
 import './Sidebar.css';
 import ImportPlaylistDialog from './ImportPlaylistDialog';
 
@@ -27,6 +28,7 @@ function Sidebar({
   onExportPlaylistAll,
 }) {
   const { sidebarProgress: ytDlpSidebarProgress } = useDownload();
+  const { sidebarProgress: tidalSidebarProgress } = useTidalDownload();
   const [playlists, setPlaylists] = useState([]);
   const [importProgress, setImportProgress] = useState({ total: 0, completed: 0 });
   const [normalizeProgress, setNormalizeProgress] = useState(null); // { completed, total } | null
@@ -391,6 +393,41 @@ function Sidebar({
                   }}
                 >
                   {ytDlpSidebarProgress.msg}
+                </span>
+              </div>
+            )}
+          </button>
+        )}
+        {tidalSidebarProgress && (
+          <button
+            className="normalize-progress-wrap ytdlp-progress-clickable"
+            onClick={() => onMenuSelect('tidal')}
+            title="Go to TIDAL"
+          >
+            <div className="normalize-progress-label">
+              <span>TIDAL Downloading</span>
+              <span>
+                {tidalSidebarProgress.current} / {tidalSidebarProgress.total}
+              </span>
+            </div>
+            <div className="normalize-progress-bar">
+              <div
+                className="normalize-progress-fill ytdlp-progress-fill"
+                style={{ width: `${Math.round(tidalSidebarProgress.pct)}%` }}
+              />
+            </div>
+            {tidalSidebarProgress.msg && (
+              <div className="normalize-progress-label" style={{ marginTop: 4, opacity: 0.7 }}>
+                <span
+                  style={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    maxWidth: '100%',
+                    fontSize: 11,
+                  }}
+                >
+                  {tidalSidebarProgress.msg}
                 </span>
               </div>
             )}

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -6,6 +6,7 @@ import ImportPlaylistDialog from './ImportPlaylistDialog';
 const MENU_ITEMS = [
   { id: 'music', name: 'Music', icon: '🎵' },
   { id: 'download', name: 'YT-DLP', icon: '⬇️' },
+  { id: 'tidal', name: 'TIDAL', icon: '🌊' },
 ];
 
 const PRESET_COLORS = [

--- a/renderer/src/TidalDownloadContext.jsx
+++ b/renderer/src/TidalDownloadContext.jsx
@@ -14,6 +14,8 @@ export function TidalDownloadProvider({ children }) {
   // ── step: select ─────────────────────────────────────────────────────────────
   const [playlistInfo, setPlaylistInfo] = useState(null); // { type, title, entries }
   const [selectedIndices, setSelectedIndices] = useState(new Set());
+  const [linkIndices, setLinkIndices] = useState(new Set()); // entries already in library
+  const [libraryMap, setLibraryMap] = useState(new Map()); // url → trackId
   const [playlists, setPlaylists] = useState([]);
   const [targetPlaylistId, setTargetPlaylistId] = useState(null);
   const [targetPlaylistName, setTargetPlaylistName] = useState('');
@@ -84,6 +86,8 @@ export function TidalDownloadProvider({ children }) {
     setStep('url');
     setPlaylistInfo(null);
     setSelectedIndices(new Set());
+    setLinkIndices(new Set());
+    setLibraryMap(new Map());
     setTargetPlaylistId(null);
     setTargetPlaylistName('');
     setFetchError(null);
@@ -107,6 +111,10 @@ export function TidalDownloadProvider({ children }) {
         setPlaylistInfo,
         selectedIndices,
         setSelectedIndices,
+        linkIndices,
+        setLinkIndices,
+        libraryMap,
+        setLibraryMap,
         playlists,
         setPlaylists,
         targetPlaylistId,

--- a/renderer/src/TidalDownloadContext.jsx
+++ b/renderer/src/TidalDownloadContext.jsx
@@ -1,0 +1,138 @@
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+const TidalDownloadContext = createContext(null);
+
+export function TidalDownloadProvider({ children }) {
+  // ── shared ──────────────────────────────────────────────────────────────────
+  const [url, setUrl] = useState('');
+  const [step, setStep] = useState('url'); // 'url' | 'select' | 'download'
+
+  // ── step: url ───────────────────────────────────────────────────────────────
+  const [fetching, setFetching] = useState(false);
+  const [fetchError, setFetchError] = useState(null);
+
+  // ── step: select ─────────────────────────────────────────────────────────────
+  const [playlistInfo, setPlaylistInfo] = useState(null); // { type, title, entries }
+  const [selectedIndices, setSelectedIndices] = useState(new Set());
+  const [playlists, setPlaylists] = useState([]);
+  const [targetPlaylistId, setTargetPlaylistId] = useState(null);
+  const [targetPlaylistName, setTargetPlaylistName] = useState('');
+
+  // ── step: download ───────────────────────────────────────────────────────────
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState(null); // { msg }
+  const [trackStatuses, setTrackStatuses] = useState([]); // [{ index, title, artist, status }]
+  const [result, setResult] = useState(null); // { ok, trackIds, playlistId, error }
+
+  // Subscribe to IPC events — context never unmounts
+  useEffect(() => {
+    const unsubProgress = window.api.onTidalProgress((data) => {
+      if (data === null) {
+        setLoading(false);
+        setProgress(null);
+      } else {
+        setProgress(data);
+      }
+    });
+
+    const unsubTrack = window.api.onTidalTrackUpdate((update) => {
+      if (update.type === 'init') {
+        // Initialize the track status list from the selected entries
+        setTrackStatuses(
+          (update.tracks ?? []).map((e) => ({
+            index: e.index,
+            title: e.title,
+            artist: e.artist,
+            status: 'pending',
+          }))
+        );
+      } else {
+        setTrackStatuses((prev) => {
+          const next = [...prev];
+          const i = update.index;
+          while (next.length <= i) {
+            const n = next.length;
+            next.push({ index: n, title: `Track ${n + 1}`, artist: '', status: 'pending' });
+          }
+          next[i] = { ...next[i], ...update };
+          return next;
+        });
+      }
+    });
+
+    return () => {
+      unsubProgress();
+      unsubTrack();
+    };
+  }, []);
+
+  // ── derived ──────────────────────────────────────────────────────────────────
+  const completedCount = trackStatuses.filter(
+    (s) => s.status === 'done' || s.status === 'failed'
+  ).length;
+  const sbTotal = Math.max(trackStatuses.length, 1);
+  const sidebarProgress = loading
+    ? {
+        current: completedCount,
+        total: sbTotal,
+        pct: sbTotal > 0 ? Math.round((completedCount / sbTotal) * 100) : 0,
+        msg: progress?.msg ?? 'Downloading…',
+      }
+    : null;
+
+  const resetToUrl = useCallback(() => {
+    setStep('url');
+    setPlaylistInfo(null);
+    setSelectedIndices(new Set());
+    setTargetPlaylistId(null);
+    setTargetPlaylistName('');
+    setFetchError(null);
+    setResult(null);
+    setTrackStatuses([]);
+    setProgress(null);
+  }, []);
+
+  return (
+    <TidalDownloadContext.Provider
+      value={{
+        url,
+        setUrl,
+        step,
+        setStep,
+        fetching,
+        setFetching,
+        fetchError,
+        setFetchError,
+        playlistInfo,
+        setPlaylistInfo,
+        selectedIndices,
+        setSelectedIndices,
+        playlists,
+        setPlaylists,
+        targetPlaylistId,
+        setTargetPlaylistId,
+        targetPlaylistName,
+        setTargetPlaylistName,
+        loading,
+        setLoading,
+        progress,
+        setProgress,
+        trackStatuses,
+        setTrackStatuses,
+        result,
+        setResult,
+        sidebarProgress,
+        resetToUrl,
+      }}
+    >
+      {children}
+    </TidalDownloadContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTidalDownload() {
+  const ctx = useContext(TidalDownloadContext);
+  if (!ctx) throw new Error('useTidalDownload must be used inside TidalDownloadProvider');
+  return ctx;
+}

--- a/renderer/src/TidalDownloadContext.jsx
+++ b/renderer/src/TidalDownloadContext.jsx
@@ -14,8 +14,9 @@ export function TidalDownloadProvider({ children }) {
   // ── step: select ─────────────────────────────────────────────────────────────
   const [playlistInfo, setPlaylistInfo] = useState(null); // { type, title, entries }
   const [selectedIndices, setSelectedIndices] = useState(new Set());
-  const [linkIndices, setLinkIndices] = useState(new Set()); // entries already in library
+  const [linkIndices, setLinkIndices] = useState(new Set()); // in library, not in target playlist
   const [libraryMap, setLibraryMap] = useState(new Map()); // url → trackId
+  const [playlistMemberUrls, setPlaylistMemberUrls] = useState(new Set()); // urls already in target playlist
   const [playlists, setPlaylists] = useState([]);
   const [targetPlaylistId, setTargetPlaylistId] = useState(null);
   const [targetPlaylistName, setTargetPlaylistName] = useState('');
@@ -88,6 +89,7 @@ export function TidalDownloadProvider({ children }) {
     setSelectedIndices(new Set());
     setLinkIndices(new Set());
     setLibraryMap(new Map());
+    setPlaylistMemberUrls(new Set());
     setTargetPlaylistId(null);
     setTargetPlaylistName('');
     setFetchError(null);
@@ -115,6 +117,8 @@ export function TidalDownloadProvider({ children }) {
         setLinkIndices,
         libraryMap,
         setLibraryMap,
+        playlistMemberUrls,
+        setPlaylistMemberUrls,
         playlists,
         setPlaylists,
         targetPlaylistId,

--- a/renderer/src/TidalDownloadView.css
+++ b/renderer/src/TidalDownloadView.css
@@ -293,6 +293,18 @@
   white-space: nowrap;
 }
 
+.dl-entry--library {
+  opacity: 0.75;
+}
+
+.dl-entry-library-badge {
+  font-size: 11px;
+  color: #4caf50;
+  white-space: nowrap;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
 .dl-select-actions {
   display: flex;
   align-items: center;

--- a/renderer/src/TidalDownloadView.css
+++ b/renderer/src/TidalDownloadView.css
@@ -176,3 +176,211 @@
 .tidal-checking {
   animation: tidal-blink 1.2s ease-in-out infinite;
 }
+
+/* ── Fetch error ─────────────────────────────────────────────────────────── */
+
+.dl-fetch-error {
+  font-size: 12px;
+  color: #fc8181;
+}
+
+/* ── Select step ─────────────────────────────────────────────────────────── */
+
+.dl-select-list {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  max-height: min(420px, 50vh);
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+.dl-select-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border, #2a2a2a);
+  background: var(--bg-secondary, #1a1a1a);
+  border-radius: 6px 6px 0 0;
+}
+
+.dl-select-all {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary, #aaa);
+  cursor: pointer;
+  user-select: none;
+}
+
+.dl-select-all input[type='checkbox'] {
+  accent-color: var(--accent, #7c5cfc);
+}
+
+.dl-select-count {
+  font-size: 12px;
+  color: var(--text-secondary, #666);
+}
+
+.dl-entries {
+  overflow-y: auto;
+  max-height: calc(min(420px, 50vh) - 38px);
+}
+
+.dl-entry {
+  display: grid;
+  grid-template-columns: auto 28px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border, #1e1e1e);
+  cursor: pointer;
+  transition: background 0.1s;
+  user-select: none;
+}
+
+.dl-entry:last-child {
+  border-bottom: none;
+}
+
+.dl-entry:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.dl-entry input[type='checkbox'] {
+  accent-color: var(--accent, #7c5cfc);
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.dl-entry-num {
+  font-size: 11px;
+  color: var(--text-secondary, #555);
+  text-align: right;
+}
+
+.dl-entry-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  overflow: hidden;
+}
+
+.dl-entry-title {
+  font-size: 13px;
+  color: var(--text-primary, #ddd);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dl-entry-artist {
+  font-size: 11px;
+  color: var(--text-secondary, #888);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dl-entry-dur {
+  font-size: 11px;
+  color: var(--text-secondary, #666);
+  white-space: nowrap;
+}
+
+.dl-select-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+/* ── Download step track list ────────────────────────────────────────────── */
+
+.dl-track-list {
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 6px;
+  overflow-y: auto;
+  max-height: min(480px, 55vh);
+  margin-bottom: 12px;
+}
+
+.dl-track-row {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--border, #1e1e1e);
+}
+
+.dl-track-row:last-child {
+  border-bottom: none;
+}
+
+.dl-track-icon {
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.dl-track-icon--pending {
+  color: var(--text-secondary, #555);
+}
+.dl-track-icon--downloading {
+  color: #f6ad55;
+}
+.dl-track-icon--importing {
+  color: #63b3ed;
+}
+.dl-track-icon--done {
+  color: #68d391;
+}
+.dl-track-icon--failed {
+  color: #fc8181;
+}
+
+.dl-track-row--done {
+  background: rgba(104, 211, 145, 0.04);
+}
+.dl-track-row--failed {
+  background: rgba(252, 129, 129, 0.04);
+}
+
+.dl-track-info {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.dl-track-title {
+  font-size: 13px;
+  color: var(--text-primary, #ddd);
+}
+
+.dl-track-artist {
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+}
+
+.dl-track-error {
+  font-size: 11px;
+  color: #fc8181;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Progress bar fill (deterministic) ──────────────────────────────────── */
+
+.dl-progress-fill {
+  height: 100%;
+  background: var(--accent, #7c5cfc);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}

--- a/renderer/src/TidalDownloadView.css
+++ b/renderer/src/TidalDownloadView.css
@@ -36,6 +36,27 @@
   line-height: 1.5;
 }
 
+.tidal-install-log {
+  background: #111;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-family: monospace;
+  font-size: 12px;
+  color: #a6e3a1;
+  min-height: 60px;
+  max-height: 160px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tidal-install-log-line {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
 /* ── Login box ────────────────────────────────────────────────────────────── */
 
 .tidal-login-box {

--- a/renderer/src/TidalDownloadView.css
+++ b/renderer/src/TidalDownloadView.css
@@ -305,6 +305,10 @@
   margin-left: auto;
 }
 
+.dl-entry-playlist-badge {
+  color: #2196f3;
+}
+
 .dl-select-actions {
   display: flex;
   align-items: center;

--- a/renderer/src/TidalDownloadView.css
+++ b/renderer/src/TidalDownloadView.css
@@ -1,0 +1,157 @@
+/* ── Install prompt ───────────────────────────────────────────────────────── */
+
+.tidal-install-box {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-width: 520px;
+  padding: 24px;
+  background: var(--bg-secondary, #1e1e1e);
+  border: 1px solid var(--border, #333);
+  border-radius: 10px;
+}
+
+.tidal-install-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.tidal-install-cmd {
+  display: block;
+  padding: 10px 14px;
+  background: #111;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  font-family: monospace;
+  font-size: 13px;
+  color: #a6e3a1;
+  user-select: all;
+}
+
+.tidal-install-note {
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ── Login box ────────────────────────────────────────────────────────────── */
+
+.tidal-login-box {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 520px;
+  padding: 24px;
+  background: var(--bg-secondary, #1e1e1e);
+  border: 1px solid var(--border, #333);
+  border-radius: 10px;
+}
+
+.tidal-login-desc {
+  font-size: 13px;
+  color: var(--text-secondary, #aaa);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.tidal-login-btn {
+  align-self: flex-start;
+}
+
+.tidal-login-waiting {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.tidal-spinner {
+  font-size: 20px;
+  animation: tidal-blink 1s steps(1) infinite;
+}
+
+@keyframes tidal-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.2;
+  }
+}
+
+.tidal-login-url-box {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: rgba(124, 92, 252, 0.08);
+  border: 1px solid rgba(124, 92, 252, 0.2);
+  border-radius: 6px;
+}
+
+.tidal-login-url-label {
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+  margin: 0;
+}
+
+.tidal-login-url-link {
+  font-size: 12px;
+  color: var(--accent, #7c5cfc);
+  word-break: break-all;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.tidal-login-url-link:hover {
+  opacity: 0.8;
+}
+
+/* ── Indeterminate progress ──────────────────────────────────────────────── */
+
+.tidal-progress-indeterminate {
+  height: 100%;
+  width: 40%;
+  background: var(--accent, #7c5cfc);
+  border-radius: 2px;
+  animation: tidal-slide 1.4s ease-in-out infinite;
+}
+
+@keyframes tidal-slide {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(300%);
+  }
+}
+
+/* ── Re-auth footer ──────────────────────────────────────────────────────── */
+
+.tidal-reauth {
+  margin-top: auto;
+  padding-top: 32px;
+}
+
+.tidal-reauth-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary, #555);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.tidal-reauth-btn:hover {
+  color: var(--text-secondary, #888);
+}
+
+.tidal-checking {
+  animation: tidal-blink 1.2s ease-in-out infinite;
+}

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -31,6 +31,11 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
 
   const inputRef = useRef(null);
 
+  // ── install state ─────────────────────────────────────────────────────────
+  const [installing, setInstalling] = useState(false);
+  const [installLog, setInstallLog] = useState([]);
+  const [installError, setInstallError] = useState(null);
+
   // ── initial setup check ───────────────────────────────────────────────────
   const checkSetup = useCallback(async () => {
     setSetup(null);
@@ -56,9 +61,14 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
       window.api.openExternal(url);
     });
 
+    const unsubInstall = window.api.onTidalInstallProgress((data) => {
+      setInstallLog((prev) => [...prev.slice(-199), data.msg]);
+    });
+
     return () => {
       unsubProgress();
       unsubLoginUrl();
+      unsubInstall();
     };
   }, [checkSetup]);
 
@@ -152,23 +162,72 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
 
   // ── render: not installed ─────────────────────────────────────────────────
   if (!setup.installed) {
+    const handleInstall = async () => {
+      setInstalling(true);
+      setInstallLog([]);
+      setInstallError(null);
+      const res = await window.api.tidalInstall();
+      setInstalling(false);
+      if (res.ok) {
+        await checkSetup();
+      } else {
+        setInstallError(res.error);
+      }
+    };
+
     return (
       <div className="dl-view" style={style}>
         <div className="dl-header">
           <h2 className="dl-title">TIDAL Download</h2>
           <p className="dl-subtitle">
-            tidal-dl-ng is not installed. Install it to enable TIDAL downloads.
+            {installing ? 'Installing tidal-dl-ng…' : 'tidal-dl-ng needs to be installed.'}
           </p>
         </div>
         <div className="tidal-install-box">
-          <div className="tidal-install-title">Install tidal-dl-ng</div>
-          <code className="tidal-install-cmd">pip install tidal-dl-ng</code>
-          <p className="tidal-install-note">
-            Requires Python 3.12+. After installing, restart DjManager.
-          </p>
-          <button className="dl-btn" onClick={checkSetup}>
-            Check again
-          </button>
+          {!installing && !installError && (
+            <>
+              <div className="tidal-install-title">One-click install</div>
+              <p className="tidal-install-note">
+                Requires Python 3.12+ to be installed on your system.
+              </p>
+              <button className="dl-btn" onClick={handleInstall}>
+                Install tidal-dl-ng
+              </button>
+            </>
+          )}
+
+          {installing && (
+            <>
+              <div className="tidal-install-title">Installing…</div>
+              <div className="tidal-install-log">
+                {installLog.slice(-8).map((line, i) => (
+                  <div key={i} className="tidal-install-log-line">
+                    {line}
+                  </div>
+                ))}
+                {installLog.length === 0 && (
+                  <div className="tidal-install-log-line">Starting pip…</div>
+                )}
+              </div>
+            </>
+          )}
+
+          {installError && (
+            <>
+              <div className="tidal-install-title" style={{ color: 'var(--error, #f55)' }}>
+                Installation failed
+              </div>
+              <p className="tidal-install-note">{installError}</p>
+              <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                <button className="dl-btn" onClick={handleInstall}>
+                  Retry
+                </button>
+                <button className="dl-btn" onClick={checkSetup} style={{ opacity: 0.7 }}>
+                  Check again
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
     );

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -162,7 +162,7 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
 
   // ── render: not installed ─────────────────────────────────────────────────
   if (!setup.installed) {
-    const handleInstall = async () => {
+    const handleRetry = async () => {
       setInstalling(true);
       setInstallLog([]);
       setInstallError(null);
@@ -179,23 +179,21 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
       <div className="dl-view" style={style}>
         <div className="dl-header">
           <h2 className="dl-title">TIDAL Download</h2>
-          <p className="dl-subtitle">
-            {installing ? 'Installing tidal-dl-ng…' : 'tidal-dl-ng needs to be installed.'}
-          </p>
+          <p className="dl-subtitle">tidal-dl-ng could not be installed during startup.</p>
         </div>
         <div className="tidal-install-box">
           {!installing && !installError && (
             <>
-              <div className="tidal-install-title">One-click install</div>
+              <div className="tidal-install-title">Python not found</div>
               <p className="tidal-install-note">
-                Requires Python 3.12+ to be installed on your system.
+                tidal-dl-ng requires Python 3.12+. Install it, then click Retry. You can also check
+                Settings → Dependencies.
               </p>
-              <button className="dl-btn" onClick={handleInstall}>
-                Install tidal-dl-ng
+              <button className="dl-btn" onClick={handleRetry}>
+                Retry
               </button>
             </>
           )}
-
           {installing && (
             <>
               <div className="tidal-install-title">Installing…</div>
@@ -211,21 +209,15 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
               </div>
             </>
           )}
-
           {installError && (
             <>
               <div className="tidal-install-title" style={{ color: 'var(--error, #f55)' }}>
                 Installation failed
               </div>
               <p className="tidal-install-note">{installError}</p>
-              <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
-                <button className="dl-btn" onClick={handleInstall}>
-                  Retry
-                </button>
-                <button className="dl-btn" onClick={checkSetup} style={{ opacity: 0.7 }}>
-                  Check again
-                </button>
-              </div>
+              <button className="dl-btn" onClick={handleRetry}>
+                Retry
+              </button>
             </>
           )}
         </div>

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -41,6 +41,10 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
     setPlaylistInfo,
     selectedIndices,
     setSelectedIndices,
+    linkIndices,
+    setLinkIndices,
+    libraryMap,
+    setLibraryMap,
     playlists,
     setPlaylists,
     targetPlaylistId,
@@ -131,6 +135,23 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
 
       setPlaylistInfo(res);
 
+      // Check which entries are already in the library
+      const newLibraryMap = new Map();
+      try {
+        const entryChecks = (res.entries ?? [])
+          .filter((e) => e.url || e.id)
+          .map((e) => ({ url: e.url, id: String(e.id) }));
+        if (entryChecks.length > 0) {
+          const found = await window.api.checkDuplicateUrls(entryChecks);
+          for (const { url: u, trackId } of found) {
+            if (u) newLibraryMap.set(u, trackId);
+          }
+        }
+      } catch {
+        // non-fatal
+      }
+      setLibraryMap(newLibraryMap);
+
       const pls = await window.api.getPlaylists().catch(() => []);
       setPlaylists(pls);
       const match = pls.find((p) => p.name.toLowerCase() === (res.title ?? '').toLowerCase());
@@ -144,15 +165,33 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
 
       // Single tracks and mixes skip the select step — go straight to download
       if (res.type === 'track' || res.type === 'mix' || (res.entries?.length ?? 0) === 0) {
-        const allIndices = new Set((res.entries ?? []).map((e) => e.index));
+        const allIndices = new Set(
+          (res.entries ?? []).filter((e) => !newLibraryMap.has(e.url)).map((e) => e.index)
+        );
+        const linkIdx = new Set(
+          (res.entries ?? []).filter((e) => newLibraryMap.has(e.url)).map((e) => e.index)
+        );
         setSelectedIndices(allIndices);
+        setLinkIndices(linkIdx);
         setStep('download');
-        await runDownload(res, allIndices, pls, match?.id ?? null, res.title ?? '');
+        await runDownload(
+          res,
+          allIndices,
+          linkIdx,
+          newLibraryMap,
+          match?.id ?? null,
+          res.title ?? ''
+        );
         return;
       }
 
-      // Pre-select all available entries then go to the select step
-      setSelectedIndices(new Set(res.entries.map((e) => e.index)));
+      // Pre-select non-library entries; pre-link library entries
+      setSelectedIndices(
+        new Set(res.entries.filter((e) => !newLibraryMap.has(e.url)).map((e) => e.index))
+      );
+      setLinkIndices(
+        new Set(res.entries.filter((e) => newLibraryMap.has(e.url)).map((e) => e.index))
+      );
       setStep('select');
     } catch (err) {
       setFetchError(err.message);
@@ -163,21 +202,29 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
 
   // ── step select → download ─────────────────────────────────────────────────
   const handleDownload = async () => {
-    if (selectedIndices.size === 0 || !playlistInfo) return;
+    if (selectedIndices.size === 0 && linkIndices.size === 0) return;
+    if (!playlistInfo) return;
     setStep('download');
     await runDownload(
       playlistInfo,
       selectedIndices,
-      playlists,
+      linkIndices,
+      libraryMap,
       targetPlaylistId,
       targetPlaylistName
     );
   };
 
-  async function runDownload(info, indices, _pls, playlistId, playlistName) {
+  async function runDownload(info, indices, links, libMap, playlistId, playlistName) {
     const selectedEntries = (info.entries ?? [])
       .filter((e) => indices.has(e.index))
       .sort((a, b) => a.index - b.index);
+
+    const linkEntries = (info.entries ?? [])
+      .filter((e) => links.has(e.index))
+      .sort((a, b) => a.index - b.index);
+
+    const linkTrackIds = linkEntries.map((e) => libMap.get(e.url)).filter(Boolean);
 
     setLoading(true);
     setResult(null);
@@ -185,6 +232,7 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
     const res = await window.api.tidalDownloadUrl({
       url,
       selectedEntries,
+      linkTrackIds,
       existingPlaylistId: playlistId || null,
       newPlaylistName: !playlistId && playlistName?.trim() ? playlistName.trim() : null,
     });
@@ -202,23 +250,42 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
 
   // ── toggle selection ────────────────────────────────────────────────────────
   const handleToggleEntry = useCallback(
-    (index) => {
-      setSelectedIndices((prev) => {
-        const next = new Set(prev);
-        if (next.has(index)) next.delete(index);
-        else next.add(index);
-        return next;
-      });
+    (index, entry) => {
+      const isInLibrary = entry && libraryMap.has(entry.url);
+      if (isInLibrary) {
+        // library entries toggle in linkIndices
+        setLinkIndices((prev) => {
+          const next = new Set(prev);
+          if (next.has(index)) next.delete(index);
+          else next.add(index);
+          return next;
+        });
+      } else {
+        setSelectedIndices((prev) => {
+          const next = new Set(prev);
+          if (next.has(index)) next.delete(index);
+          else next.add(index);
+          return next;
+        });
+      }
     },
-    [setSelectedIndices]
+    [libraryMap, setSelectedIndices, setLinkIndices]
   );
 
   const handleToggleAll = useCallback(() => {
     if (!playlistInfo) return;
-    const all = playlistInfo.entries.map((e) => e.index);
-    const allSelected = all.every((i) => selectedIndices.has(i));
-    setSelectedIndices(allSelected ? new Set() : new Set(all));
-  }, [playlistInfo, selectedIndices, setSelectedIndices]);
+    const downloadable = playlistInfo.entries.filter((e) => !libraryMap.has(e.url));
+    const linkable = playlistInfo.entries.filter((e) => libraryMap.has(e.url));
+    const allDownSelected = downloadable.every((e) => selectedIndices.has(e.index));
+    const allLinkSelected = linkable.every((e) => linkIndices.has(e.index));
+    if (allDownSelected && allLinkSelected) {
+      setSelectedIndices(new Set());
+      setLinkIndices(new Set());
+    } else {
+      setSelectedIndices(new Set(downloadable.map((e) => e.index)));
+      setLinkIndices(new Set(linkable.map((e) => e.index)));
+    }
+  }, [playlistInfo, libraryMap, selectedIndices, linkIndices, setSelectedIndices, setLinkIndices]);
 
   // ── render: checking setup ────────────────────────────────────────────────
   if (setup === null) {
@@ -451,14 +518,21 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
   // ── render: step — select ─────────────────────────────────────────────────
   if (step === 'select') {
     const entries = playlistInfo?.entries ?? [];
-    const allSelected = entries.length > 0 && entries.every((e) => selectedIndices.has(e.index));
+    const downloadable = entries.filter((e) => !libraryMap.has(e.url));
+    const linkable = entries.filter((e) => libraryMap.has(e.url));
+    const allDownSelected = downloadable.every((e) => selectedIndices.has(e.index));
+    const allLinkSelected = linkable.every((e) => linkIndices.has(e.index));
+    const allSelected = entries.length > 0 && allDownSelected && allLinkSelected;
+    const totalActive = selectedIndices.size + linkIndices.size;
 
     return (
       <div className="dl-view" style={style}>
         <div className="dl-header">
           <h2 className="dl-title">{playlistInfo?.title ?? 'Select tracks'}</h2>
           <p className="dl-subtitle">
-            {entries.length} track{entries.length !== 1 ? 's' : ''} · select which to download
+            {entries.length} track{entries.length !== 1 ? 's' : ''}
+            {libraryMap.size > 0 ? ` · ${libraryMap.size} already in library` : ''}
+            {' · '}select which to download
           </p>
         </div>
 
@@ -469,27 +543,37 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
               <span>Select all</span>
             </label>
             <span className="dl-select-count">
-              {selectedIndices.size} / {entries.length} selected
+              {totalActive} / {entries.length} selected
             </span>
           </div>
           <div className="dl-entries">
-            {entries.map((entry) => (
-              <label key={entry.index} className="dl-entry">
-                <input
-                  type="checkbox"
-                  checked={selectedIndices.has(entry.index)}
-                  onChange={() => handleToggleEntry(entry.index)}
-                />
-                <span className="dl-entry-num">{entry.index + 1}</span>
-                <span className="dl-entry-info">
-                  <span className="dl-entry-title">{entry.title}</span>
-                  {entry.artist && <span className="dl-entry-artist">{entry.artist}</span>}
-                </span>
-                {entry.duration > 0 && (
-                  <span className="dl-entry-dur">{fmtDuration(entry.duration)}</span>
-                )}
-              </label>
-            ))}
+            {entries.map((entry) => {
+              const inLibrary = libraryMap.has(entry.url);
+              const checked = inLibrary
+                ? linkIndices.has(entry.index)
+                : selectedIndices.has(entry.index);
+              return (
+                <label
+                  key={entry.index}
+                  className={`dl-entry${inLibrary ? ' dl-entry--library' : ''}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => handleToggleEntry(entry.index, entry)}
+                  />
+                  <span className="dl-entry-num">{entry.index + 1}</span>
+                  <span className="dl-entry-info">
+                    <span className="dl-entry-title">{entry.title}</span>
+                    {entry.artist && <span className="dl-entry-artist">{entry.artist}</span>}
+                  </span>
+                  {inLibrary && <span className="dl-entry-library-badge">✓ In library</span>}
+                  {!inLibrary && entry.duration > 0 && (
+                    <span className="dl-entry-dur">{fmtDuration(entry.duration)}</span>
+                  )}
+                </label>
+              );
+            })}
           </div>
         </div>
 
@@ -525,10 +609,14 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
           <button
             type="button"
             className="dl-btn"
-            disabled={selectedIndices.size === 0}
+            disabled={selectedIndices.size === 0 && linkIndices.size === 0}
             onClick={handleDownload}
           >
-            Download {selectedIndices.size} track{selectedIndices.size !== 1 ? 's' : ''} →
+            {selectedIndices.size > 0 && linkIndices.size > 0
+              ? `Download ${selectedIndices.size} + link ${linkIndices.size} →`
+              : selectedIndices.size > 0
+                ? `Download ${selectedIndices.size} track${selectedIndices.size !== 1 ? 's' : ''} →`
+                : `Link ${linkIndices.size} track${linkIndices.size !== 1 ? 's' : ''} to playlist →`}
           </button>
         </div>
       </div>

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -152,7 +152,6 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
       } catch {
         // non-fatal
       }
-      setLibraryMap(newLibraryMap);
 
       const pls = await window.api.getPlaylists().catch(() => []);
       setPlaylists(pls);
@@ -173,6 +172,7 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
         const linkIdx = new Set(
           (res.entries ?? []).filter((e) => newLibraryMap.has(e.url)).map((e) => e.index)
         );
+        setLibraryMap(newLibraryMap);
         setSelectedIndices(allIndices);
         setLinkIndices(linkIdx);
         setStep('download');
@@ -189,20 +189,37 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
 
       // Pre-select non-library entries; pre-link library entries not already in matched playlist
       let newMemberUrls = new Set();
-      if (match && newLibraryMap.size > 0) {
+      if (match) {
         try {
           const memberRows = await window.api.getPlaylistSourceUrls(match.id);
           const memberTrackIds = new Set(memberRows.map((r) => r.trackId));
-          newMemberUrls = new Set(
-            [...newLibraryMap.entries()]
-              .filter(([, tid]) => memberTrackIds.has(tid))
-              .map(([u]) => u)
-          );
+          for (const entry of res.entries ?? []) {
+            const entryId = String(entry.id ?? '');
+            // Primary: trackId via libraryMap
+            const libTid = newLibraryMap.get(entry.url);
+            if (libTid && memberTrackIds.has(libTid)) {
+              newMemberUrls.add(entry.url);
+              continue;
+            }
+            // Fallback: direct pattern match (handles old source_url format)
+            if (entryId) {
+              const hit = memberRows.find(
+                (r) =>
+                  (r.source_url && r.source_url.includes(entryId)) ||
+                  (r.source_link && r.source_link.includes(entryId))
+              );
+              if (hit) {
+                newMemberUrls.add(entry.url);
+                if (!newLibraryMap.has(entry.url)) newLibraryMap.set(entry.url, hit.trackId);
+              }
+            }
+          }
         } catch {
           // non-fatal
         }
       }
       setPlaylistMemberUrls(newMemberUrls);
+      setLibraryMap(newLibraryMap);
 
       setSelectedIndices(
         new Set(res.entries.filter((e) => !newLibraryMap.has(e.url)).map((e) => e.index))
@@ -227,9 +244,8 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
   const handleTargetPlaylistChange = useCallback(
     async (newPlaylistId) => {
       setTargetPlaylistId(newPlaylistId);
-      if (!newPlaylistId || libraryMap.size === 0) {
+      if (!newPlaylistId || !playlistInfo) {
         setPlaylistMemberUrls(new Set());
-        // Restore all library entries to linkIndices
         if (playlistInfo) {
           setLinkIndices(
             new Set(playlistInfo.entries.filter((e) => libraryMap.has(e.url)).map((e) => e.index))
@@ -240,24 +256,53 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
       try {
         const memberRows = await window.api.getPlaylistSourceUrls(newPlaylistId);
         const memberTrackIds = new Set(memberRows.map((r) => r.trackId));
-        const inPlaylist = new Set(
-          [...libraryMap.entries()].filter(([, tid]) => memberTrackIds.has(tid)).map(([u]) => u)
-        );
-        setPlaylistMemberUrls(inPlaylist);
-        if (playlistInfo) {
-          setLinkIndices(
-            new Set(
-              playlistInfo.entries
-                .filter((e) => libraryMap.has(e.url) && !inPlaylist.has(e.url))
-                .map((e) => e.index)
-            )
-          );
+
+        const inPlaylist = new Set();
+        const updatedLibraryMap = new Map(libraryMap);
+
+        for (const entry of playlistInfo.entries) {
+          const entryId = String(entry.id ?? '');
+          // Primary: trackId match via libraryMap
+          const libTid = libraryMap.get(entry.url);
+          if (libTid && memberTrackIds.has(libTid)) {
+            inPlaylist.add(entry.url);
+            continue;
+          }
+          // Fallback: direct pattern match for tracks imported with old source_url format
+          if (entryId) {
+            const hit = memberRows.find(
+              (r) =>
+                (r.source_url && r.source_url.includes(entryId)) ||
+                (r.source_link && r.source_link.includes(entryId))
+            );
+            if (hit) {
+              inPlaylist.add(entry.url);
+              if (!updatedLibraryMap.has(entry.url)) updatedLibraryMap.set(entry.url, hit.trackId);
+            }
+          }
         }
+
+        if (updatedLibraryMap.size !== libraryMap.size) setLibraryMap(updatedLibraryMap);
+        setPlaylistMemberUrls(inPlaylist);
+        setLinkIndices(
+          new Set(
+            playlistInfo.entries
+              .filter((e) => updatedLibraryMap.has(e.url) && !inPlaylist.has(e.url))
+              .map((e) => e.index)
+          )
+        );
       } catch {
         setPlaylistMemberUrls(new Set());
       }
     },
-    [libraryMap, playlistInfo, setTargetPlaylistId, setPlaylistMemberUrls, setLinkIndices]
+    [
+      libraryMap,
+      playlistInfo,
+      setTargetPlaylistId,
+      setPlaylistMemberUrls,
+      setLinkIndices,
+      setLibraryMap,
+    ]
   );
 
   // ── step select → download ─────────────────────────────────────────────────

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -45,6 +45,8 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
     setLinkIndices,
     libraryMap,
     setLibraryMap,
+    playlistMemberUrls,
+    setPlaylistMemberUrls,
     playlists,
     setPlaylists,
     targetPlaylistId,
@@ -185,12 +187,33 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
         return;
       }
 
-      // Pre-select non-library entries; pre-link library entries
+      // Pre-select non-library entries; pre-link library entries not already in matched playlist
+      let newMemberUrls = new Set();
+      if (match && newLibraryMap.size > 0) {
+        try {
+          const memberRows = await window.api.getPlaylistSourceUrls(match.id);
+          const memberTrackIds = new Set(memberRows.map((r) => r.trackId));
+          newMemberUrls = new Set(
+            [...newLibraryMap.entries()]
+              .filter(([, tid]) => memberTrackIds.has(tid))
+              .map(([u]) => u)
+          );
+        } catch {
+          // non-fatal
+        }
+      }
+      setPlaylistMemberUrls(newMemberUrls);
+
       setSelectedIndices(
         new Set(res.entries.filter((e) => !newLibraryMap.has(e.url)).map((e) => e.index))
       );
+      // linkIndices = in library but NOT already in the matched playlist
       setLinkIndices(
-        new Set(res.entries.filter((e) => newLibraryMap.has(e.url)).map((e) => e.index))
+        new Set(
+          res.entries
+            .filter((e) => newLibraryMap.has(e.url) && !newMemberUrls.has(e.url))
+            .map((e) => e.index)
+        )
       );
       setStep('select');
     } catch (err) {
@@ -199,6 +222,43 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
       setFetching(false);
     }
   };
+
+  // ── target playlist change: re-check membership ────────────────────────────
+  const handleTargetPlaylistChange = useCallback(
+    async (newPlaylistId) => {
+      setTargetPlaylistId(newPlaylistId);
+      if (!newPlaylistId || libraryMap.size === 0) {
+        setPlaylistMemberUrls(new Set());
+        // Restore all library entries to linkIndices
+        if (playlistInfo) {
+          setLinkIndices(
+            new Set(playlistInfo.entries.filter((e) => libraryMap.has(e.url)).map((e) => e.index))
+          );
+        }
+        return;
+      }
+      try {
+        const memberRows = await window.api.getPlaylistSourceUrls(newPlaylistId);
+        const memberTrackIds = new Set(memberRows.map((r) => r.trackId));
+        const inPlaylist = new Set(
+          [...libraryMap.entries()].filter(([, tid]) => memberTrackIds.has(tid)).map(([u]) => u)
+        );
+        setPlaylistMemberUrls(inPlaylist);
+        if (playlistInfo) {
+          setLinkIndices(
+            new Set(
+              playlistInfo.entries
+                .filter((e) => libraryMap.has(e.url) && !inPlaylist.has(e.url))
+                .map((e) => e.index)
+            )
+          );
+        }
+      } catch {
+        setPlaylistMemberUrls(new Set());
+      }
+    },
+    [libraryMap, playlistInfo, setTargetPlaylistId, setPlaylistMemberUrls, setLinkIndices]
+  );
 
   // ── step select → download ─────────────────────────────────────────────────
   const handleDownload = async () => {
@@ -275,7 +335,9 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
   const handleToggleAll = useCallback(() => {
     if (!playlistInfo) return;
     const downloadable = playlistInfo.entries.filter((e) => !libraryMap.has(e.url));
-    const linkable = playlistInfo.entries.filter((e) => libraryMap.has(e.url));
+    const linkable = playlistInfo.entries.filter(
+      (e) => libraryMap.has(e.url) && !playlistMemberUrls.has(e.url)
+    );
     const allDownSelected = downloadable.every((e) => selectedIndices.has(e.index));
     const allLinkSelected = linkable.every((e) => linkIndices.has(e.index));
     if (allDownSelected && allLinkSelected) {
@@ -285,7 +347,15 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
       setSelectedIndices(new Set(downloadable.map((e) => e.index)));
       setLinkIndices(new Set(linkable.map((e) => e.index)));
     }
-  }, [playlistInfo, libraryMap, selectedIndices, linkIndices, setSelectedIndices, setLinkIndices]);
+  }, [
+    playlistInfo,
+    libraryMap,
+    playlistMemberUrls,
+    selectedIndices,
+    linkIndices,
+    setSelectedIndices,
+    setLinkIndices,
+  ]);
 
   // ── render: checking setup ────────────────────────────────────────────────
   if (setup === null) {
@@ -519,10 +589,14 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
   if (step === 'select') {
     const entries = playlistInfo?.entries ?? [];
     const downloadable = entries.filter((e) => !libraryMap.has(e.url));
-    const linkable = entries.filter((e) => libraryMap.has(e.url));
+    const linkable = entries.filter((e) => libraryMap.has(e.url) && !playlistMemberUrls.has(e.url));
     const allDownSelected = downloadable.every((e) => selectedIndices.has(e.index));
     const allLinkSelected = linkable.every((e) => linkIndices.has(e.index));
-    const allSelected = entries.length > 0 && allDownSelected && allLinkSelected;
+    const allSelected =
+      entries.length > 0 &&
+      allDownSelected &&
+      allLinkSelected &&
+      downloadable.length + linkable.length > 0;
     const totalActive = selectedIndices.size + linkIndices.size;
 
     return (
@@ -531,7 +605,8 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
           <h2 className="dl-title">{playlistInfo?.title ?? 'Select tracks'}</h2>
           <p className="dl-subtitle">
             {entries.length} track{entries.length !== 1 ? 's' : ''}
-            {libraryMap.size > 0 ? ` · ${libraryMap.size} already in library` : ''}
+            {libraryMap.size > 0 ? ` · ${libraryMap.size} in library` : ''}
+            {playlistMemberUrls.size > 0 ? ` · ${playlistMemberUrls.size} in playlist` : ''}
             {' · '}select which to download
           </p>
         </div>
@@ -549,6 +624,7 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
           <div className="dl-entries">
             {entries.map((entry) => {
               const inLibrary = libraryMap.has(entry.url);
+              const inPlaylist = playlistMemberUrls.has(entry.url);
               const checked = inLibrary
                 ? linkIndices.has(entry.index)
                 : selectedIndices.has(entry.index);
@@ -560,16 +636,24 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
                   <input
                     type="checkbox"
                     checked={checked}
-                    onChange={() => handleToggleEntry(entry.index, entry)}
+                    disabled={inPlaylist}
+                    onChange={() => !inPlaylist && handleToggleEntry(entry.index, entry)}
                   />
                   <span className="dl-entry-num">{entry.index + 1}</span>
                   <span className="dl-entry-info">
                     <span className="dl-entry-title">{entry.title}</span>
                     {entry.artist && <span className="dl-entry-artist">{entry.artist}</span>}
                   </span>
-                  {inLibrary && <span className="dl-entry-library-badge">✓ In library</span>}
-                  {!inLibrary && entry.duration > 0 && (
-                    <span className="dl-entry-dur">{fmtDuration(entry.duration)}</span>
+                  {inPlaylist ? (
+                    <span className="dl-entry-library-badge dl-entry-playlist-badge">
+                      ✓ In playlist
+                    </span>
+                  ) : inLibrary ? (
+                    <span className="dl-entry-library-badge">✓ In library</span>
+                  ) : (
+                    entry.duration > 0 && (
+                      <span className="dl-entry-dur">{fmtDuration(entry.duration)}</span>
+                    )
                   )}
                 </label>
               );
@@ -582,7 +666,7 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
           <select
             className="dl-playlist-select"
             value={targetPlaylistId ?? ''}
-            onChange={(e) => setTargetPlaylistId(e.target.value || null)}
+            onChange={(e) => handleTargetPlaylistChange(e.target.value || null)}
           >
             <option value="">None / new playlist</option>
             {playlists.map((pl) => (

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -1,0 +1,423 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import './DownloadView.css';
+import './TidalDownloadView.css';
+
+// Supported TIDAL URL types
+const TIDAL_URL_TYPES = [
+  { label: 'Track', example: 'tidal.com/browse/track/…' },
+  { label: 'Album', example: 'tidal.com/browse/album/…' },
+  { label: 'Playlist', example: 'tidal.com/browse/playlist/…' },
+  { label: 'Mix', example: 'tidal.com/browse/mix/…' },
+];
+
+export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style }) {
+  // ── setup state ───────────────────────────────────────────────────────────
+  const [setup, setSetup] = useState(null); // null = checking | { installed, loggedIn }
+
+  // ── login state ───────────────────────────────────────────────────────────
+  const [loginState, setLoginState] = useState('idle'); // 'idle' | 'waiting' | 'done' | 'error'
+  const [loginUrl, setLoginUrl] = useState(null);
+  const [loginError, setLoginError] = useState(null);
+
+  // ── download state ────────────────────────────────────────────────────────
+  const [url, setUrl] = useState('');
+  const [newPlaylistName, setNewPlaylistName] = useState('');
+  const [playlists, setPlaylists] = useState([]);
+  const [targetPlaylistId, setTargetPlaylistId] = useState(null);
+  const [downloading, setDownloading] = useState(false);
+  const [progressMsg, setProgressMsg] = useState('');
+  const [result, setResult] = useState(null);
+  const [history, setHistory] = useState([]);
+
+  const inputRef = useRef(null);
+
+  // ── initial setup check ───────────────────────────────────────────────────
+  const checkSetup = useCallback(async () => {
+    setSetup(null);
+    const info = await window.api.tidalCheck();
+    setSetup(info);
+  }, []);
+
+  useEffect(() => {
+    checkSetup();
+
+    const unsubProgress = window.api.onTidalProgress((data) => {
+      if (data === null) {
+        setDownloading(false);
+        setProgressMsg('');
+      } else {
+        setProgressMsg(data.msg || '');
+      }
+    });
+
+    const unsubLoginUrl = window.api.onTidalLoginUrl((url) => {
+      setLoginUrl(url);
+      // Auto-open in browser
+      window.api.openExternal(url);
+    });
+
+    return () => {
+      unsubProgress();
+      unsubLoginUrl();
+    };
+  }, [checkSetup]);
+
+  // Load playlists when we know the user is logged in
+  useEffect(() => {
+    if (setup?.loggedIn) {
+      window.api
+        .getPlaylists()
+        .then(setPlaylists)
+        .catch(() => setPlaylists([]));
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [setup?.loggedIn]);
+
+  // ── login flow ────────────────────────────────────────────────────────────
+  const handleLogin = async () => {
+    setLoginState('waiting');
+    setLoginUrl(null);
+    setLoginError(null);
+
+    const res = await window.api.tidalLogin();
+    if (res.ok) {
+      setLoginState('done');
+      await checkSetup();
+    } else {
+      setLoginState('error');
+      setLoginError(res.error);
+    }
+  };
+
+  const openLoginUrl = (e) => {
+    e.preventDefault();
+    if (loginUrl) window.api.openExternal(loginUrl);
+  };
+
+  // ── download flow ─────────────────────────────────────────────────────────
+  const handleDownload = async (e) => {
+    e.preventDefault();
+    const trimmed = url.trim();
+    if (!trimmed || downloading) return;
+
+    setDownloading(true);
+    setResult(null);
+    setProgressMsg('Starting…');
+
+    const res = await window.api.tidalDownloadUrl({
+      url: trimmed,
+      existingPlaylistId: targetPlaylistId || null,
+      newPlaylistName: !targetPlaylistId && newPlaylistName.trim() ? newPlaylistName.trim() : null,
+    });
+
+    setDownloading(false);
+    setResult(res);
+
+    if (res.ok) {
+      setHistory((prev) => [
+        { url: trimmed, at: Date.now(), count: res.trackIds.length },
+        ...prev.slice(0, 19),
+      ]);
+      // Refresh playlist list
+      window.api
+        .getPlaylists()
+        .then(setPlaylists)
+        .catch(() => {});
+    }
+  };
+
+  const handleReset = () => {
+    setUrl('');
+    setResult(null);
+    setProgressMsg('');
+    setNewPlaylistName('');
+    setTargetPlaylistId(null);
+    setTimeout(() => inputRef.current?.focus(), 50);
+  };
+
+  const formatTime = (ts) =>
+    new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+  // ── render: checking ──────────────────────────────────────────────────────
+  if (setup === null) {
+    return (
+      <div className="dl-view" style={style}>
+        <div className="dl-header">
+          <h2 className="dl-title">TIDAL Download</h2>
+          <p className="dl-subtitle tidal-checking">Checking setup…</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── render: not installed ─────────────────────────────────────────────────
+  if (!setup.installed) {
+    return (
+      <div className="dl-view" style={style}>
+        <div className="dl-header">
+          <h2 className="dl-title">TIDAL Download</h2>
+          <p className="dl-subtitle">
+            tidal-dl-ng is not installed. Install it to enable TIDAL downloads.
+          </p>
+        </div>
+        <div className="tidal-install-box">
+          <div className="tidal-install-title">Install tidal-dl-ng</div>
+          <code className="tidal-install-cmd">pip install tidal-dl-ng</code>
+          <p className="tidal-install-note">
+            Requires Python 3.12+. After installing, restart DjManager.
+          </p>
+          <button className="dl-btn" onClick={checkSetup}>
+            Check again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── render: login required ────────────────────────────────────────────────
+  if (!setup.loggedIn) {
+    return (
+      <div className="dl-view" style={style}>
+        <div className="dl-header">
+          <h2 className="dl-title">TIDAL Download</h2>
+          <p className="dl-subtitle">Connect your TIDAL account to start downloading.</p>
+        </div>
+
+        <div className="tidal-login-box">
+          {loginState === 'idle' && (
+            <>
+              <p className="tidal-login-desc">
+                Click below to start the TIDAL login flow. A browser page will open — approve the
+                request there, then return here.
+              </p>
+              <button className="dl-btn tidal-login-btn" onClick={handleLogin}>
+                Connect TIDAL account
+              </button>
+            </>
+          )}
+
+          {loginState === 'waiting' && (
+            <>
+              <div className="tidal-login-waiting">
+                <span className="tidal-spinner">⋯</span>
+                Waiting for TIDAL authentication…
+              </div>
+              {loginUrl ? (
+                <div className="tidal-login-url-box">
+                  <p className="tidal-login-url-label">
+                    A browser tab was opened. If it didn&apos;t open, click the link below:
+                  </p>
+                  <a href={loginUrl} className="tidal-login-url-link" onClick={openLoginUrl}>
+                    {loginUrl}
+                  </a>
+                </div>
+              ) : (
+                <p className="tidal-login-url-label">Opening browser…</p>
+              )}
+            </>
+          )}
+
+          {loginState === 'done' && (
+            <div className="dl-result dl-result--ok">✓ Logged in successfully</div>
+          )}
+
+          {loginState === 'error' && (
+            <div className="dl-result dl-result--err">
+              <span>✗ Login failed: {loginError}</span>
+              <button
+                type="button"
+                className="dl-back-btn"
+                onClick={() => setLoginState('idle')}
+                style={{ marginTop: 8, alignSelf: 'flex-start' }}
+              >
+                Try again
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── render: download UI ───────────────────────────────────────────────────
+  return (
+    <div className="dl-view" style={style}>
+      <div className="dl-header">
+        <h2 className="dl-title">TIDAL Download</h2>
+        <p className="dl-subtitle">
+          Paste a TIDAL URL to download and import tracks into your library.
+        </p>
+      </div>
+
+      <form className="dl-form" onSubmit={handleDownload}>
+        <div className="dl-input-row">
+          <input
+            ref={inputRef}
+            className="dl-input"
+            type="url"
+            placeholder="https://tidal.com/browse/album/…"
+            value={url}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              setResult(null);
+            }}
+            onPaste={(e) => {
+              const text = e.clipboardData?.getData('text')?.trim();
+              if (text) {
+                e.preventDefault();
+                setUrl(text);
+                setResult(null);
+              }
+            }}
+            disabled={downloading}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <button className="dl-btn" type="submit" disabled={downloading || !url.trim()}>
+            {downloading ? (
+              <span className="dl-fetch-spinner">
+                <svg className="dl-spinner-svg" viewBox="0 0 16 16" fill="none">
+                  <circle cx="8" cy="8" r="6" stroke="rgba(255,255,255,0.3)" strokeWidth="2" />
+                  <path
+                    d="M8 2a6 6 0 0 1 6 6"
+                    stroke="#fff"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+                Downloading…
+              </span>
+            ) : (
+              'Download →'
+            )}
+          </button>
+        </div>
+
+        {/* Playlist target */}
+        <div className="dl-playlist-target">
+          <label className="dl-playlist-target-label">Save to playlist</label>
+          <select
+            className="dl-playlist-select"
+            value={targetPlaylistId ?? ''}
+            onChange={(e) => setTargetPlaylistId(e.target.value || null)}
+            disabled={downloading}
+          >
+            <option value="">None / new playlist</option>
+            {playlists.map((pl) => (
+              <option key={pl.id} value={pl.id}>
+                {pl.name}
+              </option>
+            ))}
+          </select>
+          {!targetPlaylistId && (
+            <input
+              className="dl-playlist-name-input"
+              type="text"
+              placeholder="New playlist name (optional)"
+              value={newPlaylistName}
+              onChange={(e) => setNewPlaylistName(e.target.value)}
+              disabled={downloading}
+            />
+          )}
+        </div>
+      </form>
+
+      {/* Progress */}
+      {downloading && progressMsg && (
+        <div className="dl-form" style={{ marginTop: 16 }}>
+          <div className="dl-progress">
+            <div className="dl-progress-bar">
+              <div className="tidal-progress-indeterminate" />
+            </div>
+            <span className="dl-progress-msg">{progressMsg}</span>
+          </div>
+        </div>
+      )}
+
+      {/* Result */}
+      {result?.ok && (
+        <div className="dl-result dl-result--ok" style={{ marginTop: 16, maxWidth: 640 }}>
+          <span>
+            {result.trackIds.length === 1
+              ? '✓ Track added to your library'
+              : `✓ ${result.trackIds.length} tracks added to your library`}
+          </span>
+          <div className="dl-result-actions">
+            {result.playlistId ? (
+              <button
+                type="button"
+                className="dl-goto-btn"
+                onClick={() => onGoToPlaylist(result.playlistId)}
+              >
+                Go to Playlist →
+              </button>
+            ) : (
+              <button type="button" className="dl-goto-btn" onClick={onGoToLibrary}>
+                View in Music →
+              </button>
+            )}
+            <button type="button" className="dl-goto-btn" onClick={handleReset}>
+              ← New download
+            </button>
+          </div>
+        </div>
+      )}
+      {result?.error && (
+        <div className="dl-result dl-result--err" style={{ marginTop: 16, maxWidth: 640 }}>
+          <span>✗ {result.error}</span>
+          <button
+            type="button"
+            className="dl-back-btn"
+            onClick={handleReset}
+            style={{ marginTop: 8, alignSelf: 'flex-start' }}
+          >
+            ← Try again
+          </button>
+        </div>
+      )}
+
+      {/* URL types */}
+      <div className="dl-sources" style={{ marginTop: result ? 32 : 32 }}>
+        <div className="dl-sources-title">Supported URL types</div>
+        <div className="dl-sources-grid">
+          {TIDAL_URL_TYPES.map((t) => (
+            <div key={t.label} className="dl-source-chip">
+              <span className="dl-source-icon">♫</span>
+              <span>{t.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Session history */}
+      {history.length > 0 && (
+        <div className="dl-history">
+          <div className="dl-history-title">Session downloads</div>
+          {history.map((item, i) => (
+            <div key={i} className="dl-history-item">
+              <span className="dl-history-icon">♫</span>
+              <span className="dl-history-url">{item.url}</span>
+              <span className="dl-history-time">
+                {item.count} track{item.count !== 1 ? 's' : ''} · {formatTime(item.at)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Re-auth footer */}
+      <div className="tidal-reauth">
+        <button
+          type="button"
+          className="tidal-reauth-btn"
+          onClick={() => {
+            setSetup({ ...setup, loggedIn: false });
+            setLoginState('idle');
+          }}
+        >
+          Switch TIDAL account
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -184,9 +184,9 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
         <div className="tidal-install-box">
           {!installing && !installError && (
             <>
-              <div className="tidal-install-title">Python not found</div>
+              <div className="tidal-install-title">Installation failed</div>
               <p className="tidal-install-note">
-                tidal-dl-ng requires Python 3.12+. Install it, then click Retry. You can also check
+                tidal-dl-ng could not be installed automatically. Click Retry to try again, or check
                 Settings → Dependencies.
               </p>
               <button className="dl-btn" onClick={handleRetry}>

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useTidalDownload } from './TidalDownloadContext.jsx';
 import './DownloadView.css';
 import './TidalDownloadView.css';
 
-// Supported TIDAL URL types
+// Supported TIDAL URL types for the helper footer
 const TIDAL_URL_TYPES = [
   { label: 'Track', example: 'tidal.com/browse/track/…' },
   { label: 'Album', example: 'tidal.com/browse/album/…' },
@@ -10,69 +11,83 @@ const TIDAL_URL_TYPES = [
   { label: 'Mix', example: 'tidal.com/browse/mix/…' },
 ];
 
-export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style }) {
-  // ── setup state ───────────────────────────────────────────────────────────
-  const [setup, setSetup] = useState(null); // null = checking | { installed, loggedIn }
+const STATUS_ICON = {
+  pending: { icon: '□', label: 'Pending' },
+  downloading: { icon: '⋯', label: 'Downloading' },
+  importing: { icon: '↓', label: 'Importing' },
+  done: { icon: '✓', label: 'Done' },
+  failed: { icon: '✗', label: 'Failed' },
+};
 
-  // ── login state ───────────────────────────────────────────────────────────
-  const [loginState, setLoginState] = useState('idle'); // 'idle' | 'waiting' | 'done' | 'error'
+function fmtDuration(secs) {
+  if (!secs) return '';
+  const m = Math.floor(secs / 60);
+  const s = Math.floor(secs % 60);
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style }) {
+  // ── context state (persists across tab switches) ──────────────────────────
+  const {
+    url,
+    setUrl,
+    step,
+    setStep,
+    fetching,
+    setFetching,
+    fetchError,
+    setFetchError,
+    playlistInfo,
+    setPlaylistInfo,
+    selectedIndices,
+    setSelectedIndices,
+    playlists,
+    setPlaylists,
+    targetPlaylistId,
+    setTargetPlaylistId,
+    targetPlaylistName,
+    setTargetPlaylistName,
+    loading,
+    setLoading,
+    trackStatuses,
+    result,
+    setResult,
+    resetToUrl,
+  } = useTidalDownload();
+
+  // ── local state (UI gates — do not need to persist) ───────────────────────
+  const [setup, setSetup] = useState(null); // null = checking | { installed, loggedIn }
+  const [loginState, setLoginState] = useState('idle'); // 'idle'|'waiting'|'done'|'error'
   const [loginUrl, setLoginUrl] = useState(null);
   const [loginError, setLoginError] = useState(null);
-
-  // ── download state ────────────────────────────────────────────────────────
-  const [url, setUrl] = useState('');
-  const [newPlaylistName, setNewPlaylistName] = useState('');
-  const [playlists, setPlaylists] = useState([]);
-  const [targetPlaylistId, setTargetPlaylistId] = useState(null);
-  const [downloading, setDownloading] = useState(false);
-  const [progressMsg, setProgressMsg] = useState('');
-  const [result, setResult] = useState(null);
-  const [history, setHistory] = useState([]);
-
-  const inputRef = useRef(null);
-
-  // ── install state ─────────────────────────────────────────────────────────
   const [installing, setInstalling] = useState(false);
   const [installLog, setInstallLog] = useState([]);
   const [installError, setInstallError] = useState(null);
 
-  // ── initial setup check ───────────────────────────────────────────────────
-  const checkSetup = useCallback(async () => {
+  const inputRef = useRef(null);
+
+  const checkSetup = useCallback(() => {
     setSetup(null);
-    const info = await window.api.tidalCheck();
-    setSetup(info);
+    window.api.tidalCheck().then(setSetup);
   }, []);
 
+  // Subscribe to login/install IPC events on mount
   useEffect(() => {
     checkSetup();
-
-    const unsubProgress = window.api.onTidalProgress((data) => {
-      if (data === null) {
-        setDownloading(false);
-        setProgressMsg('');
-      } else {
-        setProgressMsg(data.msg || '');
-      }
+    const unsubLoginUrl = window.api.onTidalLoginUrl((u) => {
+      setLoginUrl(u);
+      window.api.openExternal(u);
     });
-
-    const unsubLoginUrl = window.api.onTidalLoginUrl((url) => {
-      setLoginUrl(url);
-      // Auto-open in browser
-      window.api.openExternal(url);
-    });
-
     const unsubInstall = window.api.onTidalInstallProgress((data) => {
       setInstallLog((prev) => [...prev.slice(-199), data.msg]);
     });
-
     return () => {
-      unsubProgress();
       unsubLoginUrl();
       unsubInstall();
     };
   }, [checkSetup]);
 
-  // Load playlists when we know the user is logged in
+  // Load playlists once logged in
   useEffect(() => {
     if (setup?.loggedIn) {
       window.api
@@ -81,74 +96,131 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
         .catch(() => setPlaylists([]));
       setTimeout(() => inputRef.current?.focus(), 50);
     }
-  }, [setup?.loggedIn]);
+  }, [setup?.loggedIn, setPlaylists]);
 
-  // ── login flow ────────────────────────────────────────────────────────────
+  // ── login flow ─────────────────────────────────────────────────────────────
   const handleLogin = async () => {
     setLoginState('waiting');
     setLoginUrl(null);
     setLoginError(null);
-
     const res = await window.api.tidalLogin();
     if (res.ok) {
       setLoginState('done');
-      await checkSetup();
+      checkSetup();
     } else {
       setLoginState('error');
       setLoginError(res.error);
     }
   };
 
-  const openLoginUrl = (e) => {
-    e.preventDefault();
-    if (loginUrl) window.api.openExternal(loginUrl);
-  };
-
-  // ── download flow ─────────────────────────────────────────────────────────
-  const handleDownload = async (e) => {
+  // ── step url → select: fetch track info ───────────────────────────────────
+  const handleLoad = async (e) => {
     e.preventDefault();
     const trimmed = url.trim();
-    if (!trimmed || downloading) return;
+    if (!trimmed || fetching) return;
 
-    setDownloading(true);
+    setFetching(true);
+    setFetchError(null);
+
+    try {
+      const res = await window.api.tidalFetchInfo(trimmed);
+      if (!res.ok) {
+        setFetchError(res.error);
+        return;
+      }
+
+      setPlaylistInfo(res);
+
+      const pls = await window.api.getPlaylists().catch(() => []);
+      setPlaylists(pls);
+      const match = pls.find((p) => p.name.toLowerCase() === (res.title ?? '').toLowerCase());
+      if (match) {
+        setTargetPlaylistId(match.id);
+        setTargetPlaylistName('');
+      } else {
+        setTargetPlaylistId(null);
+        setTargetPlaylistName(res.title ?? '');
+      }
+
+      // Single tracks and mixes skip the select step — go straight to download
+      if (res.type === 'track' || res.type === 'mix' || (res.entries?.length ?? 0) === 0) {
+        const allIndices = new Set((res.entries ?? []).map((e) => e.index));
+        setSelectedIndices(allIndices);
+        setStep('download');
+        await runDownload(res, allIndices, pls, match?.id ?? null, res.title ?? '');
+        return;
+      }
+
+      // Pre-select all available entries then go to the select step
+      setSelectedIndices(new Set(res.entries.map((e) => e.index)));
+      setStep('select');
+    } catch (err) {
+      setFetchError(err.message);
+    } finally {
+      setFetching(false);
+    }
+  };
+
+  // ── step select → download ─────────────────────────────────────────────────
+  const handleDownload = async () => {
+    if (selectedIndices.size === 0 || !playlistInfo) return;
+    setStep('download');
+    await runDownload(
+      playlistInfo,
+      selectedIndices,
+      playlists,
+      targetPlaylistId,
+      targetPlaylistName
+    );
+  };
+
+  async function runDownload(info, indices, _pls, playlistId, playlistName) {
+    const selectedEntries = (info.entries ?? [])
+      .filter((e) => indices.has(e.index))
+      .sort((a, b) => a.index - b.index);
+
+    setLoading(true);
     setResult(null);
-    setProgressMsg('Starting…');
 
     const res = await window.api.tidalDownloadUrl({
-      url: trimmed,
-      existingPlaylistId: targetPlaylistId || null,
-      newPlaylistName: !targetPlaylistId && newPlaylistName.trim() ? newPlaylistName.trim() : null,
+      url,
+      selectedEntries,
+      existingPlaylistId: playlistId || null,
+      newPlaylistName: !playlistId && playlistName?.trim() ? playlistName.trim() : null,
     });
 
-    setDownloading(false);
+    setLoading(false);
     setResult(res);
 
     if (res.ok) {
-      setHistory((prev) => [
-        { url: trimmed, at: Date.now(), count: res.trackIds.length },
-        ...prev.slice(0, 19),
-      ]);
-      // Refresh playlist list
-      window.api
+      await window.api
         .getPlaylists()
         .then(setPlaylists)
         .catch(() => {});
     }
-  };
+  }
 
-  const handleReset = () => {
-    setUrl('');
-    setResult(null);
-    setProgressMsg('');
-    setNewPlaylistName('');
-    setTargetPlaylistId(null);
-    setTimeout(() => inputRef.current?.focus(), 50);
-  };
+  // ── toggle selection ────────────────────────────────────────────────────────
+  const handleToggleEntry = useCallback(
+    (index) => {
+      setSelectedIndices((prev) => {
+        const next = new Set(prev);
+        if (next.has(index)) next.delete(index);
+        else next.add(index);
+        return next;
+      });
+    },
+    [setSelectedIndices]
+  );
 
-  const formatTime = (ts) =>
-    new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const handleToggleAll = useCallback(() => {
+    if (!playlistInfo) return;
+    const all = playlistInfo.entries.map((e) => e.index);
+    const allSelected = all.every((i) => selectedIndices.has(i));
+    setSelectedIndices(allSelected ? new Set() : new Set(all));
+  }, [playlistInfo, selectedIndices, setSelectedIndices]);
 
-  // ── render: checking ──────────────────────────────────────────────────────
+  // ── render: checking setup ────────────────────────────────────────────────
   if (setup === null) {
     return (
       <div className="dl-view" style={style}>
@@ -168,13 +240,9 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
       setInstallError(null);
       const res = await window.api.tidalInstall();
       setInstalling(false);
-      if (res.ok) {
-        await checkSetup();
-      } else {
-        setInstallError(res.error);
-      }
+      if (res.ok) checkSetup();
+      else setInstallError(res.error);
     };
-
     return (
       <div className="dl-view" style={style}>
         <div className="dl-header">
@@ -204,7 +272,7 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
                   </div>
                 ))}
                 {installLog.length === 0 && (
-                  <div className="tidal-install-log-line">Starting pip…</div>
+                  <div className="tidal-install-log-line">Starting installer…</div>
                 )}
               </div>
             </>
@@ -233,7 +301,6 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
           <h2 className="dl-title">TIDAL Download</h2>
           <p className="dl-subtitle">Connect your TIDAL account to start downloading.</p>
         </div>
-
         <div className="tidal-login-box">
           {loginState === 'idle' && (
             <>
@@ -246,7 +313,6 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
               </button>
             </>
           )}
-
           {loginState === 'waiting' && (
             <>
               <div className="tidal-login-waiting">
@@ -258,7 +324,14 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
                   <p className="tidal-login-url-label">
                     A browser tab was opened. If it didn&apos;t open, click the link below:
                   </p>
-                  <a href={loginUrl} className="tidal-login-url-link" onClick={openLoginUrl}>
+                  <a
+                    href={loginUrl}
+                    className="tidal-login-url-link"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      window.api.openExternal(loginUrl);
+                    }}
+                  >
                     {loginUrl}
                   </a>
                 </div>
@@ -267,11 +340,9 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
               )}
             </>
           )}
-
           {loginState === 'done' && (
             <div className="dl-result dl-result--ok">✓ Logged in successfully</div>
           )}
-
           {loginState === 'error' && (
             <div className="dl-result dl-result--err">
               <span>✗ Login failed: {loginError}</span>
@@ -290,68 +361,144 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
     );
   }
 
-  // ── render: download UI ───────────────────────────────────────────────────
-  return (
-    <div className="dl-view" style={style}>
-      <div className="dl-header">
-        <h2 className="dl-title">TIDAL Download</h2>
-        <p className="dl-subtitle">
-          Paste a TIDAL URL to download and import tracks into your library.
-        </p>
-      </div>
-
-      <form className="dl-form" onSubmit={handleDownload}>
-        <div className="dl-input-row">
-          <input
-            ref={inputRef}
-            className="dl-input"
-            type="url"
-            placeholder="https://tidal.com/browse/album/…"
-            value={url}
-            onChange={(e) => {
-              setUrl(e.target.value);
-              setResult(null);
-            }}
-            onPaste={(e) => {
-              const text = e.clipboardData?.getData('text')?.trim();
-              if (text) {
-                e.preventDefault();
-                setUrl(text);
-                setResult(null);
-              }
-            }}
-            disabled={downloading}
-            autoComplete="off"
-            spellCheck={false}
-          />
-          <button className="dl-btn" type="submit" disabled={downloading || !url.trim()}>
-            {downloading ? (
-              <span className="dl-fetch-spinner">
-                <svg className="dl-spinner-svg" viewBox="0 0 16 16" fill="none">
-                  <circle cx="8" cy="8" r="6" stroke="rgba(255,255,255,0.3)" strokeWidth="2" />
-                  <path
-                    d="M8 2a6 6 0 0 1 6 6"
-                    stroke="#fff"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                  />
-                </svg>
-                Downloading…
-              </span>
-            ) : (
-              'Download →'
-            )}
-          </button>
+  // ── render: step — url ────────────────────────────────────────────────────
+  if (step === 'url') {
+    return (
+      <div className="dl-view" style={style}>
+        <div className="dl-header">
+          <h2 className="dl-title">TIDAL Download</h2>
+          <p className="dl-subtitle">Paste a TIDAL URL to import tracks into your library.</p>
         </div>
 
-        {/* Playlist target */}
+        <form className="dl-form" onSubmit={handleLoad}>
+          <div className="dl-input-row">
+            <input
+              ref={inputRef}
+              className="dl-input"
+              type="url"
+              placeholder="https://tidal.com/browse/album/…"
+              value={url}
+              onChange={(e) => {
+                setUrl(e.target.value);
+                setFetchError(null);
+              }}
+              onPaste={(e) => {
+                const text = e.clipboardData?.getData('text')?.trim();
+                if (text) {
+                  e.preventDefault();
+                  setUrl(text);
+                  setFetchError(null);
+                }
+              }}
+              disabled={fetching}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <button className="dl-btn" type="submit" disabled={fetching || !url.trim()}>
+              {fetching ? (
+                <span className="dl-fetch-spinner">
+                  <svg className="dl-spinner-svg" viewBox="0 0 16 16" fill="none">
+                    <circle cx="8" cy="8" r="6" stroke="rgba(255,255,255,0.3)" strokeWidth="2" />
+                    <path
+                      d="M8 2a6 6 0 0 1 6 6"
+                      stroke="#fff"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                  Fetching…
+                </span>
+              ) : (
+                'Get tracks →'
+              )}
+            </button>
+          </div>
+          {fetchError && (
+            <div className="dl-fetch-error" style={{ marginTop: 8 }}>
+              ✗ {fetchError}
+            </div>
+          )}
+        </form>
+
+        <div className="dl-sources" style={{ marginTop: 32 }}>
+          <div className="dl-sources-title">Supported URL types</div>
+          <div className="dl-sources-grid">
+            {TIDAL_URL_TYPES.map((t) => (
+              <div key={t.label} className="dl-source-chip">
+                <span className="dl-source-icon">♫</span>
+                <span>{t.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="tidal-reauth">
+          <button
+            type="button"
+            className="tidal-reauth-btn"
+            onClick={() => {
+              setSetup({ ...setup, loggedIn: false });
+              setLoginState('idle');
+            }}
+          >
+            Switch TIDAL account
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── render: step — select ─────────────────────────────────────────────────
+  if (step === 'select') {
+    const entries = playlistInfo?.entries ?? [];
+    const allSelected = entries.length > 0 && entries.every((e) => selectedIndices.has(e.index));
+
+    return (
+      <div className="dl-view" style={style}>
+        <div className="dl-header">
+          <h2 className="dl-title">{playlistInfo?.title ?? 'Select tracks'}</h2>
+          <p className="dl-subtitle">
+            {entries.length} track{entries.length !== 1 ? 's' : ''} · select which to download
+          </p>
+        </div>
+
+        <div className="dl-select-list">
+          <div className="dl-select-header">
+            <label className="dl-select-all">
+              <input type="checkbox" checked={allSelected} onChange={handleToggleAll} />
+              <span>Select all</span>
+            </label>
+            <span className="dl-select-count">
+              {selectedIndices.size} / {entries.length} selected
+            </span>
+          </div>
+          <div className="dl-entries">
+            {entries.map((entry) => (
+              <label key={entry.index} className="dl-entry">
+                <input
+                  type="checkbox"
+                  checked={selectedIndices.has(entry.index)}
+                  onChange={() => handleToggleEntry(entry.index)}
+                />
+                <span className="dl-entry-num">{entry.index + 1}</span>
+                <span className="dl-entry-info">
+                  <span className="dl-entry-title">{entry.title}</span>
+                  {entry.artist && <span className="dl-entry-artist">{entry.artist}</span>}
+                </span>
+                {entry.duration > 0 && (
+                  <span className="dl-entry-dur">{fmtDuration(entry.duration)}</span>
+                )}
+              </label>
+            ))}
+          </div>
+        </div>
+
         <div className="dl-playlist-target">
           <label className="dl-playlist-target-label">Save to playlist</label>
           <select
             className="dl-playlist-select"
             value={targetPlaylistId ?? ''}
             onChange={(e) => setTargetPlaylistId(e.target.value || null)}
-            disabled={downloading}
           >
             <option value="">None / new playlist</option>
             {playlists.map((pl) => (
@@ -365,34 +512,96 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
               className="dl-playlist-name-input"
               type="text"
               placeholder="New playlist name (optional)"
-              value={newPlaylistName}
-              onChange={(e) => setNewPlaylistName(e.target.value)}
-              disabled={downloading}
+              value={targetPlaylistName}
+              onChange={(e) => setTargetPlaylistName(e.target.value)}
             />
           )}
         </div>
-      </form>
 
-      {/* Progress */}
-      {downloading && progressMsg && (
-        <div className="dl-form" style={{ marginTop: 16 }}>
-          <div className="dl-progress">
-            <div className="dl-progress-bar">
-              <div className="tidal-progress-indeterminate" />
-            </div>
-            <span className="dl-progress-msg">{progressMsg}</span>
+        <div className="dl-select-actions">
+          <button type="button" className="dl-back-btn" onClick={resetToUrl}>
+            ← Back
+          </button>
+          <button
+            type="button"
+            className="dl-btn"
+            disabled={selectedIndices.size === 0}
+            onClick={handleDownload}
+          >
+            Download {selectedIndices.size} track{selectedIndices.size !== 1 ? 's' : ''} →
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── render: step — download ───────────────────────────────────────────────
+  const doneCount = trackStatuses.filter((s) => s.status === 'done').length;
+  const failCount = trackStatuses.filter((s) => s.status === 'failed').length;
+  const totalCount = trackStatuses.length;
+  const progressPct = totalCount > 0 ? Math.round(((doneCount + failCount) / totalCount) * 100) : 0;
+
+  return (
+    <div className="dl-view" style={style}>
+      <div className="dl-header">
+        <h2 className="dl-title">{playlistInfo?.title ?? 'Downloading…'}</h2>
+        <p className="dl-subtitle">
+          {loading
+            ? `${doneCount} / ${totalCount} tracks added`
+            : result?.ok
+              ? `✓ Done — ${doneCount} track${doneCount !== 1 ? 's' : ''} added`
+              : result?.error
+                ? '✗ Download failed'
+                : 'Starting…'}
+        </p>
+      </div>
+
+      {/* Progress bar */}
+      {totalCount > 0 && (
+        <div className="dl-progress" style={{ marginBottom: 16 }}>
+          <div className="dl-progress-bar">
+            <div className="dl-progress-fill" style={{ width: `${progressPct}%` }} />
           </div>
+          <span className="dl-progress-msg">
+            {doneCount + failCount} / {totalCount}
+          </span>
         </div>
       )}
 
-      {/* Result */}
-      {result?.ok && (
-        <div className="dl-result dl-result--ok" style={{ marginTop: 16, maxWidth: 640 }}>
-          <span>
-            {result.trackIds.length === 1
-              ? '✓ Track added to your library'
-              : `✓ ${result.trackIds.length} tracks added to your library`}
-          </span>
+      {/* Indeterminate progress when track list is unknown (mix / raw URL) */}
+      {loading && totalCount === 0 && (
+        <div className="dl-progress" style={{ marginBottom: 16 }}>
+          <div className="dl-progress-bar">
+            <div className="tidal-progress-indeterminate" />
+          </div>
+          <span className="dl-progress-msg">Downloading…</span>
+        </div>
+      )}
+
+      {/* Per-track status list */}
+      {trackStatuses.length > 0 && (
+        <div className="dl-track-list">
+          {trackStatuses.map((s) => {
+            const si = STATUS_ICON[s.status] ?? STATUS_ICON.pending;
+            return (
+              <div key={s.index} className={`dl-track-row dl-track-row--${s.status}`}>
+                <span className={`dl-track-icon dl-track-icon--${s.status}`} title={si.label}>
+                  {si.icon}
+                </span>
+                <span className="dl-track-info">
+                  <span className="dl-track-title">{s.title}</span>
+                  {s.artist && <span className="dl-track-artist"> — {s.artist}</span>}
+                </span>
+                {s.error && <span className="dl-track-error">{s.error}</span>}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Result actions */}
+      {!loading && result?.ok && (
+        <div className="dl-result dl-result--ok" style={{ marginTop: 16 }}>
           <div className="dl-result-actions">
             {result.playlistId ? (
               <button
@@ -407,68 +616,25 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
                 View in Music →
               </button>
             )}
-            <button type="button" className="dl-goto-btn" onClick={handleReset}>
+            <button type="button" className="dl-goto-btn" onClick={resetToUrl}>
               ← New download
             </button>
           </div>
         </div>
       )}
-      {result?.error && (
-        <div className="dl-result dl-result--err" style={{ marginTop: 16, maxWidth: 640 }}>
+      {!loading && result?.error && (
+        <div className="dl-result dl-result--err" style={{ marginTop: 16 }}>
           <span>✗ {result.error}</span>
           <button
             type="button"
             className="dl-back-btn"
-            onClick={handleReset}
+            onClick={resetToUrl}
             style={{ marginTop: 8, alignSelf: 'flex-start' }}
           >
             ← Try again
           </button>
         </div>
       )}
-
-      {/* URL types */}
-      <div className="dl-sources" style={{ marginTop: result ? 32 : 32 }}>
-        <div className="dl-sources-title">Supported URL types</div>
-        <div className="dl-sources-grid">
-          {TIDAL_URL_TYPES.map((t) => (
-            <div key={t.label} className="dl-source-chip">
-              <span className="dl-source-icon">♫</span>
-              <span>{t.label}</span>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Session history */}
-      {history.length > 0 && (
-        <div className="dl-history">
-          <div className="dl-history-title">Session downloads</div>
-          {history.map((item, i) => (
-            <div key={i} className="dl-history-item">
-              <span className="dl-history-icon">♫</span>
-              <span className="dl-history-url">{item.url}</span>
-              <span className="dl-history-time">
-                {item.count} track{item.count !== 1 ? 's' : ''} · {formatTime(item.at)}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Re-auth footer */}
-      <div className="tidal-reauth">
-        <button
-          type="button"
-          className="tidal-reauth-btn"
-          onClick={() => {
-            setSetup({ ...setup, loggedIn: false });
-            setLoginState('idle');
-          }}
-        >
-          Switch TIDAL account
-        </button>
-      </div>
     </div>
   );
 }

--- a/renderer/src/__tests__/Sidebar.test.jsx
+++ b/renderer/src/__tests__/Sidebar.test.jsx
@@ -2,11 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import Sidebar from '../Sidebar.jsx';
 import { DownloadProvider } from '../DownloadContext.jsx';
+import { TidalDownloadProvider } from '../TidalDownloadContext.jsx';
 
 function renderSidebar(props = {}) {
   return render(
     <DownloadProvider>
-      <Sidebar {...props} />
+      <TidalDownloadProvider>
+        <Sidebar {...props} />
+      </TidalDownloadProvider>
     </DownloadProvider>
   );
 }

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -58,6 +58,11 @@ window.api = {
   onYtDlpEntriesReady: vi.fn().mockImplementation(() => () => {}),
   onYtDlpEntryChecked: vi.fn().mockImplementation(() => () => {}),
   onYtDlpTrackUpdate: vi.fn().mockImplementation(() => () => {}),
+  tidalCheck: vi.fn().mockResolvedValue({ installed: false, loggedIn: false, path: null }),
+  tidalLogin: vi.fn().mockResolvedValue({ ok: true }),
+  tidalDownloadUrl: vi.fn().mockResolvedValue({ ok: true, trackIds: [], playlistId: null }),
+  onTidalProgress: vi.fn().mockImplementation(() => () => {}),
+  onTidalLoginUrl: vi.fn().mockImplementation(() => () => {}),
   openExternal: vi.fn().mockResolvedValue(undefined),
   checkUsbFormat: vi
     .fn()

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -59,10 +59,12 @@ window.api = {
   onYtDlpEntryChecked: vi.fn().mockImplementation(() => () => {}),
   onYtDlpTrackUpdate: vi.fn().mockImplementation(() => () => {}),
   tidalCheck: vi.fn().mockResolvedValue({ installed: false, loggedIn: false, path: null }),
+  tidalInstall: vi.fn().mockResolvedValue({ ok: true }),
   tidalLogin: vi.fn().mockResolvedValue({ ok: true }),
   tidalDownloadUrl: vi.fn().mockResolvedValue({ ok: true, trackIds: [], playlistId: null }),
   onTidalProgress: vi.fn().mockImplementation(() => () => {}),
   onTidalLoginUrl: vi.fn().mockImplementation(() => () => {}),
+  onTidalInstallProgress: vi.fn().mockImplementation(() => () => {}),
   openExternal: vi.fn().mockResolvedValue(undefined),
   checkUsbFormat: vi
     .fn()

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -61,11 +61,13 @@ window.api = {
   onYtDlpTrackUpdate: vi.fn().mockImplementation(() => () => {}),
   tidalCheck: vi.fn().mockResolvedValue({ installed: false, loggedIn: false, path: null }),
   tidalInstall: vi.fn().mockResolvedValue({ ok: true }),
+  tidalFetchInfo: vi.fn().mockResolvedValue({ ok: false, error: 'not configured' }),
   tidalLogin: vi.fn().mockResolvedValue({ ok: true }),
   tidalDownloadUrl: vi.fn().mockResolvedValue({ ok: true, trackIds: [], playlistId: null }),
   onTidalProgress: vi.fn().mockImplementation(() => () => {}),
   onTidalLoginUrl: vi.fn().mockImplementation(() => () => {}),
   onTidalInstallProgress: vi.fn().mockImplementation(() => () => {}),
+  onTidalTrackUpdate: vi.fn().mockImplementation(() => () => {}),
   openExternal: vi.fn().mockResolvedValue(undefined),
   checkUsbFormat: vi
     .fn()

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -34,6 +34,7 @@ window.api = {
   getDepVersions: vi.fn().mockResolvedValue({}),
   checkDepUpdates: vi.fn().mockResolvedValue({}),
   updateAllDeps: vi.fn().mockResolvedValue(undefined),
+  updateTidalDlNg: vi.fn().mockResolvedValue({ ok: true }),
   clearLibrary: vi.fn().mockResolvedValue(undefined),
   clearUserData: vi.fn().mockResolvedValue(undefined),
   getLogDir: vi.fn().mockResolvedValue('/tmp/logs'),

--- a/src/audio/tidalDlManager.js
+++ b/src/audio/tidalDlManager.js
@@ -104,6 +104,69 @@ function writeTidalConfig(cfg) {
 }
 
 /**
+ * Install tidal-dl-ng via pip, streaming output to onProgress.
+ * Tries pip3 → pip → python3 -m pip → python -m pip in order.
+ * @param {(line: string) => void} onProgress
+ * @returns {Promise<void>}
+ */
+export function installTidalDlNg(onProgress) {
+  const candidates =
+    process.platform === 'win32'
+      ? [
+          ['pip', ['install', 'tidal-dl-ng']],
+          ['python', ['-m', 'pip', 'install', 'tidal-dl-ng']],
+        ]
+      : [
+          ['pip3', ['install', 'tidal-dl-ng']],
+          ['pip', ['install', 'tidal-dl-ng']],
+          ['python3', ['-m', 'pip', 'install', 'tidal-dl-ng']],
+          ['python', ['-m', 'pip', 'install', 'tidal-dl-ng']],
+        ];
+
+  function tryNext(index) {
+    if (index >= candidates.length) {
+      return Promise.reject(
+        new Error('Could not find pip or python. Please install Python 3.12+ and try again.')
+      );
+    }
+    const [cmd, args] = candidates[index];
+    return new Promise((resolve, reject) => {
+      const proc = spawn(cmd, args, {
+        env: { ...process.env, PYTHONUNBUFFERED: '1' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      proc.stdout.on('data', (chunk) => {
+        for (const line of chunk.toString().split('\n')) {
+          const t = line.trim();
+          if (t) onProgress(t);
+        }
+      });
+      proc.stderr.on('data', (chunk) => {
+        for (const line of chunk.toString().split('\n')) {
+          const t = line.trim();
+          if (t) onProgress(t);
+        }
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`${cmd} exited with code ${code}`));
+      });
+      proc.on('error', () => {
+        // This candidate not available — try the next one
+        reject(new Error(`spawn ${cmd} failed`));
+      });
+    }).catch((err) => {
+      console.warn(`[tidal-install] ${err.message} — trying next candidate`);
+      return tryNext(index + 1);
+    });
+  }
+
+  return tryNext(0);
+}
+
+/**
  * Check if tdn is installed and the user is logged in.
  * @returns {{ installed: boolean, loggedIn: boolean, path: string|null }}
  */

--- a/src/audio/tidalDlManager.js
+++ b/src/audio/tidalDlManager.js
@@ -61,78 +61,97 @@ export function findTidalDlPath() {
 }
 
 /**
- * Path to the tidal-dl-ng settings file (platformdirs user_config_dir).
+ * Return all possible tidal-dl-ng config directory base paths.
+ * The fork may use 'tidal_dl_ng' or 'tidal_dl_ng-dev' depending on
+ * how it was installed. We operate on every dir that exists.
  */
-function getConfigPath() {
+function getTidalConfigDirs() {
+  let bases;
   if (process.platform === 'win32') {
-    return path.join(os.homedir(), 'AppData', 'Local', 'tidal_dl_ng', 'settings.json');
+    bases = [
+      path.join(os.homedir(), 'AppData', 'Local', 'tidal_dl_ng'),
+      path.join(os.homedir(), 'AppData', 'Local', 'tidal_dl_ng-dev'),
+    ];
   } else if (process.platform === 'darwin') {
-    return path.join(
-      os.homedir(),
-      'Library',
-      'Application Support',
-      'tidal_dl_ng',
-      'settings.json'
-    );
+    bases = [
+      path.join(os.homedir(), 'Library', 'Application Support', 'tidal_dl_ng'),
+      path.join(os.homedir(), 'Library', 'Application Support', 'tidal_dl_ng-dev'),
+    ];
+  } else {
+    bases = [
+      path.join(os.homedir(), '.config', 'tidal_dl_ng'),
+      path.join(os.homedir(), '.config', 'tidal_dl_ng-dev'),
+    ];
   }
-  return path.join(os.homedir(), '.config', 'tidal_dl_ng', 'settings.json');
+  return bases.filter((d) => fs.existsSync(d));
 }
 
 /**
- * Path to the tidal-dl-ng OAuth token file.
+ * Return the config dir that has a settings.json (prefer the one tdn
+ * is currently writing to, identified by the most-recently-modified file).
  */
-function getTokenPath() {
-  if (process.platform === 'win32') {
-    return path.join(os.homedir(), 'AppData', 'Local', 'tidal_dl_ng', 'token.json');
-  } else if (process.platform === 'darwin') {
-    return path.join(os.homedir(), 'Library', 'Application Support', 'tidal_dl_ng', 'token.json');
-  }
-  return path.join(os.homedir(), '.config', 'tidal_dl_ng', 'token.json');
-}
-
-function readTidalConfig() {
-  try {
-    return JSON.parse(fs.readFileSync(getConfigPath(), 'utf8'));
-  } catch {
-    return {};
-  }
-}
-
-function writeTidalConfig(cfg) {
-  const p = getConfigPath();
-  fs.mkdirSync(path.dirname(p), { recursive: true });
-  fs.writeFileSync(p, JSON.stringify(cfg, null, 2));
-}
-
-/**
- * Path to the tidal-dl-ng download history file.
- * tdn skips tracks listed here — we clear it before each download
- * so all requested tracks are always fetched. The library's SHA-1
- * dedup prevents re-importing tracks that are already in the library.
- */
-function getHistoryPath() {
-  if (process.platform === 'win32') {
-    return path.join(os.homedir(), 'AppData', 'Local', 'tidal_dl_ng', 'downloaded_history.json');
-  } else if (process.platform === 'darwin') {
-    return path.join(
-      os.homedir(),
-      'Library',
-      'Application Support',
-      'tidal_dl_ng',
-      'downloaded_history.json'
-    );
-  }
-  return path.join(os.homedir(), '.config', 'tidal_dl_ng', 'downloaded_history.json');
-}
-
-function clearDownloadHistory() {
-  try {
-    const p = getHistoryPath();
-    if (fs.existsSync(p)) {
-      fs.writeFileSync(p, '[]');
+function getActiveConfigDir() {
+  const dirs = getTidalConfigDirs();
+  if (dirs.length === 0) return null;
+  if (dirs.length === 1) return dirs[0];
+  // Pick whichever settings.json was modified most recently
+  let best = dirs[0];
+  let bestMtime = 0;
+  for (const d of dirs) {
+    try {
+      const mtime = fs.statSync(path.join(d, 'settings.json')).mtimeMs;
+      if (mtime > bestMtime) {
+        bestMtime = mtime;
+        best = d;
+      }
+    } catch {
+      /* no settings.json in this dir */
     }
-  } catch (e) {
-    console.warn('[tidal-dl] failed to clear download history:', e.message);
+  }
+  return best;
+}
+
+function getTokenPath() {
+  const dir = getActiveConfigDir();
+  const base =
+    dir ??
+    (process.platform === 'win32'
+      ? path.join(os.homedir(), 'AppData', 'Local', 'tidal_dl_ng')
+      : process.platform === 'darwin'
+        ? path.join(os.homedir(), 'Library', 'Application Support', 'tidal_dl_ng')
+        : path.join(os.homedir(), '.config', 'tidal_dl_ng'));
+  return path.join(base, 'token.json');
+}
+
+/**
+ * Clear the download history in ALL tidal config dirs before each download.
+ * tdn skips tracks listed in downloaded_history.json — clearing it ensures
+ * all requested tracks are fetched. The library's SHA-1 dedup prevents
+ * re-importing tracks already in the library.
+ *
+ * The history schema is { _schema_version, settings, tracks: { id: {...} } }
+ * — we preserve schema_version and set tracks to {} and preventDuplicates to false.
+ */
+function clearDownloadHistory() {
+  for (const dir of getTidalConfigDirs()) {
+    const p = path.join(dir, 'downloaded_history.json');
+    try {
+      let existing = {};
+      try {
+        existing = JSON.parse(fs.readFileSync(p, 'utf8'));
+      } catch {
+        /* file missing or corrupt — start fresh */
+      }
+      const cleared = {
+        _schema_version: existing._schema_version ?? 1,
+        _last_updated: new Date().toISOString(),
+        settings: { preventDuplicates: false },
+        tracks: {},
+      };
+      fs.writeFileSync(p, JSON.stringify(cleared));
+    } catch (e) {
+      console.warn('[tidal-dl] failed to clear download history in', dir, ':', e.message);
+    }
   }
 }
 
@@ -321,20 +340,35 @@ export async function downloadTidal(url, outputDir, onProgress) {
 
   await fs.promises.mkdir(outputDir, { recursive: true });
 
-  // Save + set download config
-  const originalCfg = readTidalConfig();
-  const patchedCfg = {
-    ...originalCfg,
-    download_base_path: outputDir,
-    // Prefer lossless for DJs; fall back gracefully if subscription doesn't allow
-    quality_audio: originalCfg.quality_audio ?? 'HiRes_Lossless',
-    extract_flac: originalCfg.extract_flac ?? true,
-    skip_existing: false,
-    cover_album_file: false,
-  };
-  writeTidalConfig(patchedCfg);
+  // Patch settings in ALL config dirs so whichever one tdn reads gets the right values.
+  const allDirs = getTidalConfigDirs();
+  const originalCfgs = new Map();
+  for (const dir of allDirs) {
+    const cfgPath = path.join(dir, 'settings.json');
+    let original = {};
+    try {
+      original = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    } catch {
+      /* missing — will create */
+    }
+    originalCfgs.set(cfgPath, original);
+    const patched = {
+      ...original,
+      download_base_path: outputDir,
+      quality_audio: original.quality_audio ?? 'HiRes_Lossless',
+      extract_flac: original.extract_flac ?? true,
+      skip_existing: false,
+      cover_album_file: false,
+    };
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(cfgPath, JSON.stringify(patched, null, 2));
+    } catch (e) {
+      console.warn('[tidal-dl] failed to patch config in', dir, ':', e.message);
+    }
+  }
 
-  // Clear download history so tdn never skips tracks.
+  // Clear download history in all config dirs so tdn never skips tracks.
   // Library-level SHA-1 dedup prevents re-importing existing tracks.
   clearDownloadHistory();
 
@@ -368,11 +402,13 @@ export async function downloadTidal(url, outputDir, onProgress) {
     });
 
     proc.on('close', async (code) => {
-      // Restore original config
-      try {
-        writeTidalConfig(originalCfg);
-      } catch (e) {
-        console.warn('[tidal-dl] failed to restore config:', e.message);
+      // Restore original configs in all dirs
+      for (const [cfgPath, original] of originalCfgs) {
+        try {
+          fs.writeFileSync(cfgPath, JSON.stringify(original, null, 2));
+        } catch (e) {
+          console.warn('[tidal-dl] failed to restore config', cfgPath, ':', e.message);
+        }
       }
 
       if (code !== 0) {
@@ -385,10 +421,12 @@ export async function downloadTidal(url, outputDir, onProgress) {
     });
 
     proc.on('error', (err) => {
-      try {
-        writeTidalConfig(originalCfg);
-      } catch {
-        /* ignore */
+      for (const [cfgPath, original] of originalCfgs) {
+        try {
+          fs.writeFileSync(cfgPath, JSON.stringify(original, null, 2));
+        } catch {
+          /* ignore */
+        }
       }
       reject(err);
     });

--- a/src/audio/tidalDlManager.js
+++ b/src/audio/tidalDlManager.js
@@ -1,0 +1,296 @@
+/**
+ * tidal-dl-ng download manager.
+ * Wraps the `tdn` CLI (from the tidal-dl-ng Python package).
+ * Authentication uses TIDAL's OAuth device-link flow.
+ */
+import { spawn, execSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+const AUDIO_EXTS = new Set(['.mp3', '.flac', '.m4a', '.aac', '.wav', '.ogg', '.opus']);
+
+// Strip ANSI escape codes from terminal output
+function stripAnsi(str) {
+  return str.replace(/\x1B\[[0-9;]*[mGKHFABCDST]/g, '');
+}
+
+/**
+ * Find the `tdn` binary in common locations.
+ * @returns {string|null}
+ */
+export function findTidalDlPath() {
+  const candidates = [
+    path.join(os.homedir(), '.local', 'bin', 'tdn'),
+    path.join(os.homedir(), '.local', 'bin', 'tidal-dl-ng'),
+    '/usr/local/bin/tdn',
+    '/usr/bin/tdn',
+  ];
+
+  if (process.platform === 'win32') {
+    candidates.push(
+      path.join(os.homedir(), 'AppData', 'Roaming', 'Python', 'Scripts', 'tdn.exe'),
+      path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Python', 'Scripts', 'tdn.exe')
+    );
+  } else if (process.platform === 'darwin') {
+    candidates.push(
+      path.join(os.homedir(), 'Library', 'Python', '3.12', 'bin', 'tdn'),
+      path.join(os.homedir(), 'Library', 'Python', '3.11', 'bin', 'tdn'),
+      '/opt/homebrew/bin/tdn'
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  // Try PATH resolution
+  try {
+    const which = process.platform === 'win32' ? 'where' : 'which';
+    const result = execSync(`${which} tdn`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (result) return result.split('\n')[0].trim();
+  } catch {
+    /* not in PATH */
+  }
+
+  return null;
+}
+
+/**
+ * Path to the tidal-dl-ng settings file (platformdirs user_config_dir).
+ */
+function getConfigPath() {
+  if (process.platform === 'win32') {
+    return path.join(os.homedir(), 'AppData', 'Local', 'tidal-dl-ng', 'settings.json');
+  } else if (process.platform === 'darwin') {
+    return path.join(
+      os.homedir(),
+      'Library',
+      'Application Support',
+      'tidal-dl-ng',
+      'settings.json'
+    );
+  }
+  return path.join(os.homedir(), '.config', 'tidal-dl-ng', 'settings.json');
+}
+
+/**
+ * Path to the tidal-dl-ng OAuth token file.
+ */
+function getTokenPath() {
+  if (process.platform === 'win32') {
+    return path.join(os.homedir(), 'AppData', 'Local', 'tidal-dl-ng', 'token.json');
+  } else if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', 'tidal-dl-ng', 'token.json');
+  }
+  return path.join(os.homedir(), '.config', 'tidal-dl-ng', 'token.json');
+}
+
+function readTidalConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(getConfigPath(), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeTidalConfig(cfg) {
+  const p = getConfigPath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(cfg, null, 2));
+}
+
+/**
+ * Check if tdn is installed and the user is logged in.
+ * @returns {{ installed: boolean, loggedIn: boolean, path: string|null }}
+ */
+export function checkTidalSetup() {
+  const binPath = findTidalDlPath();
+  if (!binPath) return { installed: false, loggedIn: false, path: null };
+
+  try {
+    const tokenPath = getTokenPath();
+    if (!fs.existsSync(tokenPath)) return { installed: true, loggedIn: false, path: binPath };
+    const token = JSON.parse(fs.readFileSync(tokenPath, 'utf8'));
+    if (!token.access_token) return { installed: true, loggedIn: false, path: binPath };
+    // Treat as logged in even if expiry is close — tidalapi handles token refresh
+    return { installed: true, loggedIn: true, path: binPath };
+  } catch {
+    return { installed: true, loggedIn: false, path: binPath };
+  }
+}
+
+/**
+ * Start the TIDAL OAuth login flow.
+ * Spawns `tdn login`, parses the device-link URL from stdout/stderr,
+ * and calls onUrl once the URL is available.
+ * Resolves when login completes (process exits 0).
+ *
+ * @param {(url: string) => void} onUrl
+ * @returns {Promise<void>}
+ */
+export function startLogin(onUrl) {
+  const binPath = findTidalDlPath();
+  if (!binPath) {
+    return Promise.reject(
+      new Error('tidal-dl-ng not found. Install it with: pip install tidal-dl-ng')
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(binPath, ['login'], {
+      env: { ...process.env, TERM: 'dumb', NO_COLOR: '1', FORCE_COLOR: '0' },
+    });
+
+    let urlSent = false;
+
+    function scanForUrl(text) {
+      if (urlSent) return;
+      // Match TIDAL device-link URLs
+      const match = text.match(/https?:\/\/[^\s]*(link\.tidal\.com|tidal\.com)[^\s]*/i);
+      if (match) {
+        urlSent = true;
+        onUrl(match[0].replace(/[.,;!?]+$/, ''));
+      }
+    }
+
+    proc.stdout.on('data', (chunk) => {
+      const text = stripAnsi(chunk.toString());
+      console.log('[tidal-login] stdout:', text.trim());
+      scanForUrl(text);
+    });
+
+    proc.stderr.on('data', (chunk) => {
+      const text = stripAnsi(chunk.toString());
+      console.log('[tidal-login] stderr:', text.trim());
+      scanForUrl(text);
+    });
+
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`tdn login exited with code ${code}`));
+    });
+
+    proc.on('error', reject);
+  });
+}
+
+/**
+ * Recursively scan a directory for audio files newer than a given timestamp.
+ */
+async function scanForAudioFiles(dir, sinceMs) {
+  const results = [];
+  async function walk(current) {
+    let entries;
+    try {
+      entries = await fs.promises.readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (AUDIO_EXTS.has(path.extname(entry.name).toLowerCase())) {
+        try {
+          const stat = await fs.promises.stat(full);
+          if (stat.mtimeMs >= sinceMs - 5000) results.push(full);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+  await walk(dir);
+  return results;
+}
+
+/**
+ * Download a TIDAL URL using `tdn dl`.
+ * Temporarily sets download_base_path to outputDir, restores after.
+ *
+ * @param {string} url
+ * @param {string} outputDir  Directory to download into
+ * @param {(msg: string) => void} onProgress
+ * @returns {Promise<string[]>}  Paths of downloaded audio files
+ */
+export async function downloadTidal(url, outputDir, onProgress) {
+  const binPath = findTidalDlPath();
+  if (!binPath) {
+    throw new Error('tidal-dl-ng not found. Install it with: pip install tidal-dl-ng');
+  }
+
+  await fs.promises.mkdir(outputDir, { recursive: true });
+
+  // Save + set download config
+  const originalCfg = readTidalConfig();
+  const patchedCfg = {
+    ...originalCfg,
+    download_base_path: outputDir,
+    // Prefer lossless for DJs; fall back gracefully if subscription doesn't allow
+    quality_audio: originalCfg.quality_audio ?? 'HiRes_Lossless',
+    extract_flac: originalCfg.extract_flac ?? true,
+    skip_existing: false,
+    cover_album_file: false,
+  };
+  writeTidalConfig(patchedCfg);
+
+  const startTime = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(binPath, ['dl', url], {
+      env: { ...process.env, TERM: 'dumb', NO_COLOR: '1', FORCE_COLOR: '0' },
+    });
+
+    let stderr = '';
+
+    proc.stdout.on('data', (chunk) => {
+      const text = stripAnsi(chunk.toString());
+      for (const line of text.split('\n')) {
+        const t = line.trim();
+        if (t) {
+          console.log('[tidal-dl] stdout:', t);
+          onProgress(t);
+        }
+      }
+    });
+
+    proc.stderr.on('data', (chunk) => {
+      const text = stripAnsi(chunk.toString());
+      stderr += text;
+      for (const line of text.split('\n')) {
+        const t = line.trim();
+        if (t) console.log('[tidal-dl] stderr:', t);
+      }
+    });
+
+    proc.on('close', async (code) => {
+      // Restore original config
+      try {
+        writeTidalConfig(originalCfg);
+      } catch (e) {
+        console.warn('[tidal-dl] failed to restore config:', e.message);
+      }
+
+      if (code !== 0) {
+        reject(new Error(`tidal-dl-ng exited with code ${code}: ${stderr.trim().slice(0, 400)}`));
+        return;
+      }
+
+      const files = await scanForAudioFiles(outputDir, startTime);
+      resolve(files);
+    });
+
+    proc.on('error', (err) => {
+      try {
+        writeTidalConfig(originalCfg);
+      } catch {
+        /* ignore */
+      }
+      reject(err);
+    });
+  });
+}

--- a/src/audio/tidalDlManager.js
+++ b/src/audio/tidalDlManager.js
@@ -29,6 +29,7 @@ export function findTidalDlPath() {
 
   if (process.platform === 'win32') {
     candidates.push(
+      path.join(os.homedir(), '.local', 'bin', 'tdn.exe'),
       path.join(os.homedir(), 'AppData', 'Roaming', 'Python', 'Scripts', 'tdn.exe'),
       path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Python', 'Scripts', 'tdn.exe')
     );

--- a/src/audio/tidalDlManager.js
+++ b/src/audio/tidalDlManager.js
@@ -65,17 +65,17 @@ export function findTidalDlPath() {
  */
 function getConfigPath() {
   if (process.platform === 'win32') {
-    return path.join(os.homedir(), 'AppData', 'Local', 'tidal-dl-ng', 'settings.json');
+    return path.join(os.homedir(), 'AppData', 'Local', 'tidal_dl_ng', 'settings.json');
   } else if (process.platform === 'darwin') {
     return path.join(
       os.homedir(),
       'Library',
       'Application Support',
-      'tidal-dl-ng',
+      'tidal_dl_ng',
       'settings.json'
     );
   }
-  return path.join(os.homedir(), '.config', 'tidal-dl-ng', 'settings.json');
+  return path.join(os.homedir(), '.config', 'tidal_dl_ng', 'settings.json');
 }
 
 /**
@@ -83,11 +83,11 @@ function getConfigPath() {
  */
 function getTokenPath() {
   if (process.platform === 'win32') {
-    return path.join(os.homedir(), 'AppData', 'Local', 'tidal-dl-ng', 'token.json');
+    return path.join(os.homedir(), 'AppData', 'Local', 'tidal_dl_ng', 'token.json');
   } else if (process.platform === 'darwin') {
-    return path.join(os.homedir(), 'Library', 'Application Support', 'tidal-dl-ng', 'token.json');
+    return path.join(os.homedir(), 'Library', 'Application Support', 'tidal_dl_ng', 'token.json');
   }
-  return path.join(os.homedir(), '.config', 'tidal-dl-ng', 'token.json');
+  return path.join(os.homedir(), '.config', 'tidal_dl_ng', 'token.json');
 }
 
 function readTidalConfig() {

--- a/src/audio/tidalDlManager.js
+++ b/src/audio/tidalDlManager.js
@@ -105,6 +105,38 @@ function writeTidalConfig(cfg) {
 }
 
 /**
+ * Path to the tidal-dl-ng download history file.
+ * tdn skips tracks listed here — we clear it before each download
+ * so all requested tracks are always fetched. The library's SHA-1
+ * dedup prevents re-importing tracks that are already in the library.
+ */
+function getHistoryPath() {
+  if (process.platform === 'win32') {
+    return path.join(os.homedir(), 'AppData', 'Local', 'tidal_dl_ng', 'downloaded_history.json');
+  } else if (process.platform === 'darwin') {
+    return path.join(
+      os.homedir(),
+      'Library',
+      'Application Support',
+      'tidal_dl_ng',
+      'downloaded_history.json'
+    );
+  }
+  return path.join(os.homedir(), '.config', 'tidal_dl_ng', 'downloaded_history.json');
+}
+
+function clearDownloadHistory() {
+  try {
+    const p = getHistoryPath();
+    if (fs.existsSync(p)) {
+      fs.writeFileSync(p, '[]');
+    }
+  } catch (e) {
+    console.warn('[tidal-dl] failed to clear download history:', e.message);
+  }
+}
+
+/**
  * Install tidal-dl-ng via pip, streaming output to onProgress.
  * Tries pip3 → pip → python3 -m pip → python -m pip in order.
  * @param {(line: string) => void} onProgress
@@ -301,6 +333,10 @@ export async function downloadTidal(url, outputDir, onProgress) {
     cover_album_file: false,
   };
   writeTidalConfig(patchedCfg);
+
+  // Clear download history so tdn never skips tracks.
+  // Library-level SHA-1 dedup prevents re-importing existing tracks.
+  clearDownloadHistory();
 
   const startTime = Date.now();
 

--- a/src/audio/tidalDlManager.js
+++ b/src/audio/tidalDlManager.js
@@ -10,6 +10,99 @@ import os from 'os';
 
 const AUDIO_EXTS = new Set(['.mp3', '.flac', '.m4a', '.aac', '.wav', '.ogg', '.opus']);
 
+// Embedded Python script for fetching TIDAL track listings via tidalapi.
+// Written to a temp file and executed with the uv-managed Python interpreter.
+const FETCH_INFO_SCRIPT = `
+import sys, json, re
+try:
+    import tidalapi
+except ImportError:
+    print(json.dumps({'ok': False, 'error': 'tidalapi not installed'}))
+    sys.exit(1)
+
+def parse_url(url):
+    patterns = [
+        (r'/album/(\\d+)', 'album'),
+        (r'/playlist/([0-9a-f-]{36})', 'playlist'),
+        (r'/mix/([a-zA-Z0-9_-]+)', 'mix'),
+        (r'/track/(\\d+)', 'track'),
+    ]
+    for pattern, rtype in patterns:
+        m = re.search(pattern, url)
+        if m:
+            return rtype, m.group(1)
+    return None, None
+
+if len(sys.argv) < 3:
+    print(json.dumps({'ok': False, 'error': 'Usage: script.py <url> <token_path>'}))
+    sys.exit(1)
+
+url = sys.argv[1]
+token_path = sys.argv[2]
+
+try:
+    with open(token_path) as f:
+        token = json.load(f)
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': f'Token error: {str(e)}'}))
+    sys.exit(1)
+
+try:
+    session = tidalapi.Session()
+    session.load_oauth_session(
+        token.get('token_type', 'Bearer'),
+        token['access_token'],
+        token.get('refresh_token')
+    )
+    if not session.check_login():
+        print(json.dumps({'ok': False, 'error': 'Not logged in to TIDAL'}))
+        sys.exit(1)
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': f'Session error: {str(e)}'}))
+    sys.exit(1)
+
+rtype, rid = parse_url(url)
+if not rtype:
+    print(json.dumps({'ok': False, 'error': 'Could not parse TIDAL URL. Use tidal.com/browse/album/123, /track/123, or /playlist/uuid'}))
+    sys.exit(1)
+
+def track_to_entry(t, idx, entry_url=None):
+    return {
+        'index': idx,
+        'id': str(t.id),
+        'title': t.name,
+        'artist': t.artist.name if t.artist else '',
+        'duration': t.duration,
+        'url': entry_url or f'https://tidal.com/browse/track/{t.id}',
+    }
+
+try:
+    if rtype == 'track':
+        t = session.track(int(rid))
+        entries = [track_to_entry(t, 0, url)]
+        title = ((t.artist.name + ' - ') if t.artist else '') + t.name
+    elif rtype == 'album':
+        a = session.album(int(rid))
+        tracks = list(a.tracks())
+        title = a.name
+        entries = [track_to_entry(t, i) for i, t in enumerate(tracks)]
+    elif rtype == 'playlist':
+        pl = session.playlist(rid)
+        tracks = list(pl.tracks())
+        title = pl.name
+        entries = [track_to_entry(t, i) for i, t in enumerate(tracks)]
+    elif rtype == 'mix':
+        print(json.dumps({'ok': True, 'type': 'mix', 'title': 'TIDAL Mix', 'entries': []}))
+        sys.exit(0)
+    else:
+        print(json.dumps({'ok': False, 'error': f'Unsupported type: {rtype}'}))
+        sys.exit(1)
+    print(json.dumps({'ok': True, 'type': rtype, 'title': title, 'entries': entries}))
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': str(e)}))
+    sys.exit(1)
+`;
+
 // Strip ANSI escape codes from terminal output
 function stripAnsi(str) {
   return str.replace(/\x1B\[[0-9;]*[mGKHFABCDST]/g, '');
@@ -58,6 +151,97 @@ export function findTidalDlPath() {
   }
 
   return null;
+}
+
+/**
+ * Find the Python interpreter bundled with the uv-managed tidal-dl-ng-for-dj environment.
+ * Falls back to system Python if the uv env is not found.
+ * @returns {string|null}
+ */
+export function findTidalPython() {
+  const uvToolDir = path.join(os.homedir(), '.local', 'share', 'uv', 'tools', 'tidal-dl-ng-for-dj');
+  const candidates =
+    process.platform === 'win32'
+      ? [
+          path.join(uvToolDir, 'Scripts', 'python.exe'),
+          path.join(uvToolDir, 'Scripts', 'python3.exe'),
+        ]
+      : [path.join(uvToolDir, 'bin', 'python3'), path.join(uvToolDir, 'bin', 'python')];
+
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+
+  // Fall back to system Python
+  const which = process.platform === 'win32' ? 'where' : 'which';
+  for (const cmd of ['python3', 'python']) {
+    try {
+      const result = execSync(`${which} ${cmd}`, {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      if (result) return result.split('\n')[0].trim();
+    } catch {
+      /* not in PATH */
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch TIDAL track/album/playlist info for a given URL using tidalapi.
+ * Uses the uv-managed Python interpreter and the embedded fetch script.
+ * @param {string} url
+ * @returns {Promise<{ ok: boolean, type?: string, title?: string, entries?: Array, error?: string }>}
+ */
+export async function fetchTidalInfo(url) {
+  const pythonPath = findTidalPython();
+  if (!pythonPath) {
+    return { ok: false, error: 'Python interpreter not found. Ensure tidal-dl-ng is installed.' };
+  }
+
+  const tokenPath = getTokenPath();
+  if (!fs.existsSync(tokenPath)) {
+    return { ok: false, error: 'Not logged in to TIDAL. Please connect your account first.' };
+  }
+
+  // Write the embedded script to a temp file
+  const scriptPath = path.join(os.tmpdir(), 'dj_manager_tidal_fetch.py');
+  try {
+    fs.writeFileSync(scriptPath, FETCH_INFO_SCRIPT.trimStart());
+  } catch (e) {
+    return { ok: false, error: `Failed to write fetch script: ${e.message}` };
+  }
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+
+    const proc = spawn(pythonPath, [scriptPath, url, tokenPath], {
+      env: { ...process.env, PYTHONUNBUFFERED: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on('close', () => {
+      try {
+        const result = JSON.parse(stdout.trim());
+        resolve(result);
+      } catch {
+        resolve({ ok: false, error: stderr.trim() || stdout.trim() || 'Failed to parse response' });
+      }
+    });
+
+    proc.on('error', (err) => {
+      resolve({ ok: false, error: err.message });
+    });
+  });
 }
 
 /**
@@ -324,15 +508,19 @@ async function scanForAudioFiles(dir, sinceMs) {
 }
 
 /**
- * Download a TIDAL URL using `tdn dl`.
+ * Download one or more TIDAL URLs using `tdn dl`.
  * Temporarily sets download_base_path to outputDir, restores after.
  *
- * @param {string} url
- * @param {string} outputDir  Directory to download into
+ * When `onFileReady` is provided, it is called for each audio file as soon as
+ * tdn signals "Downloaded item '...'." — enabling progressive library import.
+ *
+ * @param {string|string[]} urlOrUrls  Single URL or array of track URLs
+ * @param {string} outputDir           Directory to download into
  * @param {(msg: string) => void} onProgress
- * @returns {Promise<string[]>}  Paths of downloaded audio files
+ * @param {{ onFileReady?: (filePath: string) => void }} [opts]
+ * @returns {Promise<string[]>}  Paths of all downloaded audio files
  */
-export async function downloadTidal(url, outputDir, onProgress) {
+export async function downloadTidal(urlOrUrls, outputDir, onProgress, { onFileReady } = {}) {
   const binPath = findTidalDlPath();
   if (!binPath) {
     throw new Error('tidal-dl-ng not found. Install it with: pip install tidal-dl-ng');
@@ -373,9 +561,37 @@ export async function downloadTidal(url, outputDir, onProgress) {
   clearDownloadHistory();
 
   const startTime = Date.now();
+  const urlArray = Array.isArray(urlOrUrls) ? urlOrUrls : [urlOrUrls];
+  // Track which files we've already reported to onFileReady
+  const seenFiles = new Set();
+
+  function restore() {
+    for (const [cfgPath, original] of originalCfgs) {
+      try {
+        fs.writeFileSync(cfgPath, JSON.stringify(original, null, 2));
+      } catch (e) {
+        console.warn('[tidal-dl] failed to restore config', cfgPath, ':', e.message);
+      }
+    }
+  }
+
+  /**
+   * Scan outputDir for newly appeared audio files and call onFileReady for each.
+   * Called after tdn logs "Downloaded item" so we detect files right after each track.
+   */
+  async function reportNewFiles() {
+    if (!onFileReady) return;
+    const allFiles = await scanForAudioFiles(outputDir, startTime);
+    for (const f of allFiles) {
+      if (!seenFiles.has(f)) {
+        seenFiles.add(f);
+        onFileReady(f);
+      }
+    }
+  }
 
   return new Promise((resolve, reject) => {
-    const proc = spawn(binPath, ['dl', url], {
+    const proc = spawn(binPath, ['dl', ...urlArray], {
       env: { ...process.env, TERM: 'dumb', NO_COLOR: '1', FORCE_COLOR: '0' },
     });
 
@@ -385,9 +601,14 @@ export async function downloadTidal(url, outputDir, onProgress) {
       const text = stripAnsi(chunk.toString());
       for (const line of text.split('\n')) {
         const t = line.trim();
-        if (t) {
-          console.log('[tidal-dl] stdout:', t);
-          onProgress(t);
+        if (!t) continue;
+        console.log('[tidal-dl] stdout:', t);
+        onProgress(t);
+
+        // tdn logs "Downloaded item 'Artist - Title'." right before it moves the file.
+        // Wait 800ms for the shutil.move to complete, then pick up the new file.
+        if (/Downloaded item '/i.test(t)) {
+          setTimeout(() => reportNewFiles(), 800);
         }
       }
     });
@@ -402,32 +623,22 @@ export async function downloadTidal(url, outputDir, onProgress) {
     });
 
     proc.on('close', async (code) => {
-      // Restore original configs in all dirs
-      for (const [cfgPath, original] of originalCfgs) {
-        try {
-          fs.writeFileSync(cfgPath, JSON.stringify(original, null, 2));
-        } catch (e) {
-          console.warn('[tidal-dl] failed to restore config', cfgPath, ':', e.message);
-        }
-      }
+      restore();
 
       if (code !== 0) {
         reject(new Error(`tidal-dl-ng exited with code ${code}: ${stderr.trim().slice(0, 400)}`));
         return;
       }
 
-      const files = await scanForAudioFiles(outputDir, startTime);
-      resolve(files);
+      // Catch any files the progressive scan may have missed (e.g. fast downloads)
+      await reportNewFiles();
+
+      const allFiles = await scanForAudioFiles(outputDir, startTime);
+      resolve(allFiles);
     });
 
     proc.on('error', (err) => {
-      for (const [cfgPath, original] of originalCfgs) {
-        try {
-          fs.writeFileSync(cfgPath, JSON.stringify(original, null, 2));
-        } catch {
-          /* ignore */
-        }
-      }
+      restore();
       reject(err);
     });
   });

--- a/src/deps.js
+++ b/src/deps.js
@@ -8,8 +8,9 @@ import fs from 'fs';
 import https from 'https';
 import { createWriteStream } from 'fs';
 import { app } from 'electron';
-import { exec } from 'child_process';
+import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
+import { installTidalDlNg, findTidalDlPath } from './audio/tidalDlManager.js';
 
 const execAsync = promisify(exec);
 
@@ -67,7 +68,78 @@ export function getInstalledVersions() {
     ffmpeg: readVersion('ffmpeg'),
     analyzer: readVersion('analyzer'),
     ytDlp: readVersion('yt-dlp'),
+    tidalDlNg: readVersion('tidal-dl-ng'),
   };
+}
+
+async function getTidalDlNgVersion() {
+  const cmds =
+    process.platform === 'win32'
+      ? ['pip show tidal-dl-ng', 'python -m pip show tidal-dl-ng']
+      : ['pip3 show tidal-dl-ng', 'pip show tidal-dl-ng', 'python3 -m pip show tidal-dl-ng'];
+  for (const cmd of cmds) {
+    try {
+      const { stdout } = await execAsync(cmd);
+      const match = stdout.match(/^Version:\s*(.+)$/m);
+      if (match) return match[1].trim();
+    } catch {
+      /* try next */
+    }
+  }
+  return 'installed';
+}
+
+async function installTidalDlNgDep(onProgress) {
+  await installTidalDlNg((line) => onProgress?.(line, -1));
+  const version = await getTidalDlNgVersion();
+  writeVersion('tidal-dl-ng', { version, installedAt: new Date().toISOString() });
+}
+
+async function upgradeTidalDlNgDep(onProgress) {
+  const candidates =
+    process.platform === 'win32'
+      ? [
+          ['pip', ['install', '--upgrade', 'tidal-dl-ng']],
+          ['python', ['-m', 'pip', 'install', '--upgrade', 'tidal-dl-ng']],
+        ]
+      : [
+          ['pip3', ['install', '--upgrade', 'tidal-dl-ng']],
+          ['pip', ['install', '--upgrade', 'tidal-dl-ng']],
+          ['python3', ['-m', 'pip', 'install', '--upgrade', 'tidal-dl-ng']],
+          ['python', ['-m', 'pip', 'install', '--upgrade', 'tidal-dl-ng']],
+        ];
+
+  let lastErr;
+  for (const [cmd, args] of candidates) {
+    try {
+      await new Promise((resolve, reject) => {
+        const proc = spawn(cmd, args, {
+          env: { ...process.env, PYTHONUNBUFFERED: '1' },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        proc.stdout.on('data', (chunk) => {
+          for (const line of chunk.toString().split('\n')) {
+            const t = line.trim();
+            if (t) onProgress?.(t, -1);
+          }
+        });
+        proc.stderr.on('data', (chunk) => {
+          for (const line of chunk.toString().split('\n')) {
+            const t = line.trim();
+            if (t) onProgress?.(t, -1);
+          }
+        });
+        proc.on('close', (code) => (code === 0 ? resolve() : reject(new Error(`exit ${code}`))));
+        proc.on('error', reject);
+      });
+      const version = await getTidalDlNgVersion();
+      writeVersion('tidal-dl-ng', { version, installedAt: new Date().toISOString() });
+      return;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr ?? new Error('Could not find pip to upgrade tidal-dl-ng');
 }
 
 // ── Readiness ─────────────────────────────────────────────────────────────────
@@ -432,14 +504,19 @@ export async function ensureDeps(onProgress) {
     fs.existsSync(getFfmpegRuntimePath()) && fs.existsSync(getFfprobeRuntimePath());
   const analyzerReady = fs.existsSync(getAnalyzerRuntimePath());
   const ytDlpReady = fs.existsSync(getYtDlpRuntimePath());
-  if (ffmpegReady && analyzerReady && ytDlpReady) return;
+  const tidalReady = Boolean(findTidalDlPath());
+  if (ffmpegReady && analyzerReady && ytDlpReady && tidalReady) return;
 
   const binDir = getBinDir();
   await fs.promises.mkdir(binDir, { recursive: true });
   const tmp = path.join(app.getPath('temp'), 'djman-deps');
   await fs.promises.mkdir(tmp, { recursive: true });
 
-  const totalSteps = (!ffmpegReady ? 1 : 0) + (!analyzerReady ? 1 : 0) + (!ytDlpReady ? 1 : 0);
+  const totalSteps =
+    (!ffmpegReady ? 1 : 0) +
+    (!analyzerReady ? 1 : 0) +
+    (!ytDlpReady ? 1 : 0) +
+    (!tidalReady ? 1 : 0);
   let step = 0;
   const stepCb = (msg, pct) => onProgress?.(`[${step}/${totalSteps}] ${msg}`, pct);
 
@@ -455,6 +532,17 @@ export async function ensureDeps(onProgress) {
     if (!ytDlpReady) {
       step++;
       await downloadYtDlp(tmp, stepCb);
+    }
+    if (!tidalReady) {
+      step++;
+      stepCb('Installing tidal-dl-ng…', 0);
+      try {
+        await installTidalDlNgDep((msg) => stepCb(msg, -1));
+        stepCb('tidal-dl-ng installed.', 100);
+      } catch (err) {
+        console.warn('[deps] tidal-dl-ng install failed (non-fatal):', err.message);
+        stepCb('tidal-dl-ng install failed — Python 3.12+ may not be available.', -1);
+      }
     }
     onProgress?.('Setup complete.', 100);
   } finally {
@@ -519,15 +607,32 @@ export async function updateYtDlp(onProgress, tag = null) {
   }
 }
 
+export async function updateTidalDlNg(onProgress) {
+  try {
+    onProgress?.('Upgrading tidal-dl-ng…', 0);
+    await upgradeTidalDlNgDep(onProgress);
+    onProgress?.('tidal-dl-ng updated.', 100);
+  } catch (err) {
+    onProgress?.(`tidal-dl-ng update failed: ${err.message}`, -1);
+    throw err;
+  }
+}
+
 export async function updateAll(onProgress) {
   const binDir = getBinDir();
   await fs.promises.mkdir(binDir, { recursive: true });
   const tmp = path.join(app.getPath('temp'), 'djman-deps');
   await fs.promises.mkdir(tmp, { recursive: true });
   try {
-    await downloadFFmpeg(tmp, (msg, pct) => onProgress?.(`[1/3] ${msg}`, pct));
-    await downloadAnalyzer(tmp, (msg, pct) => onProgress?.(`[2/3] ${msg}`, pct));
-    await downloadYtDlp(tmp, (msg, pct) => onProgress?.(`[3/3] ${msg}`, pct));
+    await downloadFFmpeg(tmp, (msg, pct) => onProgress?.(`[1/4] ${msg}`, pct));
+    await downloadAnalyzer(tmp, (msg, pct) => onProgress?.(`[2/4] ${msg}`, pct));
+    await downloadYtDlp(tmp, (msg, pct) => onProgress?.(`[3/4] ${msg}`, pct));
+    onProgress?.('[4/4] Upgrading tidal-dl-ng…', 0);
+    try {
+      await upgradeTidalDlNgDep((msg) => onProgress?.(`[4/4] ${msg}`, -1));
+    } catch (err) {
+      console.warn('[deps] tidal-dl-ng upgrade failed (non-fatal):', err.message);
+    }
     onProgress?.('All dependencies updated.', 100);
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });

--- a/src/deps.js
+++ b/src/deps.js
@@ -10,8 +10,7 @@ import { createWriteStream } from 'fs';
 import { app } from 'electron';
 import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
-import { installTidalDlNg, findTidalDlPath } from './audio/tidalDlManager.js';
-
+import { findTidalDlPath } from './audio/tidalDlManager.js';
 const execAsync = promisify(exec);
 
 // ── Paths ─────────────────────────────────────────────────────────────────────
@@ -46,6 +45,10 @@ export function getYtDlpRuntimePath() {
   return path.join(getBinDir(), 'yt-dlp');
 }
 
+export function getUvRuntimePath() {
+  return path.join(getBinDir(), process.platform === 'win32' ? 'uv.exe' : 'uv');
+}
+
 function versionFile(name) {
   return path.join(getBinDir(), `${name}.version`);
 }
@@ -73,6 +76,17 @@ export function getInstalledVersions() {
 }
 
 async function getTidalDlNgVersion() {
+  const uvPath = getUvRuntimePath();
+  if (fs.existsSync(uvPath)) {
+    try {
+      const { stdout } = await execAsync(`"${uvPath}" tool list`);
+      const match = stdout.match(/tidal-dl-ng\s+v?([\d.]+)/i);
+      if (match) return match[1];
+    } catch {
+      /* fall through */
+    }
+  }
+  // Fallback: pip show
   const cmds =
     process.platform === 'win32'
       ? ['pip show tidal-dl-ng', 'python -m pip show tidal-dl-ng']
@@ -89,57 +103,159 @@ async function getTidalDlNgVersion() {
   return 'installed';
 }
 
+async function downloadUvBinary(onProgress) {
+  const { platform, arch } = process;
+  const assetMap = {
+    linux:
+      arch === 'arm64'
+        ? 'uv-aarch64-unknown-linux-gnu.tar.gz'
+        : 'uv-x86_64-unknown-linux-gnu.tar.gz',
+    darwin: arch === 'arm64' ? 'uv-aarch64-apple-darwin.tar.gz' : 'uv-x86_64-apple-darwin.tar.gz',
+    win32: 'uv-x86_64-pc-windows-msvc.zip',
+  };
+  const assetName = assetMap[platform];
+  if (!assetName) throw new Error(`Unsupported platform for uv: ${platform}`);
+
+  const release = await getLatestRelease('astral-sh', 'uv');
+  const asset = release.assets.find((a) => a.name === assetName);
+  if (!asset) throw new Error(`No uv asset found: ${assetName}`);
+
+  const tmp = path.join(app.getPath('temp'), 'djman-uv-dl');
+  await fs.promises.mkdir(tmp, { recursive: true });
+  try {
+    const archive = path.join(tmp, assetName);
+    await downloadFile(
+      asset.browser_download_url,
+      archive,
+      (r, t) => t > 0 && onProgress?.(`Downloading uv… ${Math.round((r / t) * 100)}%`, -1)
+    );
+    const dir = path.join(tmp, 'extracted');
+    if (assetName.endsWith('.tar.gz')) await extractTarGz(archive, dir);
+    else await extractZip(archive, dir);
+
+    const uvBinName = platform === 'win32' ? 'uv.exe' : 'uv';
+    const uvSrc = await findFile(dir, uvBinName);
+    if (!uvSrc) throw new Error('uv binary not found in archive');
+
+    const dest = getUvRuntimePath();
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(uvSrc, dest);
+    if (platform !== 'win32') fs.chmodSync(dest, 0o755);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 async function installTidalDlNgDep(onProgress) {
-  await installTidalDlNg((line) => onProgress?.(line, -1));
+  let uvPath = getUvRuntimePath();
+  if (!fs.existsSync(uvPath)) {
+    onProgress?.('Downloading uv…', -1);
+    await downloadUvBinary(onProgress);
+    uvPath = getUvRuntimePath();
+  }
+
+  onProgress?.('Installing tidal-dl-ng…', -1);
+  await new Promise((resolve, reject) => {
+    const proc = spawn(uvPath, ['tool', 'install', '--reinstall', 'tidal-dl-ng'], {
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    proc.stdout.on('data', (chunk) => {
+      for (const line of chunk.toString().split('\n')) {
+        const t = line.trim();
+        if (t) onProgress?.(t, -1);
+      }
+    });
+    proc.stderr.on('data', (chunk) => {
+      for (const line of chunk.toString().split('\n')) {
+        const t = line.trim();
+        if (t) onProgress?.(t, -1);
+      }
+    });
+    proc.on('close', (code) =>
+      code === 0 ? resolve() : reject(new Error(`uv tool install exited with code ${code}`))
+    );
+    proc.on('error', reject);
+  });
+
   const version = await getTidalDlNgVersion();
   writeVersion('tidal-dl-ng', { version, installedAt: new Date().toISOString() });
 }
 
-async function upgradeTidalDlNgDep(onProgress) {
-  const candidates =
-    process.platform === 'win32'
-      ? [
-          ['pip', ['install', '--upgrade', 'tidal-dl-ng']],
-          ['python', ['-m', 'pip', 'install', '--upgrade', 'tidal-dl-ng']],
-        ]
-      : [
-          ['pip3', ['install', '--upgrade', 'tidal-dl-ng']],
-          ['pip', ['install', '--upgrade', 'tidal-dl-ng']],
-          ['python3', ['-m', 'pip', 'install', '--upgrade', 'tidal-dl-ng']],
-          ['python', ['-m', 'pip', 'install', '--upgrade', 'tidal-dl-ng']],
-        ];
+export { installTidalDlNgDep as ensureTidalDlNg };
 
-  let lastErr;
-  for (const [cmd, args] of candidates) {
-    try {
-      await new Promise((resolve, reject) => {
-        const proc = spawn(cmd, args, {
-          env: { ...process.env, PYTHONUNBUFFERED: '1' },
-          stdio: ['ignore', 'pipe', 'pipe'],
-        });
-        proc.stdout.on('data', (chunk) => {
-          for (const line of chunk.toString().split('\n')) {
-            const t = line.trim();
-            if (t) onProgress?.(t, -1);
-          }
-        });
-        proc.stderr.on('data', (chunk) => {
-          for (const line of chunk.toString().split('\n')) {
-            const t = line.trim();
-            if (t) onProgress?.(t, -1);
-          }
-        });
-        proc.on('close', (code) => (code === 0 ? resolve() : reject(new Error(`exit ${code}`))));
-        proc.on('error', reject);
+async function upgradeTidalDlNgDep(onProgress) {
+  const uvPath = getUvRuntimePath();
+  if (fs.existsSync(uvPath)) {
+    await new Promise((resolve, reject) => {
+      const proc = spawn(uvPath, ['tool', 'upgrade', 'tidal-dl-ng'], {
+        env: { ...process.env },
+        stdio: ['ignore', 'pipe', 'pipe'],
       });
-      const version = await getTidalDlNgVersion();
-      writeVersion('tidal-dl-ng', { version, installedAt: new Date().toISOString() });
-      return;
-    } catch (err) {
-      lastErr = err;
+      proc.stdout.on('data', (chunk) => {
+        for (const line of chunk.toString().split('\n')) {
+          const t = line.trim();
+          if (t) onProgress?.(t, -1);
+        }
+      });
+      proc.stderr.on('data', (chunk) => {
+        for (const line of chunk.toString().split('\n')) {
+          const t = line.trim();
+          if (t) onProgress?.(t, -1);
+        }
+      });
+      proc.on('close', (code) =>
+        code === 0 ? resolve() : reject(new Error(`uv tool upgrade exited with code ${code}`))
+      );
+      proc.on('error', reject);
+    });
+  } else {
+    // Fallback: pip upgrade
+    const candidates =
+      process.platform === 'win32'
+        ? [
+            ['pip', ['install', '--upgrade', 'tidal-dl-ng']],
+            ['python', ['-m', 'pip', 'install', '--upgrade', 'tidal-dl-ng']],
+          ]
+        : [
+            ['pip3', ['install', '--upgrade', 'tidal-dl-ng']],
+            ['pip', ['install', '--upgrade', 'tidal-dl-ng']],
+            ['python3', ['-m', 'pip', 'install', '--upgrade', 'tidal-dl-ng']],
+            ['python', ['-m', 'pip', 'install', '--upgrade', 'tidal-dl-ng']],
+          ];
+    let lastErr;
+    for (const [cmd, args] of candidates) {
+      try {
+        await new Promise((resolve, reject) => {
+          const proc = spawn(cmd, args, {
+            env: { ...process.env, PYTHONUNBUFFERED: '1' },
+            stdio: ['ignore', 'pipe', 'pipe'],
+          });
+          proc.stdout.on('data', (chunk) => {
+            for (const line of chunk.toString().split('\n')) {
+              const t = line.trim();
+              if (t) onProgress?.(t, -1);
+            }
+          });
+          proc.stderr.on('data', (chunk) => {
+            for (const line of chunk.toString().split('\n')) {
+              const t = line.trim();
+              if (t) onProgress?.(t, -1);
+            }
+          });
+          proc.on('close', (code) => (code === 0 ? resolve() : reject(new Error(`exit ${code}`))));
+          proc.on('error', reject);
+        });
+        break;
+      } catch (err) {
+        lastErr = err;
+      }
     }
+    if (lastErr) throw lastErr;
   }
-  throw lastErr ?? new Error('Could not find pip to upgrade tidal-dl-ng');
+
+  const version = await getTidalDlNgVersion();
+  writeVersion('tidal-dl-ng', { version, installedAt: new Date().toISOString() });
 }
 
 // ── Readiness ─────────────────────────────────────────────────────────────────

--- a/src/deps.js
+++ b/src/deps.js
@@ -80,7 +80,7 @@ async function getTidalDlNgVersion() {
   if (fs.existsSync(uvPath)) {
     try {
       const { stdout } = await execAsync(`"${uvPath}" tool list`);
-      const match = stdout.match(/tidal-dl-ng\s+v?([\d.]+)/i);
+      const match = stdout.match(/tidal-dl-ng(?:-for-dj)?\s+v?([\d.]+)/i);
       if (match) return match[1];
     } catch {
       /* fall through */
@@ -156,10 +156,14 @@ async function installTidalDlNgDep(onProgress) {
 
   onProgress?.('Installing tidal-dl-ng…', -1);
   await new Promise((resolve, reject) => {
-    const proc = spawn(uvPath, ['tool', 'install', '--reinstall', 'tidal-dl-ng'], {
-      env: { ...process.env },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    const proc = spawn(
+      uvPath,
+      ['tool', 'install', '--reinstall', 'git+https://github.com/Radexito/tidal-dl-ng-For-DJ.git'],
+      {
+        env: { ...process.env },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
     proc.stdout.on('data', (chunk) => {
       for (const line of chunk.toString().split('\n')) {
         const t = line.trim();
@@ -188,10 +192,19 @@ async function upgradeTidalDlNgDep(onProgress) {
   const uvPath = getUvRuntimePath();
   if (fs.existsSync(uvPath)) {
     await new Promise((resolve, reject) => {
-      const proc = spawn(uvPath, ['tool', 'upgrade', 'tidal-dl-ng'], {
-        env: { ...process.env },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
+      const proc = spawn(
+        uvPath,
+        [
+          'tool',
+          'install',
+          '--reinstall',
+          'git+https://github.com/Radexito/tidal-dl-ng-For-DJ.git',
+        ],
+        {
+          env: { ...process.env },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }
+      );
       proc.stdout.on('data', (chunk) => {
         for (const line of chunk.toString().split('\n')) {
           const t = line.trim();

--- a/src/main.js
+++ b/src/main.js
@@ -86,6 +86,7 @@ import {
   checkForUpdates,
   updateAnalyzer,
   updateYtDlp,
+  updateTidalDlNg,
   updateAll,
 } from './deps.js';
 import { initLogger, getLogDir } from './logger.js';
@@ -618,6 +619,19 @@ ipcMain.handle('update-all-deps', async (_event) => {
     if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', { msg, pct });
   });
   if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', null);
+});
+
+ipcMain.handle('update-tidal-dl-ng', async (_event) => {
+  try {
+    await updateTidalDlNg((msg, pct) => {
+      if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', { msg, pct });
+    });
+    if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', null);
+    return { ok: true };
+  } catch (err) {
+    if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', null);
+    return { ok: false, error: err.message };
+  }
 });
 
 // ─── Auto-tagger ──────────────────────────────────────────────────────────────

--- a/src/main.js
+++ b/src/main.js
@@ -78,6 +78,7 @@ import {
   checkTidalSetup,
   startLogin as tidalStartLogin,
   downloadTidal,
+  fetchTidalInfo,
 } from './audio/tidalDlManager.js';
 import { ensureDeps, getFfmpegRuntimePath } from './deps.js';
 import {
@@ -931,6 +932,18 @@ ipcMain.handle('tidal-install', async () => {
   }
 });
 
+ipcMain.handle('tidal-fetch-info', async (_event, url) => {
+  console.log('[tidal-fetch-info] fetching info for:', url);
+  try {
+    const info = await fetchTidalInfo(url);
+    console.log(`[tidal-fetch-info] ok — type=${info.type} entries=${info.entries?.length}`);
+    return info;
+  } catch (err) {
+    console.error('[tidal-fetch-info] error:', err.message);
+    return { ok: false, error: err.message };
+  }
+});
+
 ipcMain.handle('tidal-login', async () => {
   try {
     await tidalStartLogin((url) => {
@@ -944,40 +957,69 @@ ipcMain.handle('tidal-login', async () => {
 
 ipcMain.handle(
   'tidal-download-url',
-  async (_event, { url, existingPlaylistId, newPlaylistName }) => {
-    const sendProgress = (msg) => {
-      if (global.mainWindow) global.mainWindow.webContents.send('tidal-progress', { msg });
+  async (_event, { url, selectedEntries, existingPlaylistId, newPlaylistName }) => {
+    const send = (ch, data) => {
+      if (global.mainWindow) global.mainWindow.webContents.send(ch, data);
     };
+    const sendTrackUpdate = (data) => send('tidal-track-update', data);
+    const sendProgress = (msg) => send('tidal-progress', { msg });
 
     try {
-      sendProgress('Starting download…');
-
       const tmpDir = path.join(app.getPath('userData'), 'tidal_tmp');
 
-      const files = await downloadTidal(url, tmpDir, sendProgress);
+      // Resolve the download URLs: individual track URLs when selectedEntries are provided,
+      // otherwise the raw URL (for mixes and direct single-URL downloads).
+      const downloadUrls =
+        selectedEntries?.length > 0
+          ? selectedEntries.map((e) => `https://tidal.com/browse/track/${e.id}`)
+          : [url];
 
-      if (files.length === 0) {
-        return { ok: false, error: 'Download finished but no audio files were found.' };
-      }
-
-      sendProgress('Importing to library…');
-
+      // Create playlist before starting download so tracks can be added progressively.
       let playlistId = null;
-      const trackIds = [];
-
       if (existingPlaylistId) {
         playlistId = existingPlaylistId;
-      } else if (newPlaylistName) {
+      } else if (newPlaylistName?.trim()) {
         try {
-          const { id } = findOrCreatePlaylist(newPlaylistName, null, url);
+          const { id } = findOrCreatePlaylist(newPlaylistName.trim(), null, url);
           playlistId = id;
-          if (global.mainWindow) global.mainWindow.webContents.send('playlists-updated');
+          send('playlists-updated');
         } catch (err) {
           console.error('[tidal] findOrCreatePlaylist failed:', err.message);
         }
       }
 
-      for (const filePath of files) {
+      // Emit init event so the UI can render the full track list immediately.
+      if (selectedEntries?.length > 0) {
+        sendTrackUpdate({ type: 'init', tracks: selectedEntries });
+      }
+
+      const trackIds = [];
+      // fileIndex tracks which selectedEntry corresponds to the next file reported by onFileReady.
+      // tdn downloads in the order we pass URLs, so positional matching is reliable.
+      let fileIndex = 0;
+
+      const onFileReady = async (filePath) => {
+        const entry = selectedEntries?.[fileIndex] ?? null;
+        const idx = fileIndex;
+        fileIndex++;
+
+        if (entry) {
+          sendTrackUpdate({
+            index: idx,
+            title: entry.title,
+            artist: entry.artist,
+            status: 'importing',
+          });
+        } else {
+          // No entry info (e.g. mix download) — emit a generic update
+          sendTrackUpdate({
+            index: idx,
+            title: path.basename(filePath),
+            artist: '',
+            status: 'importing',
+          });
+        }
+
         try {
           const trackId = await importAudioFile(filePath, {
             source_url: url,
@@ -986,18 +1028,40 @@ ipcMain.handle(
           trackIds.push(trackId);
           if (playlistId) {
             addTrackToPlaylist(playlistId, trackId);
-            if (global.mainWindow) global.mainWindow.webContents.send('playlists-updated');
+            send('playlists-updated');
           }
-          if (global.mainWindow) global.mainWindow.webContents.send('library-updated');
+          send('library-updated');
+          sendTrackUpdate({
+            index: idx,
+            title: entry?.title ?? path.basename(filePath),
+            artist: entry?.artist ?? '',
+            status: 'done',
+            trackId,
+          });
         } catch (err) {
           console.error('[tidal] importAudioFile failed:', err.message);
+          sendTrackUpdate({
+            index: idx,
+            title: entry?.title ?? path.basename(filePath),
+            artist: entry?.artist ?? '',
+            status: 'failed',
+            error: err.message,
+          });
         }
+      };
+
+      sendProgress('Starting download…');
+      const files = await downloadTidal(downloadUrls, tmpDir, sendProgress, { onFileReady });
+
+      send('tidal-progress', null);
+
+      if (files.length === 0 && trackIds.length === 0) {
+        return { ok: false, error: 'Download finished but no audio files were found.' };
       }
 
-      if (global.mainWindow) global.mainWindow.webContents.send('tidal-progress', null);
       return { ok: true, trackIds, playlistId: playlistId ?? null };
     } catch (err) {
-      if (global.mainWindow) global.mainWindow.webContents.send('tidal-progress', null);
+      send('tidal-progress', null);
       return { ok: false, error: err.message };
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -78,7 +78,6 @@ import {
   checkTidalSetup,
   startLogin as tidalStartLogin,
   downloadTidal,
-  installTidalDlNg,
 } from './audio/tidalDlManager.js';
 import { ensureDeps, getFfmpegRuntimePath } from './deps.js';
 import {
@@ -87,6 +86,7 @@ import {
   updateAnalyzer,
   updateYtDlp,
   updateTidalDlNg,
+  ensureTidalDlNg,
   updateAll,
 } from './deps.js';
 import { initLogger, getLogDir } from './logger.js';
@@ -921,7 +921,7 @@ ipcMain.handle('tidal-check', async () => {
 
 ipcMain.handle('tidal-install', async () => {
   try {
-    await installTidalDlNg((line) => {
+    await ensureTidalDlNg((line) => {
       if (global.mainWindow)
         global.mainWindow.webContents.send('tidal-install-progress', { msg: line });
     });

--- a/src/main.js
+++ b/src/main.js
@@ -74,6 +74,11 @@ import {
   downloadUrl as ytDlpDownloadUrl,
   fetchPlaylistInfo as ytDlpFetchPlaylistInfo,
 } from './audio/ytDlpManager.js';
+import {
+  checkTidalSetup,
+  startLogin as tidalStartLogin,
+  downloadTidal,
+} from './audio/tidalDlManager.js';
 import { ensureDeps, getFfmpegRuntimePath } from './deps.js';
 import {
   getInstalledVersions,
@@ -892,6 +897,84 @@ ipcMain.handle(
 ipcMain.handle('open-external', async (_event, url) => {
   shell.openExternal(url);
 });
+
+// ─── TIDAL download ───────────────────────────────────────────────────────────
+
+ipcMain.handle('tidal-check', async () => {
+  return checkTidalSetup();
+});
+
+ipcMain.handle('tidal-login', async () => {
+  try {
+    await tidalStartLogin((url) => {
+      if (global.mainWindow) global.mainWindow.webContents.send('tidal-login-url', url);
+    });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+});
+
+ipcMain.handle(
+  'tidal-download-url',
+  async (_event, { url, existingPlaylistId, newPlaylistName }) => {
+    const sendProgress = (msg) => {
+      if (global.mainWindow) global.mainWindow.webContents.send('tidal-progress', { msg });
+    };
+
+    try {
+      sendProgress('Starting download…');
+
+      const tmpDir = path.join(app.getPath('userData'), 'tidal_tmp');
+
+      const files = await downloadTidal(url, tmpDir, sendProgress);
+
+      if (files.length === 0) {
+        return { ok: false, error: 'Download finished but no audio files were found.' };
+      }
+
+      sendProgress('Importing to library…');
+
+      let playlistId = null;
+      const trackIds = [];
+
+      if (existingPlaylistId) {
+        playlistId = existingPlaylistId;
+      } else if (newPlaylistName) {
+        try {
+          const { id } = findOrCreatePlaylist(newPlaylistName, null, url);
+          playlistId = id;
+          if (global.mainWindow) global.mainWindow.webContents.send('playlists-updated');
+        } catch (err) {
+          console.error('[tidal] findOrCreatePlaylist failed:', err.message);
+        }
+      }
+
+      for (const filePath of files) {
+        try {
+          const trackId = await importAudioFile(filePath, {
+            source_url: url,
+            source_platform: 'tidal',
+          });
+          trackIds.push(trackId);
+          if (playlistId) {
+            addTrackToPlaylist(playlistId, trackId);
+            if (global.mainWindow) global.mainWindow.webContents.send('playlists-updated');
+          }
+          if (global.mainWindow) global.mainWindow.webContents.send('library-updated');
+        } catch (err) {
+          console.error('[tidal] importAudioFile failed:', err.message);
+        }
+      }
+
+      if (global.mainWindow) global.mainWindow.webContents.send('tidal-progress', null);
+      return { ok: true, trackIds, playlistId: playlistId ?? null };
+    } catch (err) {
+      if (global.mainWindow) global.mainWindow.webContents.send('tidal-progress', null);
+      return { ok: false, error: err.message };
+    }
+  }
+);
 
 // ─── USB / Rekordbox Export ────────────────────────────────────────────────────
 

--- a/src/main.js
+++ b/src/main.js
@@ -78,6 +78,7 @@ import {
   checkTidalSetup,
   startLogin as tidalStartLogin,
   downloadTidal,
+  installTidalDlNg,
 } from './audio/tidalDlManager.js';
 import { ensureDeps, getFfmpegRuntimePath } from './deps.js';
 import {
@@ -902,6 +903,18 @@ ipcMain.handle('open-external', async (_event, url) => {
 
 ipcMain.handle('tidal-check', async () => {
   return checkTidalSetup();
+});
+
+ipcMain.handle('tidal-install', async () => {
+  try {
+    await installTidalDlNg((line) => {
+      if (global.mainWindow)
+        global.mainWindow.webContents.send('tidal-install-progress', { msg: line });
+    });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
 });
 
 ipcMain.handle('tidal-login', async () => {

--- a/src/main.js
+++ b/src/main.js
@@ -1021,8 +1021,10 @@ ipcMain.handle(
         }
 
         try {
+          const trackSourceUrl = entry?.id ? `https://tidal.com/browse/track/${entry.id}` : url;
           const trackId = await importAudioFile(filePath, {
-            source_url: url,
+            source_url: trackSourceUrl,
+            source_link: url !== trackSourceUrl ? url : null,
             source_platform: 'tidal',
           });
           trackIds.push(trackId);

--- a/src/main.js
+++ b/src/main.js
@@ -957,7 +957,7 @@ ipcMain.handle('tidal-login', async () => {
 
 ipcMain.handle(
   'tidal-download-url',
-  async (_event, { url, selectedEntries, existingPlaylistId, newPlaylistName }) => {
+  async (_event, { url, selectedEntries, linkTrackIds, existingPlaylistId, newPlaylistName }) => {
     const send = (ch, data) => {
       if (global.mainWindow) global.mainWindow.webContents.send(ch, data);
     };
@@ -1051,14 +1051,30 @@ ipcMain.handle(
       };
 
       sendProgress('Starting download…');
-      const files = await downloadTidal(downloadUrls, tmpDir, sendProgress, { onFileReady });
 
-      send('tidal-progress', null);
-
-      if (files.length === 0 && trackIds.length === 0) {
-        return { ok: false, error: 'Download finished but no audio files were found.' };
+      // Only call tdn if there are new tracks to download
+      const hasDownloads = selectedEntries?.length > 0 || !selectedEntries;
+      if (hasDownloads) {
+        const files = await downloadTidal(downloadUrls, tmpDir, sendProgress, { onFileReady });
+        if (files.length === 0 && trackIds.length === 0 && (linkTrackIds?.length ?? 0) === 0) {
+          send('tidal-progress', null);
+          return { ok: false, error: 'Download finished but no audio files were found.' };
+        }
       }
 
+      // Link already-in-library tracks to the playlist (no re-download needed)
+      if (linkTrackIds?.length > 0 && playlistId) {
+        for (const tid of linkTrackIds) {
+          try {
+            addTrackToPlaylist(playlistId, tid);
+          } catch {
+            // ignore duplicate playlist entry errors
+          }
+        }
+        send('playlists-updated');
+      }
+
+      send('tidal-progress', null);
       return { ok: true, trackIds, playlistId: playlistId ?? null };
     } catch (err) {
       send('tidal-progress', null);

--- a/src/preload.js
+++ b/src/preload.js
@@ -151,6 +151,7 @@ contextBridge.exposeInMainWorld('api', {
   // TIDAL download
   tidalCheck: () => ipcRenderer.invoke('tidal-check'),
   tidalInstall: () => ipcRenderer.invoke('tidal-install'),
+  tidalFetchInfo: (url) => ipcRenderer.invoke('tidal-fetch-info', url),
   tidalLogin: () => ipcRenderer.invoke('tidal-login'),
   tidalDownloadUrl: (opts) => ipcRenderer.invoke('tidal-download-url', opts),
   onTidalProgress: (cb) => {
@@ -167,6 +168,11 @@ contextBridge.exposeInMainWorld('api', {
     const handler = (_, data) => cb(data);
     ipcRenderer.on('tidal-install-progress', handler);
     return () => ipcRenderer.removeListener('tidal-install-progress', handler);
+  },
+  onTidalTrackUpdate: (cb) => {
+    const handler = (_, data) => cb(data);
+    ipcRenderer.on('tidal-track-update', handler);
+    return () => ipcRenderer.removeListener('tidal-track-update', handler);
   },
 
   clearLibrary: () => ipcRenderer.invoke('clear-library'),

--- a/src/preload.js
+++ b/src/preload.js
@@ -145,6 +145,7 @@ contextBridge.exposeInMainWorld('api', {
     return () => ipcRenderer.removeListener('ytdlp-track-update', handler);
   },
   updateYtDlp: (tag) => ipcRenderer.invoke('update-yt-dlp', tag ?? null),
+  updateTidalDlNg: () => ipcRenderer.invoke('update-tidal-dl-ng'),
   openExternal: (url) => ipcRenderer.invoke('open-external', url),
 
   // TIDAL download

--- a/src/preload.js
+++ b/src/preload.js
@@ -147,6 +147,21 @@ contextBridge.exposeInMainWorld('api', {
   updateYtDlp: (tag) => ipcRenderer.invoke('update-yt-dlp', tag ?? null),
   openExternal: (url) => ipcRenderer.invoke('open-external', url),
 
+  // TIDAL download
+  tidalCheck: () => ipcRenderer.invoke('tidal-check'),
+  tidalLogin: () => ipcRenderer.invoke('tidal-login'),
+  tidalDownloadUrl: (opts) => ipcRenderer.invoke('tidal-download-url', opts),
+  onTidalProgress: (cb) => {
+    const handler = (_, data) => cb(data);
+    ipcRenderer.on('tidal-progress', handler);
+    return () => ipcRenderer.removeListener('tidal-progress', handler);
+  },
+  onTidalLoginUrl: (cb) => {
+    const handler = (_, url) => cb(url);
+    ipcRenderer.on('tidal-login-url', handler);
+    return () => ipcRenderer.removeListener('tidal-login-url', handler);
+  },
+
   clearLibrary: () => ipcRenderer.invoke('clear-library'),
   clearUserData: () => ipcRenderer.invoke('clear-user-data'),
   getLogDir: () => ipcRenderer.invoke('get-log-dir'),

--- a/src/preload.js
+++ b/src/preload.js
@@ -149,6 +149,7 @@ contextBridge.exposeInMainWorld('api', {
 
   // TIDAL download
   tidalCheck: () => ipcRenderer.invoke('tidal-check'),
+  tidalInstall: () => ipcRenderer.invoke('tidal-install'),
   tidalLogin: () => ipcRenderer.invoke('tidal-login'),
   tidalDownloadUrl: (opts) => ipcRenderer.invoke('tidal-download-url', opts),
   onTidalProgress: (cb) => {
@@ -160,6 +161,11 @@ contextBridge.exposeInMainWorld('api', {
     const handler = (_, url) => cb(url);
     ipcRenderer.on('tidal-login-url', handler);
     return () => ipcRenderer.removeListener('tidal-login-url', handler);
+  },
+  onTidalInstallProgress: (cb) => {
+    const handler = (_, data) => cb(data);
+    ipcRenderer.on('tidal-install-progress', handler);
+    return () => ipcRenderer.removeListener('tidal-install-progress', handler);
   },
 
   clearLibrary: () => ipcRenderer.invoke('clear-library'),


### PR DESCRIPTION
Rebased onto latest `dev`.

Adds a TIDAL download tab powered by tidal-dl-ng, including:
- TIDAL setup/login flow
- Download by track, album, playlist, or mix URL
- Progress reporting and download history
- `TidalDownloadView` component (always-mounted, state preserved on tab switch)