### PR TITLE
feat: use channel name as artist when video title has no artist delimiter

### DIFF
--- a/src/__tests__/importManager.test.js
+++ b/src/__tests__/importManager.test.js
@@ -292,6 +292,55 @@ describe('importAudioFile — artist detection from filename', () => {
     expect(mockAddTrack.mock.calls[0][0].title).toBe('untitled_track');
   });
 
+  it('uses channel name as artist when no tag, no dash in filename, and channel provided', async () => {
+    ffprobe.mockResolvedValueOnce({
+      format: {
+        format_name: 'mp3',
+        duration: '180.0',
+        bit_rate: '320000',
+        tags: { title: 'Midnight Dreams', artist: '' },
+      },
+      streams: [],
+    });
+
+    await importAudioFile('/music/Midnight Dreams [abc123].mp3', { channel: 'DJ Koze' });
+
+    expect(mockAddTrack.mock.calls[0][0].artist).toBe('DJ Koze');
+    expect(mockAddTrack.mock.calls[0][0].title).toBe('Midnight Dreams');
+  });
+
+  it('does not overwrite ID3 artist with channel name', async () => {
+    ffprobe.mockResolvedValueOnce({
+      format: {
+        format_name: 'mp3',
+        duration: '180.0',
+        bit_rate: '320000',
+        tags: { title: 'Some Track', artist: 'Real Artist' },
+      },
+      streams: [],
+    });
+
+    await importAudioFile('/music/Some Track [abc123].mp3', { channel: 'Channel Name' });
+
+    expect(mockAddTrack.mock.calls[0][0].artist).toBe('Real Artist');
+  });
+
+  it('does not overwrite filename-parsed artist with channel name', async () => {
+    ffprobe.mockResolvedValueOnce({
+      format: {
+        format_name: 'mp3',
+        duration: '180.0',
+        bit_rate: '320000',
+        tags: { title: '', artist: '' },
+      },
+      streams: [],
+    });
+
+    await importAudioFile('/music/Deadmau5 - Some Track [abc123].mp3', { channel: 'Channel Name' });
+
+    expect(mockAddTrack.mock.calls[0][0].artist).toBe('Deadmau5');
+  });
+
   it('keeps ID3 title when artist is missing but filename has dash', async () => {
     ffprobe.mockResolvedValueOnce({
       format: {

--- a/src/audio/importManager.js
+++ b/src/audio/importManager.js
@@ -233,6 +233,11 @@ export async function importAudioFile(filePath, sourceMeta = {}) {
     }
   }
 
+  // Last-resort fallback: use channel/uploader name as artist when still empty
+  if (!resolvedArtist && sourceMeta.channel) {
+    resolvedArtist = sourceMeta.channel;
+  }
+
   // Extract embedded album art (best-effort, non-blocking)
   const artworkPath = await extractArtwork(dest, hash);
 

--- a/src/audio/ytDlpManager.js
+++ b/src/audio/ytDlpManager.js
@@ -363,7 +363,7 @@ function _fetchPlaylistInfoOnce(url, options = {}) {
  * @param {(data: object) => void} [onProgress] - Progress callback, receives { msg, pct, trackPct, overallCurrent, overallTotal }
  * @param {{
  *   cookiesBrowser?: string|null,
- *   onFileReady?: (file: { filePath, originalUrl, trackUrl, platform, quality, title, index }) => void,
+ *   onFileReady?: (file: { filePath, originalUrl, trackUrl, platform, quality, title, channel, index }) => void,
  *   onPlaylistDetected?: (info: { name: string|null, total: number }) => void,
  *   onTrackMeta?: (info: { index: number, title: string }) => void,
  * }} [options]
@@ -399,6 +399,7 @@ async function _downloadUrlOnce(url, onProgress, options = {}) {
   // Unique marker so we can reliably identify --print output lines among other stdout noise
   const FILE_MARKER = '__YTDLP_FILE__:';
   const TRACK_MARKER = '__YTDLP_TRACK__:';
+  const CHANNEL_MARKER = '__YTDLP_CHANNEL__:';
 
   const args = [
     '-f',
@@ -417,6 +418,9 @@ async function _downloadUrlOnce(url, onProgress, options = {}) {
     // Reliable per-track progress: fires before each download starts, goes to stdout
     '--print',
     `before_dl:${TRACK_MARKER}%(n_entries|1)s:%(title)s`,
+    // Channel/uploader for artist fallback when video title has no "Artist - Title" delimiter
+    '--print',
+    `before_dl:${CHANNEL_MARKER}%(channel|uploader|NA)s`,
     // --print after_move gives us the definitive final filepath after all post-processors
     // (audio extraction, remux, etc.) have run. This is our primary file detection mechanism.
     '--print',
@@ -452,6 +456,7 @@ async function _downloadUrlOnce(url, onProgress, options = {}) {
     let currentTrackPct = 0;
     let playlistDetectedFired = false;
     let currentTrackTitle = null;
+    let currentTrackChannel = null;
     let stderr = '';
 
     const destinationFiles = [];
@@ -467,10 +472,12 @@ async function _downloadUrlOnce(url, onProgress, options = {}) {
         platform,
         quality: currentQuality,
         title,
+        channel: currentTrackChannel || null,
         index: destinationFiles.length - 1,
       });
       // Reset per-track state for the next item
       currentTrackTitle = null;
+      currentTrackChannel = null;
       currentTrackUrl = null;
     };
 
@@ -493,6 +500,13 @@ async function _downloadUrlOnce(url, onProgress, options = {}) {
       if (trimmed.startsWith(FILE_MARKER)) {
         const f = trimmed.slice(FILE_MARKER.length).trim();
         if (f) fireFileReady(f);
+        return;
+      }
+
+      // Channel/uploader for artist fallback: --print before_dl emits CHANNEL_MARKER:<name>
+      if (trimmed.startsWith(CHANNEL_MARKER)) {
+        const name = trimmed.slice(CHANNEL_MARKER.length).trim();
+        currentTrackChannel = name && name !== 'NA' ? name : null;
         return;
       }
 

--- a/src/main.js
+++ b/src/main.js
@@ -745,6 +745,7 @@ ipcMain.handle(
         platform,
         quality,
         title,
+        channel,
         index,
       }) => {
         handledPaths.add(filePath);
@@ -755,6 +756,7 @@ ipcMain.handle(
             source_link: trackUrl !== originalUrl ? trackUrl : null,
             source_platform: platform,
             source_quality: quality,
+            channel: channel || null,
           });
           trackIds.push(trackId);
           if (playlistId) {


### PR DESCRIPTION
Closes #162

## Summary

When downloading via yt-dlp, if the video title contains no recognised `Artist - Title` delimiter, fall back to using the channel/uploader name as the artist field.

## Changes

- **`ytDlpManager.js`**: added `--print before_dl:%(channel|uploader|NA)s` to the yt-dlp args; captures the value in `currentTrackChannel` and passes it as `channel` in the `onFileReady` callback.
- **`main.js`**: forwards the `channel` field from `onFileReady` to `importAudioFile` via `sourceMeta.channel`.
- **`importManager.js`**: after the existing tag and filename-dash fallbacks, uses `sourceMeta.channel` as last-resort artist (only when artist is still empty).
- **`importManager.test.js`**: adds 4 new test cases covering the new behaviour.

## Acceptance Criteria

- [x] If video title contains a recognised delimiter (`-`, `–`, `—`, `|`), existing split logic is unchanged
- [x] If no delimiter is found, `channel` / `uploader` from yt-dlp metadata is used as the artist
- [x] Title field contains the full original video title (no trimming)
- [x] Works for both single-video and playlist downloads