### PR TITLE
fix(#159): add regression tests for import-to-playlist association

### DIFF
--- a/renderer/src/__tests__/Sidebar.test.jsx
+++ b/renderer/src/__tests__/Sidebar.test.jsx
@@ -141,6 +141,74 @@ describe('Sidebar', () => {
   });
 });
 
+describe('Sidebar — import dialog playlist association', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const defaultProps = {
+    selectedMenuItemId: 'music',
+    onMenuSelect: vi.fn(),
+    onExportPlaylistRekordboxUsb: vi.fn(),
+    onExportPlaylistAll: vi.fn(),
+  };
+
+  it('passes playlist id (not the whole object) to importAudioFiles when creating new playlist', async () => {
+    window.api.selectAudioFiles.mockResolvedValueOnce(['/tmp/track.mp3']);
+    window.api.createPlaylist.mockResolvedValueOnce({ id: 7 });
+
+    renderSidebar({ ...defaultProps });
+    fireEvent.click(screen.getByText('Import Audio Files'));
+
+    await waitFor(() => screen.getByText('Import to Playlist'));
+
+    fireEvent.click(screen.getByRole('radio', { name: /Create new playlist/ }));
+    fireEvent.change(screen.getByPlaceholderText('New playlist name'), {
+      target: { value: 'My New Set' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => {
+      expect(window.api.createPlaylist).toHaveBeenCalledWith('My New Set');
+      // Regression: must pass the integer id, not the whole { id } object
+      expect(window.api.importAudioFiles).toHaveBeenCalledWith(['/tmp/track.mp3'], 7);
+    });
+  });
+
+  it('passes playlist id to importAudioFiles when selecting an existing playlist', async () => {
+    window.api.getPlaylists.mockResolvedValue([
+      { id: 42, name: 'Techno Set', color: null, track_count: 5, total_duration: 1500 },
+    ]);
+    window.api.selectAudioFiles.mockResolvedValueOnce(['/tmp/track.mp3']);
+
+    renderSidebar({ ...defaultProps });
+    await waitFor(() => screen.getByText('Techno Set'));
+
+    fireEvent.click(screen.getByText('Import Audio Files'));
+    await waitFor(() => screen.getByText('Import to Playlist'));
+
+    fireEvent.click(screen.getByRole('radio', { name: /Techno Set/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => {
+      expect(window.api.importAudioFiles).toHaveBeenCalledWith(['/tmp/track.mp3'], 42);
+    });
+  });
+
+  it('passes null to importAudioFiles when "Library only" is selected', async () => {
+    window.api.selectAudioFiles.mockResolvedValueOnce(['/tmp/track.mp3']);
+
+    renderSidebar({ ...defaultProps });
+    fireEvent.click(screen.getByText('Import Audio Files'));
+    await waitFor(() => screen.getByText('Import to Playlist'));
+
+    // "Library only" is the default — just click Import
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => {
+      expect(window.api.importAudioFiles).toHaveBeenCalledWith(['/tmp/track.mp3'], null);
+    });
+  });
+});
+
 describe('Sidebar — normalization progress bar', () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -8,7 +8,7 @@ window.api = {
   getTrackIds: vi.fn().mockResolvedValue([]),
   getPlaylists: vi.fn().mockResolvedValue([]),
   getPlaylist: vi.fn().mockResolvedValue(null),
-  createPlaylist: vi.fn().mockResolvedValue(1),
+  createPlaylist: vi.fn().mockResolvedValue({ id: 1 }),
   renamePlaylist: vi.fn().mockResolvedValue(undefined),
   updatePlaylistColor: vi.fn().mockResolvedValue(undefined),
   deletePlaylist: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

- **Root cause**: `createPlaylist` IPC returns `{ id }`, not a bare number. `Sidebar.jsx` was assigning the whole object as `playlistId`, so `addTracksToPlaylist` received `{ id: 1 }` instead of `1` — causing the playlist association to silently fail due to a foreign key mismatch. Fixed in `06554be`, but no tests existed to prevent regression.
- **Mock bug**: `setup.js` mocked `createPlaylist` returning `1` instead of `{ id: 1 }`, meaning `result?.id` resolved to `undefined` in any test that exercised this path.

## Changes

- `renderer/src/__tests__/setup.js`: fix `createPlaylist` mock to return `{ id: 1 }` matching the real IPC contract
- `renderer/src/__tests__/Sidebar.test.jsx`: add 3 regression tests for the import dialog flows — create new playlist, select existing playlist, library-only

## Test plan

- [ ] `cd renderer && npx vitest run src/__tests__/Sidebar.test.jsx` — all 17 tests pass
- [ ] Manually import an audio file and select "Create new playlist" — track appears in the new playlist
- [ ] Manually import and select an existing playlist — track appears in that playlist

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)