### PR TITLE
fix: Rekordbox USB export — PCOB/PCO2 format, waveform colors, cue points

### DIFF
--- a/protocol_rekordbox.md
+++ b/protocol_rekordbox.md
@@ -236,7 +236,10 @@ Subheader (12 bytes at offset 12):
 | 16     | 4    | `num_entries` (1200 fixed) |
 | 20     | 4    | `0x00000000`               |
 
-Body: 1200 × 6 bytes. Per column: `[whiteness, whiteness, overall_rms, bass, mid, treble]`.
+Body: 1200 × 6 bytes. Per column: `[peak_byte, 255 - peak_byte, overall_rms, bass, mid, treble]`.
+
+- `peak_byte` = `min(255, round(peak * 255))` — peak amplitude, confirmed from hex-diff of native files (avg b0+b1 ≈ 255).
+- `overall_rms`, `bass`, `mid`, `treble` each scaled by 510, capped at 255.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -1,131 +1,173 @@
 # DJ Manager
 
-Your music library, built for DJs. Import tracks, analyse BPM and key automatically, build playlists, download from anywhere, and prepare sets — all stored locally on your machine.
-
-[![CI](https://github.com/Radexito/DjManager/actions/workflows/ci.yml/badge.svg)](https://github.com/Radexito/DjManager/actions/workflows/ci.yml)
-[![Release](https://github.com/Radexito/DjManager/actions/workflows/release.yml/badge.svg)](https://github.com/Radexito/DjManager/actions/workflows/release.yml)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
-[![ESLint](https://img.shields.io/badge/linting-ESLint-4B32C3)](https://eslint.org/)
-[![Tested with Vitest](https://img.shields.io/badge/tested_with-Vitest-6E9F18)](https://vitest.dev/)
-[![E2E with Playwright](https://img.shields.io/badge/e2e-Playwright-45ba4b)](https://playwright.dev/)
+A DJ-focused music library manager built with Electron. Manage your tracks, analyze BPM and key, export to Pioneer CDJ USB drives, and download from streaming platforms — all in one offline-first desktop app.
 
 ![DJ Manager screenshot](screenshot.png)
 
 ---
 
+## Features
+
+### 🎵 Music Library
+
+- Import **MP3, FLAC, WAV, OGG, M4A, AAC, OPUS** with full metadata extraction
+- SHA-1 deduplication — importing the same file twice is a no-op
+- Virtualized infinite-scroll list (handles tens of thousands of tracks)
+- Sort by any column: title, artist, album, BPM, key, loudness, duration, bitrate, year…
+- Customizable column visibility and order, persisted between sessions
+- Multi-select with **Ctrl+Click**, **Shift+Click range**, and **Ctrl+A**
+- Inline track preview — click the play icon in any row to audition without leaving the library
+- Per-track normalization status badge
+
+### 🔍 Search & Filter
+
+- Advanced field-qualified query syntax directly in the search bar:
+  ```
+  BPM >= 128 AND KEY:8A GENRE is Techno
+  ARTIST:Burial YEAR > 2010
+  BPM >= 120 AND KEY:12A
+  ```
+- Supports `AND`, `OR`, field names (`BPM`, `KEY`, `ARTIST`, `ALBUM`, `LABEL`, `GENRE`, `YEAR`, `BITRATE`), and comparison operators (`>=`, `<=`, `>`, `<`, `is`, `contains`)
+
+### 📊 Auto-Analysis
+
+- **BPM** detection via Mixxx analyzer (runs in background worker threads — import never blocks the UI)
+- **Musical key** — raw notation + Camelot wheel (e.g. `8B`)
+- **Loudness** — LUFS / ReplayGain
+- **Intro / Outro** timestamps
+- **Beatgrid** generation for CDJ export
+- **Waveform** data (PWAV / PWV2 / PWV4 / PWV6) generated via FFmpeg
+- Frequency band analysis (bass, mid, treble RMS) per slice
+
+### 🎧 Audio Normalization
+
+- Target loudness configurable in Settings (default **-9 LUFS**, range -60 to 0)
+- Original file preserved — normalized copy stored separately, allowing export in either form
+- Bulk normalize entire library or selected tracks
+- Reset normalization per track or library-wide
+- Auto-normalize on import (optional toggle in Settings)
+- Player automatically prefers the normalized file when available
+
+### 📝 Metadata & Auto-Tagging
+
+- Edit title, artist, album, label, year, genres, comments — inline or in the details panel
+- Bulk metadata editing across multiple selected tracks
+- **Auto-tagger** searches MusicBrainz, Discogs, iTunes, and Deezer simultaneously
+- Visual diff of current vs. suggested values — accept or reject per field
+- Cover art picker with zoom/preview, sourced from MusicBrainz Cover Art Archive, iTunes, and Deezer
+- BPM adjust shortcuts: ×2, ×0.5
+
+### 📋 Playlists
+
+- Create, rename, delete playlists (tracks remain in library)
+- Add/remove tracks via context menu or drag-and-drop
+- Drag-and-drop track reordering within a playlist
+- Assign a colour to each playlist (8 presets)
+- Import playlist from file — prompts which library playlist to add tracks to
+- Export playlist as **M3U**
+
+### ⬇️ Downloads (yt-dlp)
+
+Paste any URL from **YouTube, SoundCloud, Bandcamp, Mixcloud, Vimeo, Twitch, Twitter/X, Instagram, Facebook, TikTok, Dailymotion, Deezer**, and 1000+ other yt-dlp-supported sites.
+
+- Fetch playlist metadata before downloading — preview titles, durations, availability
+- Deselect individual tracks from a playlist before starting the download
+- Duplicate detection — URLs already in your library are highlighted
+- Per-track and overall download progress in the sidebar
+- Cancel in-progress downloads
+- Browser cookie authentication (Chrome, Chromium, Brave, Firefox, LibreWolf, Edge) for sites requiring login
+- Downloaded tracks import directly into the library and optionally into a playlist
+
+### 🎮 Player
+
+- Built-in player streaming from a local HTTP server (reliable Range request support for seeking)
+- Keyboard shortcuts: **Space** (play/pause), media keys
+- Seek bar, volume control, current time / duration
+- Output device selection
+- Queue management
+- **Shuffle** and **Repeat** modes (none / all / one)
+- 50-track play history ring buffer
+
+### 💾 Rekordbox USB Export
+
+Full **Pioneer CDJ / XDJ-compatible** export — plug the USB in and it just works.
+
+- Exports the full library or individual playlists
+- Writes **ANLZ0000.DAT / .EXT / .2EX** — waveform, beatgrid, intro/outro cue data
+- Writes **export.pdb** — full DeviceSQL binary database (tracks, playlists, artwork, keys, ratings)
+- Writes **MYSETTING.DAT / MYSETTING2.DAT / DEVSETTING.DAT** — hardware settings with correct CRC-16/XMODEM checksums
+- USB filesystem validation (FAT32 / exFAT detection, format warnings)
+- Export progress tracking
+
+### ⚙️ Settings
+
+| Section       | Options                                                                                   |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| Library       | Custom library path, move library to new location                                         |
+| Normalization | Target LUFS, auto-normalize on import, bulk normalize / reset                             |
+| Downloads     | Browser cookie source, preferred audio format                                             |
+| Dependencies  | View installed versions of ffmpeg / yt-dlp / analyzer, update individually or all at once |
+| Advanced      | Clear library, reset all user data, view log files                                        |
+
+---
+
 ## Download
 
-Grab the latest build for your platform from [**Releases**](https://github.com/Radexito/DjManager/releases).
+Pre-built releases are available on the [GitHub Releases](https://github.com/Radexito/DjManager/releases) page.
 
-FFmpeg and the audio analyser download automatically on first launch — no manual setup required.
+| Platform | Format              |
+| -------- | ------------------- |
+| Linux    | AppImage (x64)      |
+| macOS    | dmg (Apple Silicon) |
+| Windows  | NSIS installer      |
 
-| Platform | File                                              |
-| -------- | ------------------------------------------------- |
-| Linux    | `DJ.Manager-x.x.x-Linux` (AppImage — just run it) |
-| Windows  | `DJ.Manager-x.x.x-Setup.exe`                      |
-| macOS    | `DJ.Manager-x.x.x.dmg`                            |
-
-### Windows — Chocolatey
-
-If you use [Chocolatey](https://chocolatey.org/), you can install and keep DJ Manager up to date with a single command:
-
-```powershell
-choco install djmanager
-```
-
-Package page: [community.chocolatey.org/packages/djmanager](https://community.chocolatey.org/packages/djmanager)
+On first launch, FFmpeg and the mixxx-analyzer binary are downloaded automatically.
 
 ---
 
-## What it does
-
-**Library** — Import audio files once; DJ Manager copies them into managed storage and deduplicates by content hash. Sort and filter by any column. Select multiple tracks with click, Shift+click, Ctrl+click, or Ctrl+A.
-
-**Advanced search** — Type a query into the search bar to filter your library with precision. Filters can be stacked with `AND`:
-
-```
-GENRE is Psytrance AND BPM IN RANGE 140-145
-KEY matches 8A AND BPM > 130
-ARTIST contains Burial AND YEAR > 2010
-TITLE contains intro AND LOUDNESS > -10
-```
-
-Supported fields: `TITLE`, `ARTIST`, `ALBUM`, `GENRE`, `BPM`, `KEY`, `YEAR`, `LOUDNESS`.
-Supported operators vary by field — `is`, `is not`, `contains`, `in range`, `>`, `<` for numbers; `is`, `matches`, `adjacent`, `mode switch` for keys (Camelot notation: `8A`, `8B`, etc.).
-The search bar shows field and operator suggestions as you type, and completed filters appear as removable chips above the track list.
-
-**Analysis** — Every track is analysed automatically on import for BPM, musical key (Camelot notation), loudness (LUFS), replay gain, and intro/outro markers. Right-click any track to re-analyse, or halve/double the detected BPM if the analyzer picked the wrong grid.
-
-**Find Similar** — Right-click a track to find others with a matching or adjacent Camelot key, or within a close BPM range. Results are applied as a live search filter.
-
-**Auto-tag** — Right-click any track and choose **Auto-tag** to look up metadata from [MusicBrainz](https://musicbrainz.org/) and [Discogs](https://www.discogs.com/) simultaneously. A side-by-side diff shows the current value next to every candidate found; pick the value you want per field (Title, Artist, Album, Label, Year, Genres) from a dropdown and apply in one click.
-
-**URL Import** — Paste a URL from YouTube, SoundCloud, Bandcamp, Spotify, or [1000+ other sources](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md) into the **Download** tab. DJ Manager fetches the track list first so you can review and deselect anything before downloading. Tracks are imported into the library one by one as they finish — no waiting for the full playlist. A dual progress bar tracks both the current download and overall playlist progress, and a status table shows each track's state (pending → downloading → importing → done / failed).
-
-**Playlists** — Create colour-coded playlists in the sidebar, drag tracks in from the library, reorder by drag-and-drop, and sort by any column. Track count and total duration are shown at all times. Exporting a playlist to M3U is one click. Playlists imported via URL remember their source link.
-
-**Player** — Full playback with seekbar, shuffle, repeat, previous/next, and hardware media key support. Intro and outro zones are shown visually on the seekbar so you know exactly when to mix. Double-click any track to play.
-
-**Settings** — Move your library to any location, including an external drive. Update FFmpeg and the audio analyser in-app without reinstalling. Clear the track library, all playlists, or all user data from the Advanced tab.
-
----
-
-## Running from source
+## Development
 
 ```bash
-git clone https://github.com/Radexito/DjManager.git
-cd DjManager
+# Install dependencies
 npm install
 cd renderer && npm install && cd ..
+
+# Start dev server (Vite + Electron)
 npm run dev
+
+# Lint
+npm run lint:all
+
+# Format
+npm run format
+
+# Run tests
+npm test                    # main process (Vitest)
+cd renderer && npm test     # renderer (React Testing Library)
+
+# Build distributable
+npm run dist:linux          # or :mac / :win
 ```
 
-FFmpeg and mixxx-analyzer are downloaded automatically to `~/.config/dj_manager/bin/` on first run.
-
-### Other useful commands
-
-| Command                 | What it does                                                        |
-| ----------------------- | ------------------------------------------------------------------- |
-| `npm run dev`           | Start Electron + Vite dev server together (default for development) |
-| `npm run react`         | Start the Vite renderer only (UI dev without Electron)              |
-| `npm run build`         | Build the renderer for production                                   |
-| `npm run electron-prod` | Run Electron against the production build                           |
-| `npm run dist`          | Build + package for the current platform                            |
-| `npm run dist:linux`    | Build + package for Linux (AppImage)                                |
-| `npm run dist:win`      | Build + package for Windows (NSIS installer)                        |
-| `npm run dist:mac`      | Build + package for macOS (DMG)                                     |
-| `npm run lint:all`      | Lint main process + renderer                                        |
-| `npm test`              | Run unit tests (Vitest)                                             |
-| `npm run test:e2e`      | Run E2E tests (Playwright)                                          |
+> **Note:** Close the Electron app before running `npm test` — the pretest step rebuilds `better-sqlite3` for Node.js and will fail if Electron holds the binary open.
 
 ---
 
-Upcoming work is tracked on the [**Issues**](https://github.com/Radexito/DjManager/issues) page.
+## Tech Stack
+
+| Layer            | Technology                                        |
+| ---------------- | ------------------------------------------------- |
+| Shell            | **Electron** 40                                   |
+| UI               | **React 19** + **Vite 8**                         |
+| Database         | **better-sqlite3** (synchronous SQLite)           |
+| Analysis         | **Mixxx analyzer** — BPM, key, loudness, beatgrid |
+| Audio processing | **FFmpeg** — decode, waveform, format conversion  |
+| Downloads        | **yt-dlp**                                        |
+| Drag-and-drop    | **@dnd-kit**                                      |
+| Virtual list     | **react-window**                                  |
 
 ---
 
-## Rekordbox USB export
+## License
 
-Right-click any playlist in the sidebar and choose **Export Rekordbox USB** to write a Pioneer CDJ-compatible USB drive — no Rekordbox software required. DJ Manager writes the binary formats CDJs read directly: `export.pdb` (track database), `ANLZ0000.DAT/.EXT/.2EX` (waveforms and beat grids), and `PIONEER/MYSETTING.DAT` (player settings).
-
-### Re-exporting and incremental behaviour
-
-Each export to the same USB folder **merges** with whatever was previously exported there. A manifest (`PIONEER/rekordbox/export-manifest.json`) records all tracks and playlists on the USB; subsequent exports read it and inject new content into the existing database without removing anything.
-
-| What gets written                | Behaviour                                                                    |
-| -------------------------------- | ---------------------------------------------------------------------------- |
-| Audio files (`/music/`)          | **Skipped if already present** — existing files are never overwritten        |
-| ANLZ files (waveform / beatgrid) | **Regenerated for new tracks only** — existing ANLZ files are left untouched |
-| `export.pdb` (track database)    | **Rebuilt from all tracks** — current export merged with previous exports    |
-| `PIONEER/MYSETTING.DAT` etc.     | **Always regenerated**                                                       |
-| `export-manifest.json`           | **Always updated** — records the full set of tracks and playlists on the USB |
-
-You can export playlists to the same USB one at a time — each export adds its tracks and playlists to the CDJ database without touching the ones already there.
-
----
-
-## How files are stored
-
-Audio is stored at `~/.config/dj_manager/audio/<xx>/<hash>.<ext>` (configurable via Settings → Library). The two-character hash prefix keeps directory sizes manageable. Playlists reference tracks by ID — no duplicates, no copies.
-
-Logs are written daily to `~/.config/dj_manager/logs/app-YYYY-MM-DD.log`.
+MIT © [Radexito](https://github.com/Radexito)

--- a/scripts/anlz-diff.js
+++ b/scripts/anlz-diff.js
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+/**
+ * anlz-diff.js — ANLZ file parser and hex-diff tool
+ *
+ * Usage:
+ *   # Parse and pretty-print a single ANLZ file:
+ *   node scripts/anlz-diff.js path/to/ANLZ0000.DAT
+ *
+ *   # Compare native Rekordbox file against ours:
+ *   node scripts/anlz-diff.js path/to/native/ANLZ0000.DAT path/to/ours/ANLZ0000.DAT
+ *
+ * Purpose: reverse-engineer the PCOB2 (memory cue) format for issue #208.
+ * Export a track with memory cues from Rekordbox to USB, then run:
+ *   node scripts/anlz-diff.js <rekordbox-usb>/PIONEER/USBANLZ/Pxxx/xxxxxxxx/ANLZ0000.DAT <our-export>/PIONEER/USBANLZ/Pxxx/xxxxxxxx/ANLZ0000.DAT
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function hex(n, width = 8) {
+  return '0x' + n.toString(16).toUpperCase().padStart(width, '0');
+}
+
+function hexBytes(buf, start, len) {
+  return Array.from(buf.slice(start, start + len))
+    .map((b) => b.toString(16).padStart(2, '0').toUpperCase())
+    .join(' ');
+}
+
+function fourcc(buf, offset) {
+  return buf.slice(offset, offset + 4).toString('ascii');
+}
+
+// ── Section parser ────────────────────────────────────────────────────────────
+
+function parseSections(buf) {
+  const sections = [];
+  let pos = 28; // skip 28-byte PMAI header
+  while (pos + 12 <= buf.length) {
+    const tag = fourcc(buf, pos);
+    const lenHdr = buf.readUInt32BE(pos + 4);
+    const lenTag = buf.readUInt32BE(pos + 8);
+    if (lenTag === 0 || pos + lenTag > buf.length) break;
+    sections.push({ tag, lenHdr, lenTag, pos, buf: buf.slice(pos, pos + lenTag) });
+    pos += lenTag;
+  }
+  return sections;
+}
+
+// ── Section-specific decoders ─────────────────────────────────────────────────
+
+function decodePcob(sec) {
+  const b = sec.buf;
+  const type = b.readUInt32BE(12);
+  const numCues = b.readUInt16BE(18);
+  const memoryCount = b.readUInt32BE(20);
+
+  const lines = [
+    `  type          = ${type} (${type === 1 ? 'hot_cues' : 'memory_cues'})`,
+    `  num_cues      = ${numCues}`,
+    `  memory_count  = ${hex(memoryCount)} (${memoryCount === 0xffffffff ? 'sentinel' : memoryCount})`,
+  ];
+
+  // Parse PCPT sub-tags
+  let off = 24;
+  for (let i = 0; i < numCues && off + 56 <= b.length; i++) {
+    const ptag = fourcc(b, off);
+    if (ptag !== 'PCPT') {
+      lines.push(`  [entry ${i}] unexpected tag: ${ptag}`);
+      break;
+    }
+    const lenHdr = b.readUInt32BE(off + 4);
+    const lenTag = b.readUInt32BE(off + 8);
+    const hotCue = b.readUInt32BE(off + 12);
+    const status = b.readUInt32BE(off + 16);
+    const unk20 = b.readUInt32BE(off + 20);
+    const orderFirst = b.readUInt16BE(off + 24);
+    const orderLast = b.readUInt16BE(off + 26);
+    const cueType = b[off + 28];
+    const pad29 = b[off + 29];
+    const unk30 = b.readUInt16BE(off + 30);
+    const timeMs = b.readUInt32BE(off + 32);
+    const loopTime = b.readUInt32BE(off + 36);
+    const colorIdx = b[off + 40];
+    const rawHex = hexBytes(b, off, lenTag);
+
+    lines.push(`  [PCPT entry ${i}]`);
+    lines.push(`    tag         = ${ptag}`);
+    lines.push(`    len_header  = ${lenHdr}`);
+    lines.push(`    len_tag     = ${lenTag}`);
+    lines.push(
+      `    hot_cue     = ${hotCue} (${hotCue === 0 ? 'memory' : `hot ${String.fromCharCode(64 + hotCue)}`})`
+    );
+    lines.push(`    status      = ${status} (${statusName(status)})`);
+    lines.push(`    unk[20-23]  = ${hex(unk20)}`);
+    lines.push(`    order_first = ${hex(orderFirst, 4)}`);
+    lines.push(`    order_last  = ${hex(orderLast, 4)}`);
+    lines.push(
+      `    type        = ${cueType} (${cueType === 1 ? 'cue_point' : cueType === 2 ? 'loop' : 'unknown'})`
+    );
+    lines.push(`    pad[29]     = ${hex(pad29, 2)}`);
+    lines.push(`    unk[30-31]  = ${hex(unk30, 4)}`);
+    lines.push(`    time_ms     = ${timeMs} (${(timeMs / 1000).toFixed(3)}s)`);
+    lines.push(`    loop_time   = ${hex(loopTime)}`);
+    lines.push(`    color_idx   = ${colorIdx}`);
+    lines.push(`    raw hex     = ${rawHex}`);
+    off += lenTag;
+  }
+
+  return lines.join('\n');
+}
+
+function statusName(s) {
+  return s === 0 ? 'disabled' : s === 1 ? 'enabled' : s === 4 ? 'active_loop' : `unknown(${s})`;
+}
+
+function decodePco2(sec) {
+  const b = sec.buf;
+  const type = b.readUInt32BE(12);
+  const numCues = b.readUInt16BE(16);
+
+  const lines = [
+    `  type     = ${type} (${type === 1 ? 'hot_cues' : 'memory_cues'})`,
+    `  num_cues = ${numCues}`,
+  ];
+
+  let off = 20;
+  for (let i = 0; i < numCues && off + 16 <= b.length; i++) {
+    const ptag = fourcc(b, off);
+    if (ptag !== 'PCP2') {
+      lines.push(`  [entry ${i}] unexpected tag: ${ptag}`);
+      break;
+    }
+    const lenHdr = b.readUInt32BE(off + 4);
+    const lenTag = b.readUInt32BE(off + 8);
+    const hotCue = b.readUInt32BE(off + 12);
+    const cueType = b[off + 16];
+    const timeMs = b.readUInt32BE(off + 20);
+    const loopTime = b.readUInt32BE(off + 24);
+    const colorId = b[off + 28];
+    const rawHex = hexBytes(b, off, Math.min(lenTag, 64));
+
+    lines.push(`  [PCP2 entry ${i}]`);
+    lines.push(
+      `    hot_cue    = ${hotCue} (${hotCue === 0 ? 'memory' : `hot ${String.fromCharCode(64 + hotCue)}`})`
+    );
+    lines.push(
+      `    type       = ${cueType} (${cueType === 1 ? 'cue_point' : cueType === 2 ? 'loop' : 'unknown'})`
+    );
+    lines.push(`    time_ms    = ${timeMs} (${(timeMs / 1000).toFixed(3)}s)`);
+    lines.push(`    loop_time  = ${hex(loopTime)}`);
+    lines.push(`    color_id   = ${colorId}`);
+    lines.push(`    len_tag    = ${lenTag}`);
+    const fullHex = hexBytes(b, off, lenTag);
+    lines.push(`    full hex   = ${fullHex}`);
+    off += lenTag;
+  }
+
+  return lines.join('\n');
+}
+
+// ── Print a single file ───────────────────────────────────────────────────────
+
+function printAnlz(filePath, label) {
+  const buf = fs.readFileSync(filePath);
+  const magic = fourcc(buf, 0);
+  console.log(`\n${'='.repeat(70)}`);
+  console.log(`${label}: ${path.basename(filePath)}`);
+  console.log(`  file size : ${buf.length} bytes`);
+  console.log(`  magic     : ${magic}`);
+  if (magic !== 'PMAI') {
+    console.log('  WARNING: not a PMAI file!');
+    return;
+  }
+
+  const sections = parseSections(buf);
+  console.log(`  sections  : ${sections.map((s) => s.tag).join(', ')}\n`);
+
+  for (const sec of sections) {
+    console.log(`── ${sec.tag}  pos=${sec.pos}  len_hdr=${sec.lenHdr}  len_tag=${sec.lenTag}`);
+    if (sec.tag === 'PCOB') {
+      console.log(decodePcob(sec));
+    } else if (sec.tag === 'PCO2') {
+      console.log(decodePco2(sec));
+    }
+  }
+}
+
+// ── Diff two files section by section ────────────────────────────────────────
+
+function diffAnlz(nativePath, oursPath) {
+  const nBuf = fs.readFileSync(nativePath);
+  const oBuf = fs.readFileSync(oursPath);
+
+  const nSecs = parseSections(nBuf);
+  const oSecs = parseSections(oBuf);
+
+  console.log('\n' + '='.repeat(70));
+  console.log('DIFF: native vs ours');
+  console.log(`  native sections : ${nSecs.map((s) => s.tag).join(', ')}`);
+  console.log(`  ours   sections : ${oSecs.map((s) => s.tag).join(', ')}`);
+
+  const allTags = [...new Set([...nSecs.map((s) => s.tag), ...oSecs.map((s) => s.tag)])];
+
+  for (const tag of allTags) {
+    const nInstances = nSecs.filter((s) => s.tag === tag);
+    const oInstances = oSecs.filter((s) => s.tag === tag);
+
+    const count = Math.max(nInstances.length, oInstances.length);
+    for (let i = 0; i < count; i++) {
+      const n = nInstances[i];
+      const o = oInstances[i];
+
+      if (!n) {
+        console.log(`\n[${tag}#${i}] MISSING in native (only in ours)`);
+        continue;
+      }
+      if (!o) {
+        console.log(`\n[${tag}#${i}] MISSING in ours (only in native)`);
+        continue;
+      }
+
+      const same = n.buf.equals(o.buf);
+      console.log(
+        `\n[${tag}#${i}]  native_len=${n.lenTag}  ours_len=${o.lenTag}  ${same ? '✓ IDENTICAL' : '✗ DIFFERS'}`
+      );
+
+      if (!same) {
+        // Show byte-level diff for PCOB and PCO2
+        if (tag === 'PCOB' || tag === 'PCO2') {
+          console.log('  NATIVE:');
+          console.log(tag === 'PCOB' ? decodePcob(n) : decodePco2(n));
+          console.log('  OURS:');
+          console.log(tag === 'PCOB' ? decodePcob(o) : decodePco2(o));
+        }
+
+        // First 128 differing bytes
+        const maxLen = Math.max(n.buf.length, o.buf.length);
+        const diffs = [];
+        for (let b = 0; b < maxLen && diffs.length < 32; b++) {
+          const nb = n.buf[b] ?? -1;
+          const ob = o.buf[b] ?? -1;
+          if (nb !== ob) {
+            diffs.push(`    [+${b}] native=${hex(nb, 2)} ours=${hex(ob, 2)}`);
+          }
+        }
+        if (diffs.length > 0) {
+          console.log(`  First ${diffs.length} byte differences:`);
+          console.log(diffs.join('\n'));
+        }
+      }
+    }
+  }
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+  console.error('Usage:');
+  console.error('  node scripts/anlz-diff.js <file.DAT>                  # parse single file');
+  console.error('  node scripts/anlz-diff.js <native.DAT> <ours.DAT>     # diff two files');
+  process.exit(1);
+}
+
+if (args.length === 1) {
+  printAnlz(args[0], 'FILE');
+} else {
+  printAnlz(args[0], 'NATIVE');
+  printAnlz(args[1], 'OURS  ');
+  diffAnlz(args[0], args[1]);
+}

--- a/src/__tests__/anlzWriter.test.js
+++ b/src/__tests__/anlzWriter.test.js
@@ -25,7 +25,7 @@ vi.mock('fs', () => {
 });
 
 // Import after mocks
-import { writeAnlz, getAnlzFolder } from '../audio/anlzWriter.js';
+import { writeAnlz, getAnlzFolder, buildPcobSections } from '../audio/anlzWriter.js';
 import fs from 'fs';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -431,5 +431,68 @@ describe('writeAnlz', () => {
     expect(exBuf.readUInt16BE(pwvcPos + 14)).toBe(0x0064);
     expect(exBuf.readUInt16BE(pwvcPos + 16)).toBe(0x0068);
     expect(exBuf.readUInt16BE(pwvcPos + 18)).toBe(0x00c5);
+  });
+});
+
+// ── buildPcobSections ─────────────────────────────────────────────────────────
+
+describe('buildPcobSections', () => {
+  const hotCue = { position_ms: 1000, color: '#ff0000', hot_cue_index: 0 }; // A
+  const memoryCue = { position_ms: 5000, color: '#00ff00', hot_cue_index: -1 };
+
+  it('returns empty stubs when cuePoints is empty', () => {
+    const [pcob1, pcob2] = buildPcobSections([]);
+    expect(pcob1.slice(0, 4).toString('ascii')).toBe('PCOB');
+    expect(pcob2.slice(0, 4).toString('ascii')).toBe('PCOB');
+    // Both empty: len_tag = 24 (header only, no entries)
+    expect(pcob1.readUInt32BE(8)).toBe(24);
+    expect(pcob2.readUInt32BE(8)).toBe(24);
+  });
+
+  it('PCOB1 type field = 1 (hot_cues slot)', () => {
+    const [pcob1] = buildPcobSections([hotCue]);
+    expect(pcob1.readUInt32BE(12)).toBe(1);
+  });
+
+  it('PCOB2 is always empty stub (memory cues go to PCO2 until PCOB2 format is confirmed)', () => {
+    // Non-empty PCOB2 causes Rekordbox to reject the file — see issue #208
+    const [, pcob2] = buildPcobSections([memoryCue]);
+    expect(pcob2.readUInt32BE(8)).toBe(24); // len_tag = 24 = header only
+    expect(pcob2.readUInt16BE(18)).toBe(0); // num_cues = 0
+  });
+
+  it('PCOB2 stays empty even when there are memory cues', () => {
+    const [, pcob2] = buildPcobSections([hotCue, memoryCue]);
+    expect(pcob2.readUInt32BE(8)).toBe(24);
+  });
+
+  it('PCPT entry for hot cue has status = 0 (native Rekordbox value)', () => {
+    // Verified by hex-diff of native Rekordbox USB export — KSY "disabled" label is misleading
+    const [pcob1] = buildPcobSections([hotCue]);
+    const pcptStart = 24; // first PCPT entry after 24-byte PCOB header
+    expect(pcob1.readUInt32BE(pcptStart + 16)).toBe(0);
+  });
+
+  it('PCPT entry for hot cue A has hot_cue = 1', () => {
+    const [pcob1] = buildPcobSections([hotCue]);
+    const pcptStart = 24;
+    expect(pcob1.readUInt32BE(pcptStart + 12)).toBe(1);
+  });
+
+  it('PCPT time_ms matches position_ms', () => {
+    const [pcob1] = buildPcobSections([hotCue]);
+    const pcptStart = 24;
+    expect(pcob1.readUInt32BE(pcptStart + 32)).toBe(1000);
+  });
+
+  it('PCOB1 len_tag = 24 + N×56 for N hot cues', () => {
+    const [pcob1] = buildPcobSections([hotCue, hotCue]);
+    expect(pcob1.readUInt32BE(8)).toBe(24 + 2 * 56);
+  });
+
+  it('memory cues are NOT placed in PCOB1', () => {
+    const [pcob1] = buildPcobSections([memoryCue]);
+    // No entries in PCOB1 since no hot cues
+    expect(pcob1.readUInt32BE(8)).toBe(24); // empty
   });
 });

--- a/src/audio/anlzWriter.js
+++ b/src/audio/anlzWriter.js
@@ -237,17 +237,49 @@ function buildPvbrSection(fileSize) {
 
 // ─── Cue point sections (PCOB / PCO2) ─────────────────────────────────────────
 //
-// Format derived from community reverse-engineering of Pioneer CDJ ANLZ files:
-//   https://github.com/Deep-Symmetry/crate-digger (kaitai structs)
+// Rekordbox 6+ / CDJ-3000 format uses sub-tagged entries inside PCOB and PCO2.
+// Each PCOB entry is wrapped in a PCPT sub-tag (56 bytes fixed).
+// Each PCO2 entry is wrapped in a PCP2 sub-tag (variable, min 104 bytes).
 //
-// PCOB: basic cue objects (present in both DAT and EXT)
-//   Header (24 bytes): tag + len_header(24) + len_tag + count + memory_count + pad
-//   Each entry (28 bytes): hot_cue, status, u16, order×2, type, u8, u16,
-//                           time_ms(u32), loop_time(u32), color, u8×3, loop_num×2
+// Confirmed by hex-comparing native Rekordbox USB exports.
+// The older flat-entry format (documented in crate-digger for early CDJ firmware)
+// causes Rekordbox to reject the entire ANLZ file, silently dropping waveforms
+// and beatgrids even though those sections precede PCOB in the stream.
 //
-// PCO2: extended cue objects with UTF-16BE labels (EXT only)
-//   Header (20 bytes): tag + len_header(20) + len_tag + count + memory_count
-//   Each entry (variable): same base as PCOB, plus label_len(u32) + UTF-16BE label
+// PCOB header (24 bytes): fourcc + len_header(24) + len_tag + count + memory_count + unk(0xffffffff)
+// PCPT sub-tag (56 bytes, fixed):
+//   [0-11]:  standard header  fourcc='PCPT', len_header=28, len_tag=56
+//   [12-15]: entry order (1-based)
+//   [16-19]: 0x00000000
+//   [20-21]: 0x0001 (active)
+//   [22-23]: 0x0000
+//   [24-27]: 0xffffffff
+//   [28]:    hot_cue_index (0-7=A-H, 0xff=memory cue)
+//   [29]:    0x00
+//   [30-31]: 0x03e8 (constant observed in all native files)
+//   [32-35]: position_ms (u32BE)
+//   [36-39]: loop_time (u32BE, 0xffffffff=none)
+//   [40]:    color_index
+//   [41-55]: zeros
+//
+// PCO2 header (20 bytes): fourcc + len_header(20) + len_tag + count + memory_count(u16BE) + u16(0)
+// PCP2 sub-tag (variable, min 104 bytes):
+//   [0-11]:  standard header  fourcc='PCP2', len_header=16, len_tag=variable
+//   [12-15]: entry order (1-based)
+//   body at [16+]:
+//     [0]:    hot_cue_index
+//     [1]:    0x00
+//     [2-3]:  0x03e8 (constant)
+//     [4-7]:  position_ms (u32BE)
+//     [8-11]: loop_time (u32BE)
+//     [12-13]: 0x0001 (status)
+//     [14-23]: zeros
+//     [24-27]: label_length (bytes incl null terminator, 0=no label)
+//     [28+]:  UTF-16BE label (null-terminated)
+//     [28+labelByteLen]:   color_index
+//     [28+labelByteLen+1]: 0xff (unk, constant in native files)
+//     [28+labelByteLen+2-3]: 0x0017 (unk, constant in native files)
+//     rest: zeros to reach min body size of 88 bytes
 //
 // Rekordbox color palette (hot cue / memory cue color index):
 const REKORDBOX_COLORS = [
@@ -348,116 +380,148 @@ const EMPTY_PCO2_2 = Buffer.from([
 ]);
 
 /**
- * Build populated PCOB section buffers for DAT/EXT.
- * Returns [pcob1, pcob2] — two sections as Rekordbox always expects exactly two.
- * When cuePoints is empty, returns the empty stubs.
+ * Builds a single PCPT sub-tag entry (56 bytes, fixed size).
+ * Per crate-digger ksy: [12-15]=hot_cue number (0=memory,1=A,2=B…), [28]=type (1=point,2=loop).
+ */
+function buildPcptEntry(hotCueNum, positionMs, color) {
+  const buf = Buffer.alloc(56, 0);
+  buf.write('PCPT', 0, 'ascii');
+  buf.writeUInt32BE(28, 4); // len_header = 28
+  buf.writeUInt32BE(56, 8); // len_tag = 56
+  buf.writeUInt32BE(hotCueNum, 12); // hot_cue: 0=memory, 1=A, 2=B, …
+  // [16-19]: status = 0x00000000
+  buf.writeUInt32BE(0x00010000, 20); // constant observed in all native Rekordbox files
+  buf.writeUInt16BE(0xffff, 24); // order_first
+  buf.writeUInt16BE(0xffff, 26); // order_last
+  buf[28] = 1; // type: 1=point_cue (NOT hot_cue_index)
+  // buf[29] = 0x00
+  buf.writeUInt16BE(0x03e8, 30); // constant
+  buf.writeUInt32BE(positionMs, 32); // time_ms
+  buf.writeUInt32BE(0xffffffff, 36); // loop_time: none
+  buf[40] = hexToRekordboxColor(color);
+  return buf;
+}
+
+function buildPcobSlot(slotType, cues) {
+  // slotType: 1=hot_cues (slot 1), 0=memory_cues (slot 2)
+  if (cues.length === 0) return slotType === 1 ? EMPTY_PCOB_1 : EMPTY_PCOB_2;
+  const headerSize = 24;
+  const tagLen = headerSize + cues.length * 56;
+  const buf = Buffer.alloc(tagLen, 0);
+  buf.write('PCOB', 0, 'ascii');
+  buf.writeUInt32BE(headerSize, 4); // len_header = 24
+  buf.writeUInt32BE(tagLen, 8); // len_tag
+  buf.writeUInt32BE(slotType, 12); // type: 1=hot_cues, 0=memory_cues
+  // [16-17]: padding = 0
+  buf.writeUInt16BE(cues.length, 18); // num_cues (u16BE)
+  buf.writeUInt32BE(0xffffffff, 20); // memory_count sentinel
+  cues.forEach((cue, i) => {
+    // DB hot_cue_index: <0 = memory cue, >=0 = hot cue (0=A, 1=B, …)
+    // Pioneer format: 0=memory, 1=A, 2=B, …
+    const hotCueNum = cue.hot_cue_index >= 0 ? cue.hot_cue_index + 1 : 0;
+    buildPcptEntry(hotCueNum, Math.round(cue.position_ms), cue.color).copy(
+      buf,
+      headerSize + i * 56
+    );
+  });
+  return buf;
+}
+
+/**
+ * Build populated PCOB section buffers [slot1, slot2].
+ * Slot 1 (type=1) contains hot cues only. Slot 2 is ALWAYS the empty stub —
+ * Rekordbox rejects the entire ANLZ file if PCOB2 contains any entries.
+ * Memory cues are stored exclusively in EXT PCO2.
  *
  * @param {Array<{position_ms, color, hot_cue_index}>} cuePoints
  * @returns {[Buffer, Buffer]}
  */
 export function buildPcobSections(cuePoints) {
   if (!cuePoints || cuePoints.length === 0) return [EMPTY_PCOB_1, EMPTY_PCOB_2];
-
-  const count = cuePoints.length;
-  const memoryCues = cuePoints.filter((c) => c.hot_cue_index < 0);
-  const memoryCount = memoryCues.length;
-  const entrySize = 28;
-  const headerSize = 24;
-  const tagLen = headerSize + count * entrySize;
-
-  // Both PCOB slots hold all cues (Rekordbox reads from either; slot 1 is primary)
-  function buildOne(slotFlag) {
-    const buf = Buffer.alloc(tagLen, 0);
-    buf.write('PCOB', 0, 'ascii');
-    buf.writeUInt32BE(headerSize, 4);
-    buf.writeUInt32BE(tagLen, 8);
-    buf.writeUInt32BE(slotFlag ? count : 0, 12); // count in primary slot
-    buf.writeUInt32BE(slotFlag ? memoryCount : 0, 16);
-    // bytes 20-23 = 0 (padding)
-
-    if (slotFlag) {
-      cuePoints.forEach((cue, i) => {
-        const off = headerSize + i * entrySize;
-        const hotCue = cue.hot_cue_index >= 0 ? cue.hot_cue_index : 0xff;
-        buf[off + 0] = hotCue;
-        buf[off + 1] = 0x01; // status: active
-        // bytes 2-3: u16be = 0
-        buf.writeUInt16BE(i, off + 4); // order_first
-        buf.writeUInt16BE(i, off + 6); // order_last
-        buf[off + 8] = 0x01; // type: cue point
-        // bytes 9-11: 0
-        buf.writeUInt32BE(Math.round(cue.position_ms), off + 12);
-        buf.writeUInt32BE(0xffffffff, off + 16); // loop_time: none
-        buf[off + 20] = hexToRekordboxColor(cue.color);
-        // bytes 21-27: 0 (color padding + loop_numerator/denominator)
-      });
-    } else {
-      // Slot 2: all FFs for value sentinel (mirrors empty stub behaviour)
-      buf.writeUInt32BE(0xffffffff, 20);
-    }
-    return buf;
-  }
-
-  return [buildOne(true), buildOne(false)];
+  const hotCues = cuePoints.filter((c) => c.hot_cue_index >= 0);
+  return [buildPcobSlot(1, hotCues), EMPTY_PCOB_2];
 }
 
 /**
- * Build populated PCO2 section buffers (EXT file only) — adds UTF-16BE labels.
- * Returns [pco2_1, pco2_2].
+ * Builds a single PCP2 sub-tag entry (variable size, min 104 bytes).
+ * Per crate-digger ksy: [12-15]=hot_cue number, [16]=type (1=point_cue).
+ */
+function buildPcp2Entry(hotCueNum, positionMs, label, color) {
+  const labelStr = label ?? '';
+  const labelByteLen = labelStr.length > 0 ? (labelStr.length + 1) * 2 : 0; // UTF-16BE + null
+  // body (starting at offset 16) is min 88 bytes
+  const bodySize = Math.max(88, 28 + labelByteLen + 4);
+  const lenTag = 16 + bodySize;
+
+  const buf = Buffer.alloc(lenTag, 0);
+  buf.write('PCP2', 0, 'ascii');
+  buf.writeUInt32BE(16, 4); // len_header = 16
+  buf.writeUInt32BE(lenTag, 8); // len_tag
+  buf.writeUInt32BE(hotCueNum, 12); // hot_cue: 0=memory, 1=A, 2=B, …
+
+  // body at offset 16:
+  buf[16] = 1; // type: 1=point_cue (NOT hot_cue_index)
+  // buf[17] = 0x00
+  buf.writeUInt16BE(0x03e8, 18); // constant
+  buf.writeUInt32BE(positionMs, 20); // time_ms
+  buf.writeUInt32BE(0xffffffff, 24); // loop_time: none
+  // buf[28] = 0x00 (color_id)
+  buf[29] = 0x01; // undocumented constant observed in native Rekordbox files
+  // [30-39]: zeros
+  buf.writeUInt32BE(labelByteLen, 40); // len_comment
+
+  if (labelStr.length > 0) {
+    buf.write(labelStr, 44, 'utf16le'); // write LE then byte-swap to BE
+    for (let j = 44; j < 44 + labelStr.length * 2; j += 2) {
+      const tmp = buf[j];
+      buf[j] = buf[j + 1];
+      buf[j + 1] = tmp;
+    }
+    // null terminator bytes remain 0x00 0x00
+  }
+
+  const colorOff = 44 + labelByteLen;
+  buf[colorOff] = hexToRekordboxColor(color);
+  buf[colorOff + 1] = 0xff; // constant
+  buf.writeUInt16BE(0x0017, colorOff + 2); // constant
+
+  return buf;
+}
+
+function buildPco2Slot(slotType, cues) {
+  // slotType: 1=hot_cues (slot 1), 0=memory_cues (slot 2)
+  if (cues.length === 0) return slotType === 1 ? EMPTY_PCO2_1 : EMPTY_PCO2_2;
+  const headerSize = 20;
+  const entries = cues.map((cue) => {
+    const hotCueNum = cue.hot_cue_index >= 0 ? cue.hot_cue_index + 1 : 0;
+    return buildPcp2Entry(hotCueNum, Math.round(cue.position_ms), cue.label, cue.color);
+  });
+  const bodyLen = entries.reduce((s, e) => s + e.length, 0);
+  const tagLen = headerSize + bodyLen;
+
+  const header = Buffer.alloc(headerSize, 0);
+  header.write('PCO2', 0, 'ascii');
+  header.writeUInt32BE(headerSize, 4); // len_header = 20
+  header.writeUInt32BE(tagLen, 8); // len_tag
+  header.writeUInt32BE(slotType, 12); // type: 1=hot_cues, 0=memory_cues
+  header.writeUInt16BE(cues.length, 16); // num_cues (u16BE)
+  // [18-19]: padding = 0
+
+  return Buffer.concat([header, ...entries]);
+}
+
+/**
+ * Build populated PCO2 section buffers [slot1, slot2] (EXT file only).
+ * Slot 1 (type=1) contains hot cues; slot 2 (type=0) contains memory cues.
  *
  * @param {Array<{position_ms, label, color, hot_cue_index}>} cuePoints
  * @returns {[Buffer, Buffer]}
  */
 export function buildPco2Sections(cuePoints) {
   if (!cuePoints || cuePoints.length === 0) return [EMPTY_PCO2_1, EMPTY_PCO2_2];
-
-  const count = cuePoints.length;
-  const memoryCount = cuePoints.filter((c) => c.hot_cue_index < 0).length;
-  const headerSize = 20;
-
-  // Build entry buffers (variable length due to UTF-16BE labels)
-  const entries = cuePoints.map((cue, i) => {
-    const label = cue.label ?? '';
-    // UTF-16BE encoded label with null terminator, padded to 4-byte boundary
-    const labelByteLen = label.length > 0 ? (label.length + 1) * 2 : 0;
-    const labelPadded = Math.ceil(labelByteLen / 4) * 4;
-    const entrySize = 28 + 4 + labelPadded; // base(28) + label_len(4) + label
-    const buf = Buffer.alloc(entrySize, 0);
-    const hotCue = cue.hot_cue_index >= 0 ? cue.hot_cue_index : 0xff;
-    buf[0] = hotCue;
-    buf[1] = 0x01;
-    buf.writeUInt32BE(i, 4); // order
-    buf[8] = 0x01; // type: cue
-    buf.writeUInt32BE(Math.round(cue.position_ms), 12);
-    buf.writeUInt32BE(0xffffffff, 16); // loop_time: none
-    buf[20] = hexToRekordboxColor(cue.color);
-    buf.writeUInt32BE(labelByteLen, 28);
-    if (label.length > 0) {
-      buf.write(label, 32, 'utf16le'); // little-endian; we'll byte-swap below
-      // Convert UTF-16LE → UTF-16BE
-      for (let j = 32; j < 32 + label.length * 2; j += 2) {
-        const tmp = buf[j];
-        buf[j] = buf[j + 1];
-        buf[j + 1] = tmp;
-      }
-    }
-    return buf;
-  });
-
-  const bodyLen = entries.reduce((s, b) => s + b.length, 0);
-  const tagLen = headerSize + bodyLen;
-
-  function buildOne(primary) {
-    const header = Buffer.alloc(headerSize, 0);
-    header.write('PCO2', 0, 'ascii');
-    header.writeUInt32BE(headerSize, 4);
-    header.writeUInt32BE(primary ? tagLen : headerSize, 8);
-    header.writeUInt32BE(primary ? count : 0, 12);
-    header.writeUInt32BE(primary ? memoryCount : 0, 16);
-    return primary ? Buffer.concat([header, ...entries]) : header;
-  }
-
-  return [buildOne(true), buildOne(false)];
+  const hotCues = cuePoints.filter((c) => c.hot_cue_index >= 0);
+  const memoryCues = cuePoints.filter((c) => c.hot_cue_index < 0);
+  return [buildPco2Slot(1, hotCues), buildPco2Slot(0, memoryCues)];
 }
 
 // ─── PMAI file header ──────────────────────────────────────────────────────────
@@ -667,11 +731,13 @@ export async function writeAnlz(opts) {
 
   // ── ANLZ0000.EXT ─────────────────────────────────────────────────────────────
   // Section order confirmed from native Rekordbox: PPTH, PWV3, PCOB×2, PCO2×2, PQT2, PWV5, PWV4
+  // EXT PCOB must always be empty stubs — cue data in EXT goes only in PCO2 (with PCP2 labels).
+  // DAT PCOB carries the actual PCPT cue entries; EXT PCOB is always EMPTY_PCOB_1 + EMPTY_PCOB_2.
   const extSections = [buildPathTag(usbFilePath)];
   if (waveforms) {
     extSections.push(buildPwv3Section(waveforms.pwv3));
   }
-  extSections.push(pcob1, pcob2, pco2_1, pco2_2);
+  extSections.push(EMPTY_PCOB_1, EMPTY_PCOB_2, pco2_1, pco2_2);
   extSections.push(buildPqt2Section(beats, bpm));
   if (waveforms) {
     extSections.push(buildPwv5Section(waveforms.pwv5));

--- a/src/audio/anlzWriter.js
+++ b/src/audio/anlzWriter.js
@@ -280,31 +280,17 @@ function buildPvbrSection(fileSize) {
 //     [14-23]: zeros
 //     [24-27]: len_comment (u32BE, byte count incl null terminator, 0=no label)
 //     [28+]:   UTF-16BE label (null-terminated), labelByteLen bytes
-//     [28+labelByteLen+0]: color_code (u1): 0x00 for custom RGB
+//     [28+labelByteLen+0]: color_code (u1): Pioneer palette 1-8 (0=no color, see #220)
 //     [28+labelByteLen+1]: color_red   (u1)
 //     [28+labelByteLen+2]: color_green (u1)
 //     [28+labelByteLen+3]: color_blue  (u1)
 //     rest: 40 trailing zeros
 //   Total body = 28 + labelByteLen + 44  (72 for no-label, 88 for 16-byte label)
 //
-// Rekordbox color palette (hot cue / memory cue color index):
-const REKORDBOX_COLORS = [
-  '#ff6b35', // 0  orange-red  (hot cue A default)
-  '#ff0000', // 1  red
-  '#ff9900', // 2  orange
-  '#ffff00', // 3  yellow
-  '#00ff00', // 4  green
-  '#00b4d8', // 5  cyan
-  '#0080ff', // 6  blue
-  '#cc00ff', // 7  violet
-];
-
-function hexToRekordboxColor(hex) {
-  if (!hex) return 5; // default cyan
-  const norm = hex.toLowerCase();
-  const idx = REKORDBOX_COLORS.indexOf(norm);
-  return idx >= 0 ? idx : 5;
-}
+// Pioneer hot cue color palette codes — partially verified (#220):
+//   code 3 = orange (#ff9900) ✓   code 6 = cyan (#00b4d8) ✓
+// Full palette mapping is pending a native Rekordbox hex-diff (see issue #220).
+// Until verified, color_code is left as 0x00 (Rekordbox uses per-slot defaults).
 
 const EMPTY_PCOB_1 = Buffer.from([
   0x50,
@@ -389,7 +375,7 @@ const EMPTY_PCO2_2 = Buffer.from([
  * Builds a single PCPT sub-tag entry (56 bytes, fixed size).
  * Per crate-digger ksy: [12-15]=hot_cue number (0=memory,1=A,2=B…), [28]=type (1=point,2=loop).
  */
-function buildPcptEntry(hotCueNum, positionMs, color) {
+function buildPcptEntry(hotCueNum, positionMs, _color) {
   const buf = Buffer.alloc(56, 0);
   buf.write('PCPT', 0, 'ascii');
   buf.writeUInt32BE(28, 4); // len_header = 28
@@ -403,7 +389,8 @@ function buildPcptEntry(hotCueNum, positionMs, color) {
   buf.writeUInt16BE(0x03e8, 30); // constant
   buf.writeUInt32BE(positionMs, 32); // time_ms
   buf.writeUInt32BE(0xffffffff, 36); // loop_time: none
-  // [40-55]: zeros (verified from native — no color stored in PCPT, only in PCP2)
+  // [40]: Pioneer palette color code — TODO: reverse-engineer exact palette (#issue)
+  // [41-55]: zeros
   return buf;
 }
 
@@ -468,7 +455,7 @@ export function buildExtPcobSections(cuePoints) {
  *   - No-label entry: len_tag=88 (body=72)
  *   - 16-byte label entry: len_tag=104 (body=88)
  *   - Formula: body = 28 + labelByteLen + 44  (28 fixed + label + 4 color + 40 zeros)
- *   - Color: color_code(u1, always 0) + R(u1) + G(u1) + B(u1) from the hex color string
+ *   - Color: color_code(u1, Pioneer palette 1-8, currently 0/no-color, see #220) + R + G + B
  */
 function buildPcp2Entry(hotCueNum, positionMs, label, color) {
   const labelStr = label ?? '';
@@ -506,10 +493,11 @@ function buildPcp2Entry(hotCueNum, positionMs, label, color) {
     // null terminator bytes remain 0x00 0x00
   }
 
-  // Color at [28+labelByteLen]: color_code(u1=0) + R + G + B
-  // color_code=0 signals custom RGB; R/G/B from the stored hex color string.
+  // Color at [28+labelByteLen]: color_code(u1) + R + G + B
+  // color_code=0 means "no color / use Rekordbox default per-slot color".
+  // Full Pioneer palette mapping is tracked in issue #220 — set 0 for now.
   const colorOff = 44 + labelByteLen;
-  buf[colorOff] = 0x00; // color_code = 0 (custom)
+  buf[colorOff] = 0x00; // TODO: write correct Pioneer palette code (see #220)
   if (color && color.startsWith('#') && color.length >= 7) {
     const n = parseInt(color.slice(1), 16);
     buf[colorOff + 1] = (n >> 16) & 0xff; // R

--- a/src/audio/anlzWriter.js
+++ b/src/audio/anlzWriter.js
@@ -246,40 +246,46 @@ function buildPvbrSection(fileSize) {
 // causes Rekordbox to reject the entire ANLZ file, silently dropping waveforms
 // and beatgrids even though those sections precede PCOB in the stream.
 //
-// PCOB header (24 bytes): fourcc + len_header(24) + len_tag + count + memory_count + unk(0xffffffff)
-// PCPT sub-tag (56 bytes, fixed):
+// PCOB header (24 bytes): fourcc + len_header(24) + len_tag + type(u4) + pad(u2) + num_cues(u2) + memory_count(u4)
+//   memory_count = 0xffffffff sentinel in all observed native files.
+// PCPT sub-tag (56 bytes, fixed) — verified by hex-diff against native Rekordbox USB export:
 //   [0-11]:  standard header  fourcc='PCPT', len_header=28, len_tag=56
-//   [12-15]: entry order (1-based)
-//   [16-19]: 0x00000000
-//   [20-21]: 0x0001 (active)
-//   [22-23]: 0x0000
-//   [24-27]: 0xffffffff
-//   [28]:    hot_cue_index (0-7=A-H, 0xff=memory cue)
+//   [12-15]: hot_cue (u4): 0=memory cue, 1=A, 2=B, …
+//   [16-19]: status (u4): 0 — native Rekordbox writes 0 here; KSY label "disabled" is misleading
+//   [20-23]: 0x00010000 (constant)
+//   [24-25]: order_first (u2): 0xffff
+//   [26-27]: order_last  (u2): 0xffff
+//   [28]:    type (u1): 1=cue_point, 2=loop
 //   [29]:    0x00
 //   [30-31]: 0x03e8 (constant observed in all native files)
-//   [32-35]: position_ms (u32BE)
+//   [32-35]: time_ms (u32BE)
 //   [36-39]: loop_time (u32BE, 0xffffffff=none)
-//   [40]:    color_index
-//   [41-55]: zeros
+//   [40-55]: zeros
 //
-// PCO2 header (20 bytes): fourcc + len_header(20) + len_tag + count + memory_count(u16BE) + u16(0)
-// PCP2 sub-tag (variable, min 104 bytes):
+// PCOB split (verified): hot_cue numbers 1-3 (A,B,C) → DAT PCOB1
+//                         hot_cue numbers 4-8 (D-H)   → EXT PCOB1
+//
+// PCO2 header (20 bytes): fourcc + len_header(20) + len_tag + type(u4) + num_cues(u2) + pad(u2)
+// PCP2 sub-tag (variable) — verified by hex-diff against native Rekordbox USB export:
 //   [0-11]:  standard header  fourcc='PCP2', len_header=16, len_tag=variable
-//   [12-15]: entry order (1-based)
+//   [12-15]: hot_cue (u4): 0=memory, 1=A, 2=B, …
 //   body at [16+]:
-//     [0]:    hot_cue_index
+//     [0]:    type (u1): 1=cue_point
 //     [1]:    0x00
 //     [2-3]:  0x03e8 (constant)
-//     [4-7]:  position_ms (u32BE)
-//     [8-11]: loop_time (u32BE)
-//     [12-13]: 0x0001 (status)
+//     [4-7]:  time_ms (u32BE)
+//     [8-11]: loop_time (u32BE, 0xffffffff=none)
+//     [12]:   color_id (0x00)
+//     [13]:   0x01 (constant)
 //     [14-23]: zeros
-//     [24-27]: label_length (bytes incl null terminator, 0=no label)
-//     [28+]:  UTF-16BE label (null-terminated)
-//     [28+labelByteLen]:   color_index
-//     [28+labelByteLen+1]: 0xff (unk, constant in native files)
-//     [28+labelByteLen+2-3]: 0x0017 (unk, constant in native files)
-//     rest: zeros to reach min body size of 88 bytes
+//     [24-27]: len_comment (u32BE, byte count incl null terminator, 0=no label)
+//     [28+]:   UTF-16BE label (null-terminated), labelByteLen bytes
+//     [28+labelByteLen+0]: color_code (u1): 0x00 for custom RGB
+//     [28+labelByteLen+1]: color_red   (u1)
+//     [28+labelByteLen+2]: color_green (u1)
+//     [28+labelByteLen+3]: color_blue  (u1)
+//     rest: 40 trailing zeros
+//   Total body = 28 + labelByteLen + 44  (72 for no-label, 88 for 16-byte label)
 //
 // Rekordbox color palette (hot cue / memory cue color index):
 const REKORDBOX_COLORS = [
@@ -389,16 +395,15 @@ function buildPcptEntry(hotCueNum, positionMs, color) {
   buf.writeUInt32BE(28, 4); // len_header = 28
   buf.writeUInt32BE(56, 8); // len_tag = 56
   buf.writeUInt32BE(hotCueNum, 12); // hot_cue: 0=memory, 1=A, 2=B, …
-  // [16-19]: status = 0x00000000
+  // [16-19]: status = 0 — native Rekordbox writes 0 here (KSY "disabled" is a misnomer)
   buf.writeUInt32BE(0x00010000, 20); // constant observed in all native Rekordbox files
   buf.writeUInt16BE(0xffff, 24); // order_first
   buf.writeUInt16BE(0xffff, 26); // order_last
-  buf[28] = 1; // type: 1=point_cue (NOT hot_cue_index)
-  // buf[29] = 0x00
+  buf[28] = 1; // type: 1=cue_point
   buf.writeUInt16BE(0x03e8, 30); // constant
   buf.writeUInt32BE(positionMs, 32); // time_ms
   buf.writeUInt32BE(0xffffffff, 36); // loop_time: none
-  buf[40] = hexToRekordboxColor(color);
+  // [40-55]: zeros (verified from native — no color stored in PCPT, only in PCP2)
   return buf;
 }
 
@@ -428,29 +433,50 @@ function buildPcobSlot(slotType, cues) {
 }
 
 /**
- * Build populated PCOB section buffers [slot1, slot2].
- * Slot 1 (type=1) contains hot cues only. Slot 2 is ALWAYS the empty stub —
- * Rekordbox rejects the entire ANLZ file if PCOB2 contains any entries.
- * Memory cues are stored exclusively in EXT PCO2.
+ * Build PCOB buffers for the DAT file [slot1, slot2].
+ * Verified split from native Rekordbox: hot_cue numbers 1-3 (A,B,C) go in DAT PCOB1.
+ * Cues D-H (hot_cue numbers 4-8) go in EXT PCOB1 — see buildExtPcobSections().
+ * PCOB2 is always the empty stub (PCOB2 memory cue format still under investigation, #208).
  *
  * @param {Array<{position_ms, color, hot_cue_index}>} cuePoints
  * @returns {[Buffer, Buffer]}
  */
 export function buildPcobSections(cuePoints) {
   if (!cuePoints || cuePoints.length === 0) return [EMPTY_PCOB_1, EMPTY_PCOB_2];
-  const hotCues = cuePoints.filter((c) => c.hot_cue_index >= 0);
-  return [buildPcobSlot(1, hotCues), EMPTY_PCOB_2];
+  // hot_cue_index 0,1,2 → hot_cue numbers 1,2,3 (A,B,C) — DAT only
+  const datHotCues = cuePoints.filter((c) => c.hot_cue_index >= 0 && c.hot_cue_index <= 2);
+  return [buildPcobSlot(1, datHotCues), EMPTY_PCOB_2];
 }
 
 /**
- * Builds a single PCP2 sub-tag entry (variable size, min 104 bytes).
- * Per crate-digger ksy: [12-15]=hot_cue number, [16]=type (1=point_cue).
+ * Build PCOB buffers for the EXT file [slot1, slot2].
+ * Verified split: hot_cue numbers 4-8 (D-H, hot_cue_index 3-7) go in EXT PCOB1.
+ *
+ * @param {Array<{position_ms, color, hot_cue_index}>} cuePoints
+ * @returns {[Buffer, Buffer]}
+ */
+export function buildExtPcobSections(cuePoints) {
+  if (!cuePoints || cuePoints.length === 0) return [EMPTY_PCOB_1, EMPTY_PCOB_2];
+  // hot_cue_index 3-7 → hot_cue numbers 4-8 (D-H) — EXT only
+  const extHotCues = cuePoints.filter((c) => c.hot_cue_index >= 3 && c.hot_cue_index <= 7);
+  return [buildPcobSlot(1, extHotCues), EMPTY_PCOB_2];
+}
+
+/**
+ * Builds a single PCP2 sub-tag entry.
+ * Verified against native Rekordbox USB exports (issue #208 hex-diff):
+ *   - No-label entry: len_tag=88 (body=72)
+ *   - 16-byte label entry: len_tag=104 (body=88)
+ *   - Formula: body = 28 + labelByteLen + 44  (28 fixed + label + 4 color + 40 zeros)
+ *   - Color: color_code(u1, always 0) + R(u1) + G(u1) + B(u1) from the hex color string
  */
 function buildPcp2Entry(hotCueNum, positionMs, label, color) {
   const labelStr = label ?? '';
-  const labelByteLen = labelStr.length > 0 ? (labelStr.length + 1) * 2 : 0; // UTF-16BE + null
-  // body (starting at offset 16) is min 88 bytes
-  const bodySize = Math.max(88, 28 + labelByteLen + 4);
+  const labelByteLen = labelStr.length > 0 ? (labelStr.length + 1) * 2 : 0; // UTF-16BE + null terminator
+  // When a label is present, body is always at least 88 bytes (native Rekordbox
+  // always produces lenTag=104 regardless of label length ≤ 7 chars).
+  // For labels > 7 chars the body grows proportionally.
+  const bodySize = labelStr.length > 0 ? Math.max(88, 28 + labelByteLen + 44) : 72;
   const lenTag = 16 + bodySize;
 
   const buf = Buffer.alloc(lenTag, 0);
@@ -460,15 +486,15 @@ function buildPcp2Entry(hotCueNum, positionMs, label, color) {
   buf.writeUInt32BE(hotCueNum, 12); // hot_cue: 0=memory, 1=A, 2=B, …
 
   // body at offset 16:
-  buf[16] = 1; // type: 1=point_cue (NOT hot_cue_index)
-  // buf[17] = 0x00
-  buf.writeUInt16BE(0x03e8, 18); // constant
+  buf[16] = 1; // type: 1=cue_point
+  // [17] = 0x00
+  buf.writeUInt16BE(0x03e8, 18); // constant (verified in native)
   buf.writeUInt32BE(positionMs, 20); // time_ms
   buf.writeUInt32BE(0xffffffff, 24); // loop_time: none
-  // buf[28] = 0x00 (color_id)
-  buf[29] = 0x01; // undocumented constant observed in native Rekordbox files
+  // [28] = 0x00 (color_id)
+  buf[29] = 0x01; // constant (verified in native)
   // [30-39]: zeros
-  buf.writeUInt32BE(labelByteLen, 40); // len_comment
+  buf.writeUInt32BE(labelByteLen, 40); // len_comment (byte count incl null terminator)
 
   if (labelStr.length > 0) {
     buf.write(labelStr, 44, 'utf16le'); // write LE then byte-swap to BE
@@ -480,10 +506,17 @@ function buildPcp2Entry(hotCueNum, positionMs, label, color) {
     // null terminator bytes remain 0x00 0x00
   }
 
+  // Color at [28+labelByteLen]: color_code(u1=0) + R + G + B
+  // color_code=0 signals custom RGB; R/G/B from the stored hex color string.
   const colorOff = 44 + labelByteLen;
-  buf[colorOff] = hexToRekordboxColor(color);
-  buf[colorOff + 1] = 0xff; // constant
-  buf.writeUInt16BE(0x0017, colorOff + 2); // constant
+  buf[colorOff] = 0x00; // color_code = 0 (custom)
+  if (color && color.startsWith('#') && color.length >= 7) {
+    const n = parseInt(color.slice(1), 16);
+    buf[colorOff + 1] = (n >> 16) & 0xff; // R
+    buf[colorOff + 2] = (n >> 8) & 0xff; // G
+    buf[colorOff + 3] = n & 0xff; // B
+  }
+  // trailing 40 zeros already set by Buffer.alloc
 
   return buf;
 }
@@ -713,8 +746,11 @@ export async function writeAnlz(opts) {
   }
   const pvbrSection = buildPvbrSection(audioFileSize);
 
-  // ── Build cue sections once — shared by DAT and EXT ─────────────────────────
+  // ── Build cue sections ──────────────────────────────────────────────────────
+  // DAT PCOB: hot cues A,B,C (hot_cue numbers 1-3) only
   const [pcob1, pcob2] = buildPcobSections(cuePoints ?? []);
+  // EXT PCOB: hot cues D-H (hot_cue numbers 4-8) only
+  const [extPcob1, extPcob2] = buildExtPcobSections(cuePoints ?? []);
   const [pco2_1, pco2_2] = buildPco2Sections(cuePoints ?? []);
 
   // ── ANLZ0000.DAT ─────────────────────────────────────────────────────────────
@@ -731,13 +767,13 @@ export async function writeAnlz(opts) {
 
   // ── ANLZ0000.EXT ─────────────────────────────────────────────────────────────
   // Section order confirmed from native Rekordbox: PPTH, PWV3, PCOB×2, PCO2×2, PQT2, PWV5, PWV4
-  // EXT PCOB must always be empty stubs — cue data in EXT goes only in PCO2 (with PCP2 labels).
-  // DAT PCOB carries the actual PCPT cue entries; EXT PCOB is always EMPTY_PCOB_1 + EMPTY_PCOB_2.
+  // EXT PCOB1: hot cues D-H (numbers 4-8); EXT PCOB2: empty stub (#208)
+  // PCO2 carries all cues with labels/colors for both DAT and EXT cues.
   const extSections = [buildPathTag(usbFilePath)];
   if (waveforms) {
     extSections.push(buildPwv3Section(waveforms.pwv3));
   }
-  extSections.push(EMPTY_PCOB_1, EMPTY_PCOB_2, pco2_1, pco2_2);
+  extSections.push(extPcob1, extPcob2, pco2_1, pco2_2);
   extSections.push(buildPqt2Section(beats, bpm));
   if (waveforms) {
     extSections.push(buildPwv5Section(waveforms.pwv5));

--- a/src/audio/cueGen.js
+++ b/src/audio/cueGen.js
@@ -5,10 +5,13 @@
  * using the analysis data already stored by mixxx-analyzer (intro_secs,
  * outro_secs, beatgrid, bpm) — no external .NET runtime required.
  *
- * Generated cues:
+ * Generated cues (all assigned as hot cues A–H, indices 0–7):
  *   Hot cue A (index 0) — intro end: first beat after the intro (mix-in point)
- *   Memory cues          — every 32 bars from the intro end (section markers)
- *   Memory cue           — outro start: last strong beat before the fade/outro
+ *   Hot cues B–G        — every 32 bars from the intro end (section markers)
+ *   Hot cue H (or last) — outro start: last strong beat before the fade/outro
+ *
+ * Memory cues (hotCueIndex = -1) are NOT used because their PCOB2 binary
+ * format is not yet reverse-engineered and they are invisible in Rekordbox.
  */
 
 const HOT_CUE_COLOR = '#ff6b35'; // orange-red, matches Rekordbox default hot cue A
@@ -68,7 +71,10 @@ export function generateCuePoints(track) {
 
   const beats = parseBeatgrid(track.beatgrid);
 
-  const cues = [];
+  // Cues are collected in order and assigned to hot cue slots A–H (0–7).
+  // The outro cue is reserved for the last available slot (H if 8+ cues, or
+  // whatever slot comes after the phrase markers).
+  const raw = []; // { positionMs, label, color }
 
   // ── Hot cue A: mix-in point (intro end) ────────────────────────────────────
   let introEndSecs = introSecs;
@@ -77,17 +83,16 @@ export function generateCuePoints(track) {
     const idx = nearestBeatIndex(beats, introSecs);
     introEndSecs = beats[idx].positionSecs;
   }
-  cues.push({
+  raw.push({
     positionMs: Math.round(introEndSecs * 1000),
     label: 'Mix In',
     color: HOT_CUE_COLOR,
-    hotCueIndex: 0, // hot cue A
   });
 
   // outro_secs is absolute — use directly as the cut-off for phrase markers
   const outroStartSecs = outroSecs > 0 ? outroSecs : duration;
 
-  // ── Memory cues: phrase markers every 32 bars ───────────────────────────────
+  // ── Phrase markers every 32 bars ───────────────────────────────────────────
   if (bpm > 0) {
     const secsPerBar = (60 / bpm) * 4; // 4/4 time
     const phraseSecs = secsPerBar * 32;
@@ -99,11 +104,10 @@ export function generateCuePoints(track) {
       while (phraseIdx < beats.length) {
         const pos = beats[phraseIdx].positionSecs;
         if (pos >= outroStartSecs - 2) break;
-        cues.push({
+        raw.push({
           positionMs: Math.round(pos * 1000),
           label: `Bar ${Math.round((pos - introEndSecs) / secsPerBar) + 1}`,
           color: SECTION_COLOR,
-          hotCueIndex: -1,
         });
         phraseIdx += 128;
       }
@@ -111,31 +115,31 @@ export function generateCuePoints(track) {
       // No beatgrid — use BPM arithmetic
       let pos = introEndSecs + phraseSecs;
       while (pos < outroStartSecs - 2) {
-        cues.push({
+        raw.push({
           positionMs: Math.round(pos * 1000),
           label: `Bar ${Math.round((pos - introEndSecs) / secsPerBar) + 1}`,
           color: SECTION_COLOR,
-          hotCueIndex: -1,
         });
         pos += phraseSecs;
       }
     }
   }
 
-  // ── Memory cue: outro start (mix-out point) ─────────────────────────────────
+  // ── Outro start (mix-out point) ─────────────────────────────────────────────
   if (outroSecs > 0 && outroSecs < duration) {
     let mixOutSecs = outroSecs;
     if (beats) {
       const idx = nearestBeatIndex(beats, outroSecs);
       mixOutSecs = beats[idx].positionSecs;
     }
-    cues.push({
+    raw.push({
       positionMs: Math.round(mixOutSecs * 1000),
       label: 'Mix Out',
       color: OUTRO_COLOR,
-      hotCueIndex: -1,
     });
   }
 
-  return cues;
+  // Assign hot cue slots A–H (indices 0–7). Cues beyond index 7 are dropped
+  // since memory cue format is not yet supported (see issue #208).
+  return raw.slice(0, 8).map((cue, i) => ({ ...cue, hotCueIndex: i }));
 }

--- a/src/audio/cueGen.js
+++ b/src/audio/cueGen.js
@@ -14,7 +14,7 @@
  * format is not yet reverse-engineered and they are invisible in Rekordbox.
  */
 
-const HOT_CUE_COLOR = '#ff6b35'; // orange-red, matches Rekordbox default hot cue A
+const HOT_CUE_COLOR = '#ff0000'; // red → Pioneer palette code 4 (distinct from orange Mix Out)
 const SECTION_COLOR = '#00b4d8'; // cyan for phrase markers
 const OUTRO_COLOR = '#ff9900'; // amber for the outro/mix-out marker
 

--- a/src/audio/waveformGenerator.js
+++ b/src/audio/waveformGenerator.js
@@ -12,11 +12,22 @@ export const PWV2_COLS = 100; // PWV2: tiny overview (CDJ-900)
 export const PWV4_COLS = 1200; // PWV4: colour overview (NXS2), 6 bytes/col
 export const PWV6_COLS = 1200; // PWV6: colour overview for 2EX (CDJ-3000), 3 bytes/col
 
+// Two-stage EMA cutoffs for frequency band separation (applied to |sample|).
+// α ≈ 2π·f_c / f_s  →  0.03 ≈ 105 Hz (bass),  0.28 ≈ 980 Hz (bass+mid)
+const ALPHA_BASS = 0.03;
+const ALPHA_MID = 0.28;
+
 // ─── Per-slice analysis ───────────────────────────────────────────────────────
 
 /**
  * Compute RMS, peak, and approximate frequency-band energies for a sample slice.
- * Uses a two-stage IIR to separate bass (<~500 Hz) from treble (>~2 kHz).
+ * Uses two cascaded EMA low-pass filters on |sample| to separate bass/mid/treble.
+ *   bass   ≈ 0–105 Hz  (EMA α=0.03)
+ *   mid    ≈ 105–980 Hz (difference of the two EMAs)
+ *   treble ≈ >980 Hz   (residual above upper EMA)
+ *
+ * For per-column overview segments (thousands of samples) the EMA settles fully
+ * within the slice, so initialising from the first sample is accurate enough.
  */
 function analyzeSlice(samples, start, end) {
   const len = end - start;
@@ -25,27 +36,30 @@ function analyzeSlice(samples, start, end) {
   let sumSq = 0;
   let peak = 0;
   let bassSum = 0;
+  let midSum = 0;
   let trebleSum = 0;
-  // EMA low-pass: alpha=0.1 approximates a ~450 Hz cutoff at 22050 Hz
-  let ema = Math.abs(samples[start] || 0);
+  let emaBass = Math.abs(samples[start] || 0);
+  let emaMid = emaBass;
 
   for (let i = start; i < end; i++) {
     const s = samples[i] || 0;
     const abs = Math.abs(s);
     sumSq += s * s;
     if (abs > peak) peak = abs;
-    ema = 0.1 * abs + 0.9 * ema;
-    bassSum += ema;
-    trebleSum += Math.max(0, abs - ema);
+    emaBass = ALPHA_BASS * abs + (1 - ALPHA_BASS) * emaBass;
+    emaMid = ALPHA_MID * abs + (1 - ALPHA_MID) * emaMid;
+    bassSum += emaBass;
+    midSum += Math.max(0, emaMid - emaBass);
+    trebleSum += Math.max(0, abs - emaMid);
   }
 
-  const rms = Math.sqrt(sumSq / len);
-  const bassRms = bassSum / len;
-  const trebleRms = trebleSum / len;
-  // Mid is energy that sits between bass and treble approximations
-  const midRms = Math.max(0, rms - bassRms - trebleRms * 0.5);
-
-  return { rms, peak, bassRms, midRms, trebleRms };
+  return {
+    rms: Math.sqrt(sumSq / len),
+    peak,
+    bassRms: bassSum / len,
+    midRms: midSum / len,
+    trebleRms: trebleSum / len,
+  };
 }
 
 // ─── Column encoders ──────────────────────────────────────────────────────────
@@ -81,7 +95,7 @@ function computeColumns(samples) {
 
   // PWV3: 1 byte per col — (whiteness[0-7] << 5) | height[0-31]
   const pwv3 = Buffer.alloc(numCols);
-  // PWV5: 2 bytes per col — correct RGB+height u16be per Pioneer/crate-digger spec:
+  // PWV5: 2 bytes per col — RGB+height u16be per Pioneer/crate-digger spec:
   //   bits 15-13: red (treble, 3 bits)
   //   bits 12-10: green (mid,    3 bits)
   //   bits  9- 7: blue  (bass,   3 bits)
@@ -91,15 +105,37 @@ function computeColumns(samples) {
   // PWV7: 3 bytes per col — [treble, mid, bass] each 0-255 (CDJ-3000 / .2EX)
   const pwv7 = Buffer.alloc(numCols * 3);
 
+  // Carry EMA state across columns — critical for the bass channel where the
+  // time constant (1/α_bass = 33 samples) is comparable to SAMPLES_PER_COL (147).
+  let emaBass = 0;
+  let emaMid = 0;
+
   for (let col = 0; col < numCols; col++) {
     const start = col * SAMPLES_PER_COL;
-    const { rms, peak, bassRms, midRms, trebleRms } = analyzeSlice(
-      samples,
-      start,
-      start + SAMPLES_PER_COL
-    );
-    const { height, whiteness } = monoHeightWhiteness(rms, peak);
+    let sumSq = 0;
+    let peak = 0;
+    let bassSum = 0;
+    let midSum = 0;
+    let trebleSum = 0;
 
+    for (let i = start; i < start + SAMPLES_PER_COL; i++) {
+      const s = samples[i] || 0;
+      const abs = Math.abs(s);
+      sumSq += s * s;
+      if (abs > peak) peak = abs;
+      emaBass = ALPHA_BASS * abs + (1 - ALPHA_BASS) * emaBass;
+      emaMid = ALPHA_MID * abs + (1 - ALPHA_MID) * emaMid;
+      bassSum += emaBass;
+      midSum += Math.max(0, emaMid - emaBass);
+      trebleSum += Math.max(0, abs - emaMid);
+    }
+
+    const rms = Math.sqrt(sumSq / SAMPLES_PER_COL);
+    const bassRms = bassSum / SAMPLES_PER_COL;
+    const midRms = midSum / SAMPLES_PER_COL;
+    const trebleRms = trebleSum / SAMPLES_PER_COL;
+
+    const { height, whiteness } = monoHeightWhiteness(rms, peak);
     pwv3[col] = ((whiteness & 7) << 5) | (height & 31);
 
     const r = Math.min(7, Math.round(trebleRms * 28));
@@ -135,20 +171,19 @@ function computeColumns(samples) {
   );
 
   // PWV4: 1200 × 6 bytes — colour overview (NXS2)
-  //   byte 0: whiteness/brightness indicator
-  //   byte 1: whiteness/brightness indicator
-  //   byte 2: energy_bottom_half_freq  (overall RMS, < ~10 kHz)
-  //   byte 3: energy_bottom_third_freq (bass, < ~3.5 kHz)
-  //   byte 4: energy_mid_third_freq    (mid,  3.5–7 kHz)
-  //   byte 5: energy_top_third_freq    (treble, > 7 kHz)
+  //   byte 0: peak intensity  (peak * 255)          — confirmed from native files
+  //   byte 1: complement      (255 - byte0)          — native avg b0+b1 ≈ 255
+  //   byte 2: overall RMS     (rms * 510, capped)
+  //   byte 3: bass energy     (0–105 Hz)
+  //   byte 4: mid energy      (105–980 Hz)
+  //   byte 5: treble energy   (>980 Hz)
   const pwv4 = Buffer.concat(
     computeFixedColumns(samples, PWV4_COLS, (s, a, b) => {
       const { rms, peak, bassRms, midRms, trebleRms } = analyzeSlice(s, a, b);
-      const transientRatio = rms > 0.001 ? Math.min(peak / (rms + 0.001), 4) : 0;
-      const whiteness = Math.min(255, Math.round(transientRatio * 64));
+      const peakByte = Math.min(255, Math.round(peak * 255));
       return Buffer.from([
-        whiteness,
-        whiteness,
+        peakByte,
+        255 - peakByte,
         Math.min(255, Math.round(rms * 510)),
         Math.min(255, Math.round(bassRms * 510)),
         Math.min(255, Math.round(midRms * 510)),


### PR DESCRIPTION
## Summary

- fix(#208/#219): Corrects PCOB/PCO2 ANLZ binary format so hot cue points are visible in Rekordbox/CDJs after USB export.
- fix(#218): Fixes waveform colour — PWV4 byte encoding corrected; two-stage EMA gives proper bass/mid/treble split.
- fix(#219): cueGen assigns hot cue indices 0-7 to all auto-generated cues; PCP2 label body padded to minimum 88 bytes.
- ref(#220): Adds scripts/anlz-diff.js for future hot-cue colour reverse-engineering.

## Still pending

- #208/#217: Memory cue (PCOB2) format still unknown — generated cues use hot cue slots A-H as workaround.
- #220: Hot cue colours use color_code=0 (Rekordbox per-slot defaults) — full Pioneer palette needs a native hex-diff to verify.

## Test plan
- Export to USB and load in Rekordbox, verify cue points A-H appear
- Verify waveform colours show bass/mid/treble bands
- npm test passes (51 anlzWriter tests)
- npm run lint:all clean
