### PR TITLE
feat(#209): per-cue export enable/disable toggle

### DIFF
--- a/renderer/src/CuePointsEditor.css
+++ b/renderer/src/CuePointsEditor.css
@@ -258,6 +258,36 @@
   transform: scale(1.2);
 }
 
+.cpe__row--disabled .cpe__badge,
+.cpe__row--disabled .cpe__time,
+.cpe__row--disabled .cpe__label {
+  opacity: 0.35;
+}
+
+.cpe__export-toggle {
+  flex-shrink: 0;
+  font-size: 13px;
+  color: #3a8a3a;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.12s;
+}
+
+.cpe__export-toggle:hover {
+  color: #5cba5c;
+}
+
+.cpe__export-toggle--off {
+  color: #555;
+}
+
+.cpe__export-toggle--off:hover {
+  color: #888;
+}
+
 .cpe__del {
   flex-shrink: 0;
   font-size: 10px;

--- a/renderer/src/CuePointsEditor.jsx
+++ b/renderer/src/CuePointsEditor.jsx
@@ -172,6 +172,11 @@ export default function CuePointsEditor({ trackId, onCuePointsChange }) {
     setEditLabel(cue.label ?? '');
   };
 
+  const handleToggleEnabled = async (id, currentEnabled) => {
+    await window.api.updateCuePoint(id, { enabled: currentEnabled === 0 ? 1 : 0 });
+    reload();
+  };
+
   // Change a cue's type: -1 = memory, 0-7 = hot cue A-H
   const handleTypeChange = async (id, hotCueIndex) => {
     setTypePickerId(null);
@@ -248,7 +253,10 @@ export default function CuePointsEditor({ trackId, onCuePointsChange }) {
       ) : (
         <div className="cpe__list">
           {visibleCues.map((cue) => (
-            <div key={cue.id} className="cpe__row">
+            <div
+              key={cue.id}
+              className={`cpe__row${cue.enabled === 0 ? ' cpe__row--disabled' : ''}`}
+            >
               {/* Type badge — click to open type picker */}
               <div className="cpe__badge-wrap">
                 <div
@@ -334,6 +342,19 @@ export default function CuePointsEditor({ trackId, onCuePointsChange }) {
                   />
                 ))}
               </div>
+
+              {/* Export toggle */}
+              <button
+                className={`cpe__export-toggle${cue.enabled === 0 ? ' cpe__export-toggle--off' : ''}`}
+                onClick={() => handleToggleEnabled(cue.id, cue.enabled)}
+                title={
+                  cue.enabled === 0
+                    ? 'Excluded from USB export — click to include'
+                    : 'Included in USB export — click to exclude'
+                }
+              >
+                {cue.enabled === 0 ? '⊘' : '⊙'}
+              </button>
 
               {/* Delete */}
               {confirmDeleteId === cue.id ? (

--- a/src/db/cuePointRepository.js
+++ b/src/db/cuePointRepository.js
@@ -22,7 +22,7 @@ export function addCuePoint({
   return info.lastInsertRowid;
 }
 
-export function updateCuePoint(id, { label, color, hotCueIndex }) {
+export function updateCuePoint(id, { label, color, hotCueIndex, enabled }) {
   const fields = [];
   const vals = [];
   if (label !== undefined) {
@@ -36,6 +36,10 @@ export function updateCuePoint(id, { label, color, hotCueIndex }) {
   if (hotCueIndex !== undefined) {
     fields.push('hot_cue_index = ?');
     vals.push(hotCueIndex);
+  }
+  if (enabled !== undefined) {
+    fields.push('enabled = ?');
+    vals.push(enabled ? 1 : 0);
   }
   if (fields.length === 0) return;
   vals.push(id);

--- a/src/db/migrations.js
+++ b/src/db/migrations.js
@@ -185,4 +185,9 @@ export function initDB() {
     ON cue_points(track_id)
   `
   ).run();
+
+  // #209: per-cue export enable/disable toggle
+  try {
+    db.prepare('ALTER TABLE cue_points ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1').run();
+  } catch {}
 }

--- a/src/main.js
+++ b/src/main.js
@@ -441,8 +441,8 @@ ipcMain.handle('add-cue-point', (_, { trackId, positionMs, label, color, hotCueI
   return { id };
 });
 
-ipcMain.handle('update-cue-point', (_, { id, label, color, hotCueIndex }) => {
-  updateCuePoint(id, { label, color, hotCueIndex });
+ipcMain.handle('update-cue-point', (_, { id, label, color, hotCueIndex, enabled }) => {
+  updateCuePoint(id, { label, color, hotCueIndex, enabled });
   return { ok: true };
 });
 
@@ -1298,7 +1298,7 @@ ipcMain.handle(
             bpm: t.bpm_override ?? t.bpm ?? 0,
             usbRoot,
             ffmpegPath: getFfmpegRuntimePath(),
-            cuePoints: getCuePoints(t.id),
+            cuePoints: getCuePoints(t.id).filter((c) => c.enabled !== 0),
           });
         } catch (err) {
           console.warn(`ANLZ write failed for track ${t.id}:`, err.message);
@@ -1452,7 +1452,7 @@ ipcMain.handle(
             bpm: t.bpm_override ?? t.bpm ?? 0,
             usbRoot,
             ffmpegPath: getFfmpegRuntimePath(),
-            cuePoints: getCuePoints(t.id),
+            cuePoints: getCuePoints(t.id).filter((c) => c.enabled !== 0),
           });
         } catch (err) {
           console.warn(`ANLZ write failed for track ${t.id}:`, err.message);


### PR DESCRIPTION
Each cue row now has a green circle button (included in USB export) that turns grey when clicked (excluded). The cue stays in the library and is visible on the seekbar - it just gets filtered before writing ANLZ files.

- DB migration: enabled column (default 1)
- updateCuePoint accepts enabled field
- Export pipeline filters enabled=0 before anlzWriter
- UI: circle/no-entry icon per row, dimmed row styling when excluded