### PR TITLE
fix(#210): save-to-playlist selector above track list (Tidal + yt-dlp)

### DIFF
--- a/renderer/src/DownloadView.jsx
+++ b/renderer/src/DownloadView.jsx
@@ -636,6 +636,33 @@ export default function DownloadView({ onGoToLibrary, onGoToPlaylist, style }) {
           </div>
 
           {playlistInfo.type === 'playlist' && (
+            <div className="dl-playlist-target">
+              <label className="dl-playlist-target-label">1. Save to playlist</label>
+              <select
+                className="dl-playlist-select"
+                value={targetPlaylistId ?? ''}
+                onChange={(e) => handleTargetPlaylistChange(e.target.value || null)}
+              >
+                <option value="">New playlist</option>
+                {playlists.map((pl) => (
+                  <option key={pl.id} value={pl.id}>
+                    {pl.name}
+                  </option>
+                ))}
+              </select>
+              {!targetPlaylistId && (
+                <input
+                  className="dl-playlist-name-input"
+                  type="text"
+                  placeholder="Playlist name"
+                  value={targetPlaylistName}
+                  onChange={(e) => setTargetPlaylistName(e.target.value)}
+                />
+              )}
+            </div>
+          )}
+
+          {playlistInfo.type === 'playlist' && (
             <div className="dl-select-toolbar">
               <label className="dl-select-all-label">
                 <input
@@ -646,7 +673,7 @@ export default function DownloadView({ onGoToLibrary, onGoToPlaylist, style }) {
                   }}
                   onChange={handleToggleAll}
                 />
-                {allSelected ? 'Deselect all' : 'Select all'}
+                {allSelected ? 'Deselect all' : '2. Select tracks'}
               </label>
               <div className="dl-select-filter-btns">
                 {downloadableEntries.length > 0 && (
@@ -743,32 +770,6 @@ export default function DownloadView({ onGoToLibrary, onGoToPlaylist, style }) {
           </div>
 
           <div className="dl-select-footer">
-            {playlistInfo.type === 'playlist' && (
-              <div className="dl-playlist-target">
-                <label className="dl-playlist-target-label">Save to playlist</label>
-                <select
-                  className="dl-playlist-select"
-                  value={targetPlaylistId ?? ''}
-                  onChange={(e) => handleTargetPlaylistChange(e.target.value || null)}
-                >
-                  <option value="">New playlist</option>
-                  {playlists.map((pl) => (
-                    <option key={pl.id} value={pl.id}>
-                      {pl.name}
-                    </option>
-                  ))}
-                </select>
-                {!targetPlaylistId && (
-                  <input
-                    className="dl-playlist-name-input"
-                    type="text"
-                    placeholder="Playlist name"
-                    value={targetPlaylistName}
-                    onChange={(e) => setTargetPlaylistName(e.target.value)}
-                  />
-                )}
-              </div>
-            )}
             <button
               className="dl-btn"
               onClick={handleDownload}

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -656,11 +656,36 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
           </p>
         </div>
 
+        <div className="dl-playlist-target">
+          <label className="dl-playlist-target-label">1. Save to playlist</label>
+          <select
+            className="dl-playlist-select"
+            value={targetPlaylistId ?? ''}
+            onChange={(e) => handleTargetPlaylistChange(e.target.value || null)}
+          >
+            <option value="">None / new playlist</option>
+            {playlists.map((pl) => (
+              <option key={pl.id} value={pl.id}>
+                {pl.name}
+              </option>
+            ))}
+          </select>
+          {!targetPlaylistId && (
+            <input
+              className="dl-playlist-name-input"
+              type="text"
+              placeholder="New playlist name (optional)"
+              value={targetPlaylistName}
+              onChange={(e) => setTargetPlaylistName(e.target.value)}
+            />
+          )}
+        </div>
+
         <div className="dl-select-list">
           <div className="dl-select-header">
             <label className="dl-select-all">
               <input type="checkbox" checked={allSelected} onChange={handleToggleAll} />
-              <span>Select all</span>
+              <span>2. Select tracks</span>
             </label>
             <span className="dl-select-count">
               {totalActive} / {entries.length} selected
@@ -704,31 +729,6 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
               );
             })}
           </div>
-        </div>
-
-        <div className="dl-playlist-target">
-          <label className="dl-playlist-target-label">Save to playlist</label>
-          <select
-            className="dl-playlist-select"
-            value={targetPlaylistId ?? ''}
-            onChange={(e) => handleTargetPlaylistChange(e.target.value || null)}
-          >
-            <option value="">None / new playlist</option>
-            {playlists.map((pl) => (
-              <option key={pl.id} value={pl.id}>
-                {pl.name}
-              </option>
-            ))}
-          </select>
-          {!targetPlaylistId && (
-            <input
-              className="dl-playlist-name-input"
-              type="text"
-              placeholder="New playlist name (optional)"
-              value={targetPlaylistName}
-              onChange={(e) => setTargetPlaylistName(e.target.value)}
-            />
-          )}
         </div>
 
         <div className="dl-select-actions">


### PR DESCRIPTION
## Summary

- Moves the "Save to playlist" combobox to be **step 1** (above the track list) in both the Tidal and yt-dlp download selection screens
- Users now pick the target playlist first; the track list immediately reflects which entries are already in that playlist ("✓ In playlist" — disabled), which are linkable (in library, not yet in playlist), and which will be downloaded (new tracks)
- The recalculation logic (`handleTargetPlaylistChange`) was already correct; only the layout position was wrong

## Changes

- `TidalDownloadView.jsx`: playlist target moved from below the track list to above it; "Select all" label updated to "2. Select tracks" for clarity
- `DownloadView.jsx`: same layout change for yt-dlp; playlist target extracted from `dl-select-footer` and placed above the toolbar + track list

## Test plan

- [ ] Load a Tidal playlist URL — "Save to playlist" dropdown appears at the top of the selection screen
- [ ] Select an existing DJManager playlist from the dropdown — tracks already in that playlist show as disabled "✓ In playlist"
- [ ] Change to a different playlist — checkbox states update to reflect the new playlist's contents
- [ ] Do the same test with a YouTube/SoundCloud playlist via yt-dlp DownloadView
- [ ] Verify the download button still works correctly after selection

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)