### PR TITLE
feat(#157): Ctrl+Scroll / Ctrl+=/−/0 zoom control with persistence

### DIFF
--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -35,6 +35,67 @@ function App() {
     return unsub;
   }, []);
 
+  // ── Zoom control: Ctrl+=/−, Ctrl+0, Ctrl+Scroll ───────────────────────────
+  useEffect(() => {
+    const ZOOM_MIN = 0.5;
+    const ZOOM_MAX = 2.0;
+    const ZOOM_STEP = 0.1;
+    const ZOOM_KEY = 'app-zoom-factor';
+
+    const clamp = (v) => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(v * 10) / 10));
+
+    // Restore persisted zoom on mount
+    try {
+      const saved = parseFloat(localStorage.getItem(ZOOM_KEY));
+      if (saved && isFinite(saved)) window.api.setZoomFactor(clamp(saved));
+    } catch {
+      /* ignore */
+    }
+
+    const applyZoom = (delta) => {
+      const current = window.api.getZoomFactor();
+      const next = clamp(current + delta);
+      window.api.setZoomFactor(next);
+      try {
+        localStorage.setItem(ZOOM_KEY, String(next));
+      } catch {
+        /* ignore */
+      }
+    };
+
+    const handleKeyDown = (e) => {
+      if (!e.ctrlKey) return;
+      if (e.key === '=' || e.key === '+') {
+        e.preventDefault();
+        applyZoom(+ZOOM_STEP);
+      } else if (e.key === '-') {
+        e.preventDefault();
+        applyZoom(-ZOOM_STEP);
+      } else if (e.key === '0') {
+        e.preventDefault();
+        window.api.setZoomFactor(1);
+        try {
+          localStorage.removeItem(ZOOM_KEY);
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+
+    const handleWheel = (e) => {
+      if (!e.ctrlKey) return;
+      e.preventDefault();
+      applyZoom(e.deltaY < 0 ? +ZOOM_STEP : -ZOOM_STEP);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('wheel', handleWheel);
+    };
+  }, []);
+
   return (
     <PlayerProvider>
       <DownloadProvider>

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -40,6 +40,8 @@ window.api = {
   checkDepUpdates: vi.fn().mockResolvedValue({}),
   updateAllDeps: vi.fn().mockResolvedValue(undefined),
   updateTidalDlNg: vi.fn().mockResolvedValue({ ok: true }),
+  getZoomFactor: vi.fn().mockReturnValue(1),
+  setZoomFactor: vi.fn(),
   clearLibrary: vi.fn().mockResolvedValue(undefined),
   clearUserData: vi.fn().mockResolvedValue(undefined),
   getLogDir: vi.fn().mockResolvedValue('/tmp/logs'),

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer, webFrame } = require('electron');
 
 contextBridge.exposeInMainWorld('api', {
   // Track library
@@ -181,6 +181,10 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.on('tidal-track-update', handler);
     return () => ipcRenderer.removeListener('tidal-track-update', handler);
   },
+
+  // Zoom control (Ctrl+Scroll, Ctrl+=/-, Ctrl+0)
+  getZoomFactor: () => webFrame.getZoomFactor(),
+  setZoomFactor: (factor) => webFrame.setZoomFactor(factor),
 
   clearLibrary: () => ipcRenderer.invoke('clear-library'),
   clearUserData: () => ipcRenderer.invoke('clear-user-data'),


### PR DESCRIPTION
## Summary

Adds standard zoom keyboard/mouse shortcuts using Electron's `webFrame` API:

| Shortcut | Action |
|----------|--------|
| `Ctrl` + Scroll Up | Zoom in |
| `Ctrl` + Scroll Down | Zoom out |
| `Ctrl` + `=` / `+` | Zoom in |
| `Ctrl` + `-` | Zoom out |
| `Ctrl` + `0` | Reset to 100% |

- Zoom step: 0.1 per action
- Range: 0.5× – 2.0×
- Persisted to `localStorage` (`app-zoom-factor`) and restored on launch

## Changes

| File | Change |
|------|--------|
| `src/preload.js` | Expose `getZoomFactor()` / `setZoomFactor(factor)` via Electron's `webFrame` |
| `renderer/src/App.jsx` | `useEffect` subscribing to `keydown` and `wheel` events; restores persisted zoom on mount |
| `renderer/src/__tests__/setup.js` | Mocks for `getZoomFactor` / `setZoomFactor` |

## Test plan

- [ ] `Ctrl+ScrollUp` zooms in, `Ctrl+ScrollDown` zooms out
- [ ] `Ctrl+=` / `Ctrl+-` zoom in/out
- [ ] `Ctrl+0` resets zoom to 100%
- [ ] Zoom level persists after app restart
- [ ] Zoom clamps at 50% and 200%
- [ ] Scrolling without Ctrl scrolls the list (no interference)
- [ ] 130 renderer tests pass

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)