### PR TITLE
fix: suppress expected AbortError in audio play() catch handlers

### DIFF
--- a/renderer/src/PlayerContext.jsx
+++ b/renderer/src/PlayerContext.jsx
@@ -144,7 +144,9 @@ export function PlayerProvider({ children }) {
       const plName = currentPlaylistNameRef.current;
       if (rep === 'one') {
         audio.currentTime = 0;
-        audio.play().catch(console.error);
+        audio.play().catch((err) => {
+          if (err.name !== 'AbortError') console.error(err);
+        });
         return;
       }
       if (shuf) {
@@ -196,7 +198,10 @@ export function PlayerProvider({ children }) {
   );
 
   const togglePlay = useCallback(() => {
-    if (audio.paused) audio.play().catch(console.error);
+    if (audio.paused)
+      audio.play().catch((err) => {
+        if (err.name !== 'AbortError') console.error(err);
+      });
     else audio.pause();
   }, [audio]);
 
@@ -278,7 +283,10 @@ export function PlayerProvider({ children }) {
   useEffect(() => {
     if (!navigator.mediaSession) return;
     navigator.mediaSession.setActionHandler('play', () => {
-      if (audio.src) audio.play().catch(console.error);
+      if (audio.src)
+        audio.play().catch((err) => {
+          if (err.name !== 'AbortError') console.error(err);
+        });
     });
     navigator.mediaSession.setActionHandler('pause', () => audio.pause());
     navigator.mediaSession.setActionHandler('nexttrack', () => next());
@@ -309,7 +317,10 @@ export function PlayerProvider({ children }) {
       const tag = document.activeElement?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
       e.preventDefault();
-      if (audio.paused) audio.play().catch(console.error);
+      if (audio.paused)
+        audio.play().catch((err) => {
+          if (err.name !== 'AbortError') console.error(err);
+        });
       else audio.pause();
     };
     window.addEventListener('keydown', onKeyDown);


### PR DESCRIPTION
## Summary

- `audio.play()` returns a Promise that rejects with `AbortError` when interrupted by a `pause()` or `src` change before it resolves — this is expected browser behaviour
- Four call sites (`togglePlay`, `onEnded` repeat-one, `mediaSession` play handler, spacebar handler) were using bare `.catch(console.error)`, logging these as real errors
- On Windows/Electron this contributed to instability reported by a user
- All sites now match the existing pattern in `playAtIndex` — only non-`AbortError` rejections are logged

## Test plan

- [ ] Play a track and quickly click play/pause repeatedly — no `AbortError` in console
- [ ] Switch tracks rapidly — no `AbortError` in console
- [ ] Press spacebar quickly while a track loads — no `AbortError` in console
- [ ] Repeat-one mode still loops the track correctly
- [ ] Media keys (play/pause) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)