### PR TITLE
docs: acknowledge meiremans / beirbox-gui in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ npm run dist:linux          # or :mac / :win
 
 ---
 
+## Acknowledgements
+
+A huge thank you to **[meiremans](https://github.com/meiremans)** for creating [beirbox-gui](https://github.com/meiremans/beirbox-gui), which gave us a solid starting point for understanding the Pioneer Rekordbox USB binary format. Their work on reverse engineering the DeviceSQL PDB structure, ANLZ file sections, and USB layout saved an enormous amount of time and made the Rekordbox export feature in DJ Manager possible.
+
+---
+
 ## License
 
 MIT © [Radexito](https://github.com/Radexito)


### PR DESCRIPTION
Adds an Acknowledgements section to the README crediting [meiremans](https://github.com/meiremans) for [beirbox-gui](https://github.com/meiremans/beirbox-gui), whose reverse engineering work on the Pioneer Rekordbox USB binary format (DeviceSQL PDB, ANLZ sections, USB layout) was the foundation for our export feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)