### PR TITLE
feat(#157): Ctrl+Scroll / Ctrl+=/−/0 zoom control with persistence

### DIFF
--- a/renderer/src/App.css
+++ b/renderer/src/App.css
@@ -69,7 +69,7 @@ body {
 .zoom-indicator {
   position: fixed;
   top: 20px;
-  right: 56px;
+  left: 14px;
   z-index: 999;
   background: #2a2a2a;
   border: 1px solid #444;

--- a/renderer/src/App.css
+++ b/renderer/src/App.css
@@ -97,10 +97,7 @@ body {
 }
 
 .zoom-indicator-label {
-  display: block;
-  padding: 3px 0;
-  min-width: 52px;
-  text-align: center;
+  padding: 4px 10px;
 }
 
 .zoom-indicator-bar {

--- a/renderer/src/App.css
+++ b/renderer/src/App.css
@@ -98,6 +98,7 @@ body {
 
 .zoom-indicator-label {
   padding: 4px 10px;
+  font-size: 22px;
 }
 
 .zoom-indicator-bar {

--- a/renderer/src/App.css
+++ b/renderer/src/App.css
@@ -97,7 +97,10 @@ body {
 }
 
 .zoom-indicator-label {
-  padding: 3px 8px;
+  display: block;
+  padding: 3px 0;
+  min-width: 52px;
+  text-align: center;
 }
 
 .zoom-indicator-bar {

--- a/renderer/src/App.css
+++ b/renderer/src/App.css
@@ -77,19 +77,39 @@ body {
   color: #ccc;
   font-size: 12px;
   font-family: monospace;
-  padding: 4px 10px;
+  padding: 0;
   cursor: pointer;
   white-space: nowrap;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
   animation: zoom-fadein 0.12s ease;
   transition:
     background 0.12s,
-    color 0.12s;
+    color 0.12s,
+    border-color 0.12s;
 }
 
 .zoom-indicator:hover {
   background: #3a3a3a;
   color: #fff;
   border-color: #666;
+}
+
+.zoom-indicator-label {
+  padding: 4px 10px;
+}
+
+.zoom-indicator-bar {
+  display: block;
+  height: 2px;
+  background: #5a8f5a;
+  transform-origin: left center;
+  animation: zoom-countdown 3s linear forwards;
+}
+
+.zoom-indicator:hover .zoom-indicator-bar {
+  animation-play-state: paused;
 }
 
 @keyframes zoom-fadein {
@@ -100,5 +120,14 @@ body {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes zoom-countdown {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
   }
 }

--- a/renderer/src/App.css
+++ b/renderer/src/App.css
@@ -65,3 +65,40 @@ body {
   border-radius: 3px;
   transition: width 0.3s ease;
 }
+
+.zoom-indicator {
+  position: fixed;
+  bottom: 56px;
+  right: 14px;
+  z-index: 999;
+  background: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 6px;
+  color: #ccc;
+  font-size: 12px;
+  font-family: monospace;
+  padding: 4px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  animation: zoom-fadein 0.12s ease;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+.zoom-indicator:hover {
+  background: #3a3a3a;
+  color: #fff;
+  border-color: #666;
+}
+
+@keyframes zoom-fadein {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/renderer/src/App.css
+++ b/renderer/src/App.css
@@ -68,14 +68,14 @@ body {
 
 .zoom-indicator {
   position: fixed;
-  bottom: 56px;
-  right: 14px;
+  top: 20px;
+  right: 56px;
   z-index: 999;
   background: #2a2a2a;
   border: 1px solid #444;
   border-radius: 6px;
-  color: #ccc;
-  font-size: 12px;
+  color: #888;
+  font-size: 11px;
   font-family: monospace;
   padding: 0;
   cursor: pointer;
@@ -97,7 +97,7 @@ body {
 }
 
 .zoom-indicator-label {
-  padding: 4px 10px;
+  padding: 3px 8px;
 }
 
 .zoom-indicator-bar {
@@ -115,7 +115,7 @@ body {
 @keyframes zoom-fadein {
   from {
     opacity: 0;
-    transform: translateY(4px);
+    transform: translateY(-4px);
   }
   to {
     opacity: 1;

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -35,6 +35,55 @@ function App() {
     return unsub;
   }, []);
 
+  // Zoom control: Ctrl+Scroll and Ctrl+=/−/0, persisted to localStorage
+  useEffect(() => {
+    const ZOOM_STEP = 0.1;
+    const ZOOM_MIN = 0.5;
+    const ZOOM_MAX = 2.0;
+    const LS_KEY = 'app-zoom-factor';
+
+    const clamp = (v) => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, v));
+    const round = (v) => Math.round(v * 10) / 10;
+
+    const applyZoom = (factor) => {
+      const clamped = clamp(round(factor));
+      window.api.setZoomFactor(clamped);
+      localStorage.setItem(LS_KEY, String(clamped));
+    };
+
+    // Restore persisted zoom
+    const saved = parseFloat(localStorage.getItem(LS_KEY));
+    if (!isNaN(saved)) applyZoom(saved);
+
+    const onWheel = (e) => {
+      if (!e.ctrlKey) return;
+      e.preventDefault();
+      const current = window.api.getZoomFactor();
+      applyZoom(e.deltaY < 0 ? current + ZOOM_STEP : current - ZOOM_STEP);
+    };
+
+    const onKeyDown = (e) => {
+      if (!e.ctrlKey) return;
+      if (e.key === '=' || e.key === '+') {
+        e.preventDefault();
+        applyZoom(window.api.getZoomFactor() + ZOOM_STEP);
+      } else if (e.key === '-') {
+        e.preventDefault();
+        applyZoom(window.api.getZoomFactor() - ZOOM_STEP);
+      } else if (e.key === '0') {
+        e.preventDefault();
+        applyZoom(1.0);
+      }
+    };
+
+    window.addEventListener('wheel', onWheel, { passive: false });
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('wheel', onWheel);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
   return (
     <PlayerProvider>
       <DownloadProvider>

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -165,7 +165,7 @@ function App() {
               }}
               title="Reset zoom to 100%"
             >
-              <span className="zoom-indicator-label">✕</span>
+              <span className="zoom-indicator-label">{Math.round(zoomLevel * 100)}% ✕</span>
               <span className="zoom-indicator-bar" />
             </button>
           )}

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { flushSync } from 'react-dom';
 import Sidebar from './Sidebar.jsx';
 import MusicLibrary from './MusicLibrary.jsx';
 import DownloadView from './DownloadView.jsx';
@@ -51,11 +52,14 @@ function App() {
 
     const applyZoom = (factor) => {
       const clamped = clamp(round(factor));
-      window.api.setZoomFactor(clamped);
       localStorage.setItem(LS_KEY, String(clamped));
-      // Show indicator; increment key to restart countdown bar, hide after ZOOM_HIDE_DELAY
-      setZoomLevel(clamped);
-      setZoomKey((k) => k + 1);
+      // Flush counter-scale state synchronously BEFORE applying zoom so the
+      // pill is already at the correct size when the page zooms — no jump.
+      flushSync(() => {
+        setZoomLevel(clamped);
+        setZoomKey((k) => k + 1);
+      });
+      window.api.setZoomFactor(clamped);
       clearTimeout(zoomHideTimer.current);
       zoomHideTimer.current = setTimeout(() => setZoomLevel(null), ZOOM_HIDE_DELAY);
     };
@@ -151,7 +155,6 @@ function App() {
           )}
           {zoomLevel !== null && zoomLevel !== 1.0 && (
             <button
-              key={zoomKey}
               className="zoom-indicator"
               style={{ transform: `scale(${1 / zoomLevel})`, transformOrigin: 'top left' }}
               onClick={() => {
@@ -167,7 +170,7 @@ function App() {
               title="Reset zoom to 100%"
             >
               <span className="zoom-indicator-label">{Math.round(zoomLevel * 100)}% ✕</span>
-              <span className="zoom-indicator-bar" />
+              <span key={zoomKey} className="zoom-indicator-bar" />
             </button>
           )}
           {depsProgress && (

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -17,6 +17,7 @@ function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [exportState, setExportState] = useState(null); // { playlistId, mode } | null
   const [depsProgress, setDepsProgress] = useState(null); // { msg, pct } or null
+  const [zoomLevel, setZoomLevel] = useState(null); // shown when != 1.0, null = hidden
   const [search, setSearch] = useState('');
 
   const handleArtistSearch = (artist) => {
@@ -41,6 +42,7 @@ function App() {
     const ZOOM_MIN = 0.5;
     const ZOOM_MAX = 2.0;
     const LS_KEY = 'app-zoom-factor';
+    let hideTimer = null;
 
     const clamp = (v) => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, v));
     const round = (v) => Math.round(v * 10) / 10;
@@ -49,11 +51,18 @@ function App() {
       const clamped = clamp(round(factor));
       window.api.setZoomFactor(clamped);
       localStorage.setItem(LS_KEY, String(clamped));
+      // Show indicator; hide after 2s of inactivity
+      setZoomLevel(clamped);
+      clearTimeout(hideTimer);
+      hideTimer = setTimeout(() => setZoomLevel(null), 2000);
     };
 
-    // Restore persisted zoom
+    // Restore persisted zoom (silently — no indicator on launch)
     const saved = parseFloat(localStorage.getItem(LS_KEY));
-    if (!isNaN(saved)) applyZoom(saved);
+    if (!isNaN(saved)) {
+      const clamped = clamp(round(saved));
+      window.api.setZoomFactor(clamped);
+    }
 
     const onWheel = (e) => {
       if (!e.ctrlKey) return;
@@ -81,6 +90,7 @@ function App() {
     return () => {
       window.removeEventListener('wheel', onWheel);
       window.removeEventListener('keydown', onKeyDown);
+      clearTimeout(hideTimer);
     };
   }, []);
 
@@ -135,6 +145,19 @@ function App() {
               initialMode={exportState.mode}
               onClose={() => setExportState(null)}
             />
+          )}
+          {zoomLevel !== null && zoomLevel !== 1.0 && (
+            <button
+              className="zoom-indicator"
+              onClick={() => {
+                window.api.setZoomFactor(1.0);
+                localStorage.setItem('app-zoom-factor', '1');
+                setZoomLevel(null);
+              }}
+              title="Reset zoom to 100%"
+            >
+              {Math.round(zoomLevel * 100)}% ✕
+            </button>
           )}
           {depsProgress && (
             <div className="deps-overlay">

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -153,6 +153,7 @@ function App() {
             <button
               key={zoomKey}
               className="zoom-indicator"
+              style={{ transform: `scale(${1 / zoomLevel})`, transformOrigin: 'top left' }}
               onClick={() => {
                 clearTimeout(zoomHideTimer.current);
                 window.api.setZoomFactor(1.0);

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Sidebar from './Sidebar.jsx';
 import MusicLibrary from './MusicLibrary.jsx';
 import DownloadView from './DownloadView.jsx';
@@ -18,6 +18,9 @@ function App() {
   const [exportState, setExportState] = useState(null); // { playlistId, mode } | null
   const [depsProgress, setDepsProgress] = useState(null); // { msg, pct } or null
   const [zoomLevel, setZoomLevel] = useState(null); // shown when != 1.0, null = hidden
+  const [zoomKey, setZoomKey] = useState(0); // incremented on each zoom change to restart bar animation
+  const zoomHideTimer = useRef(null);
+  const ZOOM_HIDE_DELAY = 3000;
   const [search, setSearch] = useState('');
 
   const handleArtistSearch = (artist) => {
@@ -42,7 +45,6 @@ function App() {
     const ZOOM_MIN = 0.5;
     const ZOOM_MAX = 2.0;
     const LS_KEY = 'app-zoom-factor';
-    let hideTimer = null;
 
     const clamp = (v) => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, v));
     const round = (v) => Math.round(v * 10) / 10;
@@ -51,10 +53,11 @@ function App() {
       const clamped = clamp(round(factor));
       window.api.setZoomFactor(clamped);
       localStorage.setItem(LS_KEY, String(clamped));
-      // Show indicator; hide after 2s of inactivity
+      // Show indicator; increment key to restart countdown bar, hide after ZOOM_HIDE_DELAY
       setZoomLevel(clamped);
-      clearTimeout(hideTimer);
-      hideTimer = setTimeout(() => setZoomLevel(null), 2000);
+      setZoomKey((k) => k + 1);
+      clearTimeout(zoomHideTimer.current);
+      zoomHideTimer.current = setTimeout(() => setZoomLevel(null), ZOOM_HIDE_DELAY);
     };
 
     // Restore persisted zoom (silently — no indicator on launch)
@@ -90,7 +93,7 @@ function App() {
     return () => {
       window.removeEventListener('wheel', onWheel);
       window.removeEventListener('keydown', onKeyDown);
-      clearTimeout(hideTimer);
+      clearTimeout(zoomHideTimer.current);
     };
   }, []);
 
@@ -148,15 +151,22 @@ function App() {
           )}
           {zoomLevel !== null && zoomLevel !== 1.0 && (
             <button
+              key={zoomKey}
               className="zoom-indicator"
               onClick={() => {
+                clearTimeout(zoomHideTimer.current);
                 window.api.setZoomFactor(1.0);
                 localStorage.setItem('app-zoom-factor', '1');
                 setZoomLevel(null);
               }}
+              onMouseEnter={() => clearTimeout(zoomHideTimer.current)}
+              onMouseLeave={() => {
+                zoomHideTimer.current = setTimeout(() => setZoomLevel(null), ZOOM_HIDE_DELAY);
+              }}
               title="Reset zoom to 100%"
             >
-              {Math.round(zoomLevel * 100)}% ✕
+              <span className="zoom-indicator-label">{Math.round(zoomLevel * 100)}% ✕</span>
+              <span className="zoom-indicator-bar" />
             </button>
           )}
           {depsProgress && (

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -165,7 +165,7 @@ function App() {
               }}
               title="Reset zoom to 100%"
             >
-              <span className="zoom-indicator-label">{Math.round(zoomLevel * 100)}% ✕</span>
+              <span className="zoom-indicator-label">✕</span>
               <span className="zoom-indicator-bar" />
             </button>
           )}

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -26,6 +26,8 @@ window.api = {
   selectAudioFiles: vi.fn().mockResolvedValue([]),
   importAudioFiles: vi.fn().mockResolvedValue([]),
   reanalyzeTrack: vi.fn().mockResolvedValue({ ok: true }),
+  getZoomFactor: vi.fn().mockReturnValue(1.0),
+  setZoomFactor: vi.fn(),
   removeTrack: vi.fn().mockResolvedValue({ ok: true }),
   adjustBpm: vi.fn().mockResolvedValue([]),
   updateTrack: vi.fn().mockResolvedValue({}),

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer, webFrame } = require('electron');
 
 contextBridge.exposeInMainWorld('api', {
   // Track library
@@ -199,6 +199,9 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.on('tidal-track-update', handler);
     return () => ipcRenderer.removeListener('tidal-track-update', handler);
   },
+
+  getZoomFactor: () => webFrame.getZoomFactor(),
+  setZoomFactor: (factor) => webFrame.setZoomFactor(factor),
 
   clearLibrary: () => ipcRenderer.invoke('clear-library'),
   clearUserData: () => ipcRenderer.invoke('clear-user-data'),


### PR DESCRIPTION
## Summary

- `Ctrl+ScrollUp/Down` — zoom in/out
- `Ctrl+=` / `Ctrl++` — zoom in
- `Ctrl+-` — zoom out
- `Ctrl+0` — reset to 100%

Zoom step 0.1, clamped to 0.5×–2.0×. Persisted to `localStorage` (`app-zoom-factor`) and restored on launch.

## Changes

| File | Change |
|------|--------|
| `src/preload.js` | Import `webFrame`; expose `getZoomFactor()` / `setZoomFactor(factor)` |
| `renderer/src/App.jsx` | `useEffect` with `wheel` + `keydown` listeners; restores persisted zoom on mount |
| `renderer/src/__tests__/setup.js` | Mocks for `getZoomFactor` / `setZoomFactor` |

## Test plan

- [ ] `Ctrl+ScrollUp` zooms in, `Ctrl+ScrollDown` zooms out
- [ ] `Ctrl+=` / `Ctrl+-` zoom in/out
- [ ] `Ctrl+0` resets zoom to 100%
- [ ] Zoom persists after app restart
- [ ] Zoom clamps at 50% and 200%
- [ ] Scrolling without Ctrl scrolls the list normally
- [ ] 130 renderer tests pass

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)