### PR TITLE
fix: make clear-user-data remove database reliably

### DIFF
--- a/src/__tests__/resetCleanup.test.js
+++ b/src/__tests__/resetCleanup.test.js
@@ -1,0 +1,74 @@
+import path from 'path';
+import { describe, it, expect, vi } from 'vitest';
+import { getResetCleanupTargets, startResetCleanup } from '../resetCleanup.js';
+
+describe('getResetCleanupTargets', () => {
+  it('includes app data directories and legacy dev database files', () => {
+    const targets = getResetCleanupTargets({
+      userDataPath: 'C:\\Users\\me\\AppData\\Roaming\\DJ Manager',
+      cachePath: 'C:\\Users\\me\\AppData\\Local\\DJ Manager\\Cache',
+      logsPath: 'C:\\Users\\me\\AppData\\Roaming\\DJ Manager\\logs',
+      cwd: 'C:\\Users\\me\\DjManager',
+    });
+
+    expect(targets).toEqual([
+      'C:\\Users\\me\\AppData\\Roaming\\DJ Manager',
+      'C:\\Users\\me\\AppData\\Local\\DJ Manager\\Cache',
+      'C:\\Users\\me\\AppData\\Roaming\\DJ Manager\\logs',
+      path.join('C:\\Users\\me\\DjManager', 'library.db'),
+      path.join('C:\\Users\\me\\DjManager', 'library.db-shm'),
+      path.join('C:\\Users\\me\\DjManager', 'library.db-wal'),
+    ]);
+  });
+
+  it('deduplicates repeated targets', () => {
+    const targets = getResetCleanupTargets({
+      userDataPath: 'C:\\temp\\userData',
+      cachePath: 'C:\\temp\\userData',
+      logsPath: 'C:\\temp\\userData',
+      cwd: 'C:\\temp',
+    });
+
+    expect(targets).toEqual([
+      'C:\\temp\\userData',
+      path.join('C:\\temp', 'library.db'),
+      path.join('C:\\temp', 'library.db-shm'),
+      path.join('C:\\temp', 'library.db-wal'),
+    ]);
+  });
+});
+
+describe('startResetCleanup', () => {
+  it('spawns a detached node-mode helper and unreferences it', () => {
+    const unref = vi.fn();
+    const spawnImpl = vi.fn().mockReturnValue({ unref });
+
+    startResetCleanup({
+      parentPid: 4242,
+      targets: ['C:\\temp\\userData'],
+      spawnImpl,
+      execPath: 'C:\\Program Files\\DjManager\\DJ Manager.exe',
+      env: { PATH: 'C:\\Windows\\System32' },
+      scriptPath: 'C:\\Users\\me\\DjManager\\src\\resetCleanupWorker.js',
+    });
+
+    expect(spawnImpl).toHaveBeenCalledWith(
+      'C:\\Program Files\\DjManager\\DJ Manager.exe',
+      [
+        'C:\\Users\\me\\DjManager\\src\\resetCleanupWorker.js',
+        '4242',
+        JSON.stringify(['C:\\temp\\userData']),
+      ],
+      {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+        env: {
+          PATH: 'C:\\Windows\\System32',
+          ELECTRON_RUN_AS_NODE: '1',
+        },
+      }
+    );
+    expect(unref).toHaveBeenCalled();
+  });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -102,6 +102,7 @@ import { detectFilesystem, formatDrive, describeFilesystem } from './usb/usbUtil
 import { writeAnlz, getAnlzFolder } from './audio/anlzWriter.js';
 import { writeSettingFiles } from './usb/settingWriter.js';
 import { writePdb } from './usb/pdbWriter.js';
+import { getResetCleanupTargets, startResetCleanup } from './resetCleanup.js';
 import {
   getCuePoints,
   addCuePoint,
@@ -800,20 +801,16 @@ ipcMain.handle('clear-library', async () => {
 });
 
 ipcMain.handle('clear-user-data', async () => {
-  const toDelete = [app.getPath('userData'), app.getPath('cache'), app.getPath('logs')];
-  // Close the SQLite connection before quitting so Windows releases the file
-  // lock on library.db — without this, rmSync silently fails with EPERM/EBUSY
-  // and the database (and all tracks) survive the "reset" on Windows.
-  closeDB();
-  app.on('quit', () => {
-    for (const p of toDelete) {
-      try {
-        if (fs.existsSync(p)) fs.rmSync(p, { recursive: true, force: true });
-      } catch (err) {
-        console.error('[clear-user-data] failed to delete', p, err.message);
-      }
-    }
+  const toDelete = getResetCleanupTargets({
+    userDataPath: app.getPath('userData'),
+    cachePath: app.getPath('cache'),
+    logsPath: app.getPath('logs'),
   });
+  // Run the actual deletion in a detached helper after this process exits so
+  // Windows/Electron file handles cannot keep the database or userData tree
+  // alive during the reset.
+  closeDB();
+  startResetCleanup({ parentPid: process.pid, targets: toDelete });
   app.quit();
 });
 

--- a/src/resetCleanup.js
+++ b/src/resetCleanup.js
@@ -1,0 +1,50 @@
+import path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const RESET_CLEANUP_WORKER = fileURLToPath(new URL('./resetCleanupWorker.js', import.meta.url));
+const LEGACY_DB_FILES = ['library.db', 'library.db-shm', 'library.db-wal'];
+
+export function getResetCleanupTargets({
+  userDataPath,
+  cachePath,
+  logsPath,
+  cwd = process.cwd(),
+} = {}) {
+  const targets = [userDataPath, cachePath, logsPath];
+
+  for (const fileName of LEGACY_DB_FILES) {
+    targets.push(path.join(cwd, fileName));
+  }
+
+  const seen = new Set();
+  return targets.filter((target) => {
+    if (!target) return false;
+    const resolved = path.resolve(target);
+    if (seen.has(resolved)) return false;
+    seen.add(resolved);
+    return true;
+  });
+}
+
+export function startResetCleanup({
+  parentPid,
+  targets,
+  spawnImpl = spawn,
+  execPath = process.execPath,
+  env = process.env,
+  scriptPath = RESET_CLEANUP_WORKER,
+} = {}) {
+  const child = spawnImpl(execPath, [scriptPath, String(parentPid), JSON.stringify(targets)], {
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+    env: {
+      ...env,
+      ELECTRON_RUN_AS_NODE: '1',
+    },
+  });
+
+  child.unref();
+  return child;
+}

--- a/src/resetCleanupWorker.js
+++ b/src/resetCleanupWorker.js
@@ -1,0 +1,53 @@
+import fs from 'fs';
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code !== 'ESRCH';
+  }
+}
+
+async function waitForProcessExit(pid) {
+  while (isProcessRunning(pid)) {
+    await sleep(250);
+  }
+}
+
+async function removeWithRetries(target) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      fs.rmSync(target, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === 19) throw error;
+      await sleep(250);
+    }
+  }
+}
+
+async function main() {
+  const parentPid = Number(process.argv[2]);
+  const targets = JSON.parse(process.argv[3] ?? '[]');
+
+  if (!Number.isInteger(parentPid) || parentPid <= 0) {
+    throw new Error(`Invalid parent pid: ${process.argv[2]}`);
+  }
+
+  if (!Array.isArray(targets)) {
+    throw new Error('Reset cleanup targets must be an array');
+  }
+
+  await waitForProcessExit(parentPid);
+
+  for (const target of targets) {
+    await removeWithRetries(target);
+  }
+}
+
+await main();

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -40,6 +40,7 @@ export default defineConfig({
             'src/__tests__/mediaServer.test.js',
             'src/__tests__/anlzWriter.test.js',
             'src/__tests__/waveformGenerator.test.js',
+            'src/__tests__/resetCleanup.test.js',
             'src/__tests__/usbUtils.test.js',
             'src/__tests__/settingWriter.test.js',
             'src/__tests__/pdbWriter.test.js',


### PR DESCRIPTION
Run reset cleanup in a detached helper after the app exits so Windows file locks do not keep the live SQLite database around. Also clean up legacy dev database files from the project root and cover the cleanup launcher with tests.