### PR TITLE
test(player): regression guard for AudioContext crash → black screen

### DIFF
--- a/renderer/src/__tests__/PlayerContext.test.jsx
+++ b/renderer/src/__tests__/PlayerContext.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { PlayerProvider, usePlayer } from '../PlayerContext.jsx';
 
@@ -42,5 +42,113 @@ describe('PlayerProvider — context API', () => {
     expect(ctx.isPlaying).toBe(false);
     expect(ctx.currentTime).toBe(0);
     expect(ctx.duration).toBe(0);
+  });
+});
+
+// ── Black screen regression (AudioContext crash guard) ────────────────────────
+// If the Web Audio graph setup throws (e.g. NotSupportedError in some GPU/Electron
+// configurations), the PlayerProvider must still mount and expose its full API.
+// A missing try-catch here caused a renderer crash → black screen on launch.
+
+describe('PlayerProvider — AudioContext crash guard', () => {
+  let originalAudioContext;
+
+  beforeEach(() => {
+    originalAudioContext = window.AudioContext;
+  });
+
+  afterEach(() => {
+    window.AudioContext = originalAudioContext;
+  });
+
+  it('renders without crashing when AudioContext constructor throws', () => {
+    window.AudioContext = class {
+      constructor() {
+        throw new Error('NotSupportedError: AudioContext is not supported');
+      }
+    };
+
+    expect(() => renderProvider()).not.toThrow();
+  });
+
+  it('still exposes full API surface when AudioContext constructor throws', () => {
+    window.AudioContext = class {
+      constructor() {
+        throw new Error('NotSupportedError: AudioContext is not supported');
+      }
+    };
+
+    const { result } = renderProvider();
+    const ctx = result.current;
+    expect(typeof ctx.play).toBe('function');
+    expect(typeof ctx.stop).toBe('function');
+    expect(typeof ctx.seek).toBe('function');
+    expect(typeof ctx.toggleShuffle).toBe('function');
+    expect(typeof ctx.cycleRepeat).toBe('function');
+    expect(ctx.isPlaying).toBe(false);
+  });
+
+  it('renders without crashing when createMediaElementSource throws', () => {
+    window.AudioContext = class {
+      constructor() {
+        this.destination = {};
+        this.resume = vi.fn().mockResolvedValue(undefined);
+        this.close = vi.fn().mockResolvedValue(undefined);
+        this.createMediaElementSource = vi.fn(() => {
+          throw new Error('InvalidStateError: media element already connected');
+        });
+        this.createGain = vi.fn().mockReturnValue({ gain: { value: 1 }, connect: vi.fn() });
+        this.createDynamicsCompressor = vi.fn().mockReturnValue({
+          threshold: { value: 0 },
+          knee: { value: 0 },
+          ratio: { value: 1 },
+          attack: { value: 0 },
+          release: { value: 0 },
+          connect: vi.fn(),
+        });
+      }
+    };
+
+    expect(() => renderProvider()).not.toThrow();
+  });
+
+  it('still exposes full API surface when createMediaElementSource throws', () => {
+    window.AudioContext = class {
+      constructor() {
+        this.destination = {};
+        this.resume = vi.fn().mockResolvedValue(undefined);
+        this.close = vi.fn().mockResolvedValue(undefined);
+        this.createMediaElementSource = vi.fn(() => {
+          throw new Error('InvalidStateError: media element already connected');
+        });
+        this.createGain = vi.fn().mockReturnValue({ gain: { value: 1 }, connect: vi.fn() });
+        this.createDynamicsCompressor = vi.fn().mockReturnValue({
+          threshold: { value: 0 },
+          knee: { value: 0 },
+          ratio: { value: 1 },
+          attack: { value: 0 },
+          release: { value: 0 },
+          connect: vi.fn(),
+        });
+      }
+    };
+
+    const { result } = renderProvider();
+    const ctx = result.current;
+    expect(typeof ctx.play).toBe('function');
+    expect(typeof ctx.stop).toBe('function');
+    expect(typeof ctx.seek).toBe('function');
+    expect(ctx.isPlaying).toBe(false);
+  });
+
+  it('calls getMediaPort even when AudioContext is unavailable', async () => {
+    window.AudioContext = class {
+      constructor() {
+        throw new Error('NotSupportedError');
+      }
+    };
+
+    renderProvider();
+    await waitFor(() => expect(window.api.getMediaPort).toHaveBeenCalledTimes(1));
   });
 });


### PR DESCRIPTION
## Summary
- Adds 5 tests in `PlayerContext.test.jsx` covering the black screen regression
- Verifies `PlayerProvider` mounts safely when `AudioContext` constructor throws (`NotSupportedError`)
- Verifies `PlayerProvider` mounts safely when `createMediaElementSource` throws (`InvalidStateError`)
- Verifies full API surface (`play`, `stop`, `seek`, `toggleShuffle`, `cycleRepeat`, `isPlaying`) is intact in both fallback paths
- Verifies `getMediaPort` is still called even when Web Audio is unavailable

## Test plan
- [ ] `cd renderer && npx vitest run src/__tests__/PlayerContext.test.jsx` — all 8 tests pass
- [ ] Removing the try-catch in `PlayerContext.jsx` Web Audio setup causes these tests to fail (confirming they pin the guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)