### PR TITLE
fix(usb): write replay_gain as CDJ auto-gain into PDB track rows

### DIFF
--- a/src/__tests__/pdbWriter.test.js
+++ b/src/__tests__/pdbWriter.test.js
@@ -282,10 +282,21 @@ describe('buildTrackRow', () => {
     expect(buf.readUInt32LE(16)).toBe(5000000);
   });
 
-  it('Unnamed7=0x758a and Unnamed8=0x57a2 at offsets 24/26', () => {
+  it('auto_gain defaults (0x4A68 / 0x78F7) written at offsets 24/26 when no replayGain', () => {
     const buf = buildTrackRow(minimal);
-    expect(buf.readUInt16LE(24)).toBe(0x758a);
-    expect(buf.readUInt16LE(26)).toBe(0x57a2);
+    expect(buf.readUInt16LE(24)).toBe(0x4a68); // 19048 — CDJ unanalyzed reference
+    expect(buf.readUInt16LE(26)).toBe(0x78f7); // 30967 — secondary unanalyzed reference
+  });
+
+  it('auto_gain computed from replayGain at offsets 24/26', () => {
+    const buf = buildTrackRow({ ...minimal, replayGain: 0 });
+    expect(buf.readUInt16LE(24)).toBe(19048);
+    expect(buf.readUInt16LE(26)).toBe(30967);
+
+    const bufMinus6 = buildTrackRow({ ...minimal, replayGain: -6 });
+    // 10^(-6/20) * 19048 ≈ 9546
+    expect(bufMinus6.readUInt16LE(24)).toBe(Math.round(10 ** (-6 / 20) * 19048));
+    expect(bufMinus6.readUInt16LE(26)).toBe(Math.round(10 ** (-6 / 20) * 30967));
   });
 
   it('ArtistId at offset 68', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -1944,6 +1944,7 @@ ipcMain.handle(
         bitrate: t.bitrate || 0,
         comments: t.comments || '',
         rating: t.rating || 0,
+        replay_gain: t.replay_gain ?? null,
         analyzePath: anlzPaths.get(t.id) || '',
       }));
 
@@ -2099,6 +2100,7 @@ ipcMain.handle(
         bitrate: t.bitrate || 0,
         comments: t.comments || '',
         rating: t.rating || 0,
+        replay_gain: t.replay_gain ?? null,
         analyzePath: (() => {
           const usbFP = usbPaths.get(t.id);
           if (!usbFP) return '';

--- a/src/usb/pdbWriter.js
+++ b/src/usb/pdbWriter.js
@@ -346,7 +346,18 @@ export function buildTrackRow(params) {
     unknownStr6 = '',
     unknownStr7 = '',
     unknownStr8 = '',
+    replayGain = null,
   } = params;
+
+  // Converts replay_gain dB to the linear amplitude scale factor CDJs use for Auto Gain.
+  // Reference point 19048 (0x4A68) and 30967 (0x78F7) are the "unanalyzed" defaults
+  // written by native Rekordbox when no loudness analysis has run.
+  const gainToAutoGain = (ref) =>
+    replayGain == null
+      ? ref
+      : Math.max(0, Math.min(0xffff, Math.round(10 ** (replayGain / 20) * ref)));
+  const autoGain7 = gainToAutoGain(19048); // offset 24 — CDJ-NXS2 auto-gain field
+  const autoGain8 = gainToAutoGain(30967); // offset 26 — second gain reference
 
   // String encoding order matches rex track.go StringOffsets struct and MarshalBinary
   const strBufs = [
@@ -404,10 +415,10 @@ export function buildTrackRow(params) {
   pos += 4; // FileSize
   result.writeUInt32LE(checksum, pos);
   pos += 4; // Checksum
-  result.writeUInt16LE(0x758a, pos);
-  pos += 2; // Unnamed7
-  result.writeUInt16LE(0x57a2, pos);
-  pos += 2; // Unnamed8
+  result.writeUInt16LE(autoGain7, pos);
+  pos += 2; // Unnamed7 — auto_gain (CDJ-NXS2 trim)
+  result.writeUInt16LE(autoGain8, pos);
+  pos += 2; // Unnamed8 — auto_gain secondary reference
   result.writeUInt32LE(artworkId, pos);
   pos += 4; // ArtworkId
   result.writeUInt32LE(keyId, pos);
@@ -861,6 +872,7 @@ function buildPdbBuffer(input) {
         analyzeDate: now,
         sampleRate: 44100,
         sampleDepth: 16,
+        replayGain: t.replay_gain ?? null,
       })
     );
   }


### PR DESCRIPTION
Closes #287

## What

Replaces the hardcoded `Unnamed7` / `Unnamed8` constants (`0x758A` / `0x57A2`) at offsets 24–27 of the PDB track row header with values computed from the track's `replay_gain` field.

## Why

CDJ-NXS2 players read these two fields to position the trim knob when **Auto Gain** is enabled. The previous hardcoded values produced the wrong trim position for every track. Native Rekordbox writes analysis-derived values here (confirmed via binary captures, series 20-23).

## How

- Formula: `round(10^(dB/20) * ref)` where `ref` = 19048 (0x4A68) for field 7 and 30967 (0x78F7) for field 8 — community-RE'd unanalyzed defaults.
- When `replay_gain` is null the reference value is written directly, matching Rekordbox's unanalyzed behaviour.
- `replay_gain` is now threaded through both export paths in `main.js` → `pdbWriter.js` → `buildTrackRow()`.

## Test plan

- [x] Unit tests updated and passing (381/381)
- [ ] Export to USB, load on CDJ-NXS2 with Auto Gain enabled, verify trim knob position