### PR TITLE
feat(deps): rework first-run setup overlay with step list, speed, and ETA

### DIFF
--- a/renderer/src/App.css
+++ b/renderer/src/App.css
@@ -25,46 +25,6 @@ body {
   display: flex;
   overflow: hidden;
 }
-.deps-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-}
-.deps-box {
-  background: #1e1e2e;
-  border: 1px solid #3a3a5c;
-  border-radius: 10px;
-  padding: 28px 36px;
-  min-width: 340px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.deps-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: #cdd6f4;
-}
-.deps-msg {
-  font-size: 13px;
-  color: #a6adc8;
-}
-.deps-bar-track {
-  height: 6px;
-  background: #313244;
-  border-radius: 3px;
-  overflow: hidden;
-}
-.deps-bar-fill {
-  height: 100%;
-  background: #89b4fa;
-  border-radius: 3px;
-  transition: width 0.3s ease;
-}
 
 .zoom-indicator {
   position: fixed;

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -12,6 +12,7 @@ import TopBar from './TopBar.jsx';
 import { PlayerProvider } from './PlayerContext.jsx';
 import { DownloadProvider } from './DownloadContext.jsx';
 import { TidalDownloadProvider } from './TidalDownloadContext.jsx';
+import { DepsOverlay } from './DepsOverlay.jsx';
 import './App.css';
 
 function App() {
@@ -179,19 +180,7 @@ function App() {
               <span key={zoomKey} className="zoom-indicator-bar" />
             </button>
           )}
-          {depsProgress && (
-            <div className="deps-overlay">
-              <div className="deps-box">
-                <div className="deps-title">First-time setup</div>
-                <div className="deps-msg">{depsProgress.msg}</div>
-                {depsProgress.pct >= 0 && depsProgress.pct < 100 && (
-                  <div className="deps-bar-track">
-                    <div className="deps-bar-fill" style={{ width: `${depsProgress.pct}%` }} />
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
+          <DepsOverlay progress={depsProgress} onRetry={() => window.api.retryDeps?.()} />
         </TidalDownloadProvider>
       </DownloadProvider>
     </PlayerProvider>

--- a/renderer/src/DepsOverlay.css
+++ b/renderer/src/DepsOverlay.css
@@ -1,0 +1,117 @@
+.deps-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.deps-box {
+  background: #1e1e2e;
+  border: 1px solid #3a3a5c;
+  border-radius: 10px;
+  padding: 28px 36px;
+  min-width: 360px;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.deps-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #cdd6f4;
+}
+
+.deps-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.deps-step {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 13px;
+  color: #585b70;
+  transition: color 0.2s;
+}
+
+.deps-step.active {
+  color: #cdd6f4;
+}
+
+.deps-step.done {
+  color: #a6e3a1;
+}
+
+.deps-step-icon {
+  width: 14px;
+  text-align: center;
+  flex-shrink: 0;
+  font-size: 11px;
+}
+
+.deps-step-label {
+  flex-shrink: 0;
+}
+
+.deps-step-meta {
+  font-size: 11px;
+  color: #6c7086;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.deps-msg {
+  font-size: 12px;
+  color: #6c7086;
+}
+
+.deps-bar-track {
+  height: 6px;
+  background: #313244;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.deps-bar-fill {
+  height: 100%;
+  background: #89b4fa;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.deps-overall {
+  font-size: 11px;
+  color: #585b70;
+  text-align: right;
+}
+
+.deps-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  color: #f38ba8;
+}
+
+.deps-retry-btn {
+  background: #313244;
+  border: 1px solid #45475a;
+  border-radius: 6px;
+  color: #cdd6f4;
+  font-size: 12px;
+  padding: 4px 12px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.deps-retry-btn:hover {
+  background: #45475a;
+}

--- a/renderer/src/DepsOverlay.jsx
+++ b/renderer/src/DepsOverlay.jsx
@@ -1,0 +1,120 @@
+import './DepsOverlay.css';
+
+const KNOWN_STEPS = [
+  { id: 'ffmpeg', label: 'FFmpeg' },
+  { id: 'analyzer', label: 'mixxx-analyzer' },
+  { id: 'ytdlp', label: 'yt-dlp' },
+  { id: 'tidal', label: 'tidal-dl-ng' },
+];
+
+function fmt(bytes) {
+  if (bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / Math.pow(1024, i)).toFixed(i > 1 ? 1 : 0)} ${units[i]}`;
+}
+
+function fmtSpeed(bps) {
+  return bps > 0 ? `${fmt(bps)}/s` : null;
+}
+
+function fmtEta(sec) {
+  if (sec <= 0) return null;
+  if (sec < 60) return `~${Math.ceil(sec)}s`;
+  return `~${Math.ceil(sec / 60)}m`;
+}
+
+export function DepsOverlay({ progress, onRetry }) {
+  if (!progress) return null;
+
+  const {
+    stepId,
+    stepIndex,
+    stepTotal,
+    stepPct,
+    bytesDownloaded,
+    bytesTotal,
+    bytesPerSec,
+    etaSec,
+    msg,
+    pct,
+    error,
+  } = progress;
+
+  // Build step list from known steps filtered to stepTotal count.
+  // If stepId is unknown (e.g. old-format payload), fall back to simple view.
+  const hasSteps = stepTotal > 0 && stepId !== undefined;
+
+  // Derive which known steps are active in this run (stepTotal of them)
+  const activeSteps = KNOWN_STEPS.filter((s) => {
+    // Show step if it matches a step we've seen or will see
+    const idx = KNOWN_STEPS.indexOf(s);
+    return idx < stepTotal || s.id === stepId;
+  }).slice(0, stepTotal);
+
+  const currentIdx = activeSteps.findIndex((s) => s.id === stepId);
+  const isError = pct === -1 || !!error;
+  const isDone = pct === 100 && !error;
+
+  const speed = fmtSpeed(bytesPerSec);
+  const eta = fmtEta(etaSec);
+  const hasBytes = bytesTotal > 0 && bytesDownloaded > 0;
+
+  return (
+    <div className="deps-overlay">
+      <div className="deps-box">
+        <div className="deps-title">First-time setup</div>
+
+        {hasSteps && (
+          <div className="deps-steps">
+            {activeSteps.map((s, i) => {
+              const isActive = s.id === stepId && !isDone;
+              const isDoneStep = i < currentIdx || isDone;
+              return (
+                <div
+                  key={s.id}
+                  className={`deps-step${isActive ? ' active' : ''}${isDoneStep ? ' done' : ''}`}
+                >
+                  <span className="deps-step-icon">{isDoneStep ? '✓' : isActive ? '↓' : '·'}</span>
+                  <span className="deps-step-label">{s.label}</span>
+                  {isActive && hasBytes && (
+                    <span className="deps-step-meta">
+                      {fmt(bytesDownloaded)} / {fmt(bytesTotal)}
+                      {speed && ` · ${speed}`}
+                      {eta && ` · ${eta}`}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="deps-msg">{msg}</div>
+
+        {!isError && (stepPct >= 0 || pct >= 0) && (
+          <div className="deps-bar-track">
+            <div className="deps-bar-fill" style={{ width: `${stepPct >= 0 ? stepPct : pct}%` }} />
+          </div>
+        )}
+
+        {hasSteps && stepTotal > 1 && !isDone && !isError && (
+          <div className="deps-overall">
+            Step {stepIndex} of {stepTotal}
+          </div>
+        )}
+
+        {isError && (
+          <div className="deps-error">
+            <span>{error || msg}</span>
+            {onRetry && (
+              <button className="deps-retry-btn" onClick={onRetry}>
+                Retry
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -45,6 +45,7 @@ window.api = {
   getDepVersions: vi.fn().mockResolvedValue({}),
   checkDepUpdates: vi.fn().mockResolvedValue({}),
   updateAllDeps: vi.fn().mockResolvedValue(undefined),
+  retryDeps: vi.fn().mockResolvedValue(undefined),
   updateTidalDlNg: vi.fn().mockResolvedValue({ ok: true }),
   clearLibrary: vi.fn().mockResolvedValue(undefined),
   clearUserData: vi.fn().mockResolvedValue(undefined),

--- a/src/deps.js
+++ b/src/deps.js
@@ -414,7 +414,10 @@ async function downloadFFmpeg(tmp, onProgress) {
       archive,
       (r, t) =>
         t > 0 &&
-        onProgress?.(`Downloading FFmpeg… ${Math.round((r / t) * 100)}%`, Math.round((r / t) * 100))
+        onProgress?.(`Downloading FFmpeg…`, Math.round((r / t) * 100), {
+          bytesReceived: r,
+          bytesTotal: t,
+        })
     );
     onProgress?.('Extracting FFmpeg…', 99);
     const dir = path.join(tmp, 'ffmpeg-extracted');
@@ -437,7 +440,10 @@ async function downloadFFmpeg(tmp, onProgress) {
       archive,
       (r, t) =>
         t > 0 &&
-        onProgress?.(`Downloading FFmpeg… ${Math.round((r / t) * 100)}%`, Math.round((r / t) * 100))
+        onProgress?.(`Downloading FFmpeg…`, Math.round((r / t) * 100), {
+          bytesReceived: r,
+          bytesTotal: t,
+        })
     );
     onProgress?.('Extracting FFmpeg…', 99);
     const dir = path.join(tmp, 'ffmpeg-win-extracted');
@@ -467,17 +473,20 @@ async function downloadFFmpeg(tmp, onProgress) {
       ffmpegZip,
       (r, t) =>
         t > 0 &&
-        onProgress?.(`Downloading FFmpeg… ${Math.round((r / t) * 50)}%`, Math.round((r / t) * 50))
+        onProgress?.(`Downloading FFmpeg…`, Math.round((r / t) * 50), {
+          bytesReceived: r,
+          bytesTotal: t,
+        })
     );
     await downloadFile(
       'https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip',
       ffprobeZip,
       (r, t) =>
         t > 0 &&
-        onProgress?.(
-          `Downloading FFprobe… ${50 + Math.round((r / t) * 49)}%`,
-          50 + Math.round((r / t) * 49)
-        )
+        onProgress?.(`Downloading FFprobe…`, 50 + Math.round((r / t) * 49), {
+          bytesReceived: r,
+          bytesTotal: t,
+        })
     );
     onProgress?.('Extracting FFmpeg…', 99);
     await extractZip(ffmpegZip, path.join(tmp, 'ffmpeg-mac'));
@@ -527,10 +536,10 @@ async function downloadAnalyzer(tmp, onProgress) {
     archive,
     (r, t) =>
       t > 0 &&
-      onProgress?.(
-        `Downloading mixxx-analyzer… ${Math.round((r / t) * 100)}%`,
-        Math.round((r / t) * 100)
-      )
+      onProgress?.(`Downloading mixxx-analyzer…`, Math.round((r / t) * 100), {
+        bytesReceived: r,
+        bytesTotal: t,
+      })
   );
 
   onProgress?.('Extracting mixxx-analyzer…', 99);
@@ -614,7 +623,10 @@ async function downloadYtDlp(tmp, onProgress, tag = null) {
     dest,
     (r, t) =>
       t > 0 &&
-      onProgress?.(`Downloading yt-dlp… ${Math.round((r / t) * 100)}%`, Math.round((r / t) * 100))
+      onProgress?.(`Downloading yt-dlp…`, Math.round((r / t) * 100), {
+        bytesReceived: r,
+        bytesTotal: t,
+      })
   );
 
   if (platform !== 'win32') fs.chmodSync(dest, 0o755);
@@ -641,29 +653,83 @@ export async function ensureDeps(onProgress) {
   const tmp = path.join(app.getPath('temp'), 'djman-deps');
   await fs.promises.mkdir(tmp, { recursive: true });
 
-  const totalSteps =
-    (!ffmpegReady ? 1 : 0) +
-    (!analyzerReady ? 1 : 0) +
-    (!ytDlpReady ? 1 : 0) +
-    (!tidalReady ? 1 : 0);
-  let step = 0;
-  const stepCb = (msg, pct) => onProgress?.(`[${step}/${totalSteps}] ${msg}`, pct);
+  const STEP_DEFS = [
+    !ffmpegReady && { id: 'ffmpeg', label: 'FFmpeg' },
+    !analyzerReady && { id: 'analyzer', label: 'mixxx-analyzer' },
+    !ytDlpReady && { id: 'ytdlp', label: 'yt-dlp' },
+    !tidalReady && { id: 'tidal', label: 'tidal-dl-ng' },
+  ].filter(Boolean);
+  const totalSteps = STEP_DEFS.length;
+  let stepIndex = 0;
+  let currentStep = null;
+
+  // Per-step speed/ETA tracker — reset when step changes
+  let _lastBytes = 0,
+    _lastBytesTime = Date.now(),
+    _speedSamples = [];
+  const resetTracker = () => {
+    _lastBytes = 0;
+    _lastBytesTime = Date.now();
+    _speedSamples = [];
+  };
+
+  const stepCb = (msg, pct, meta = {}) => {
+    let bytesPerSec = 0,
+      etaSec = -1;
+    const { bytesReceived, bytesTotal } = meta;
+    if (bytesReceived != null && bytesTotal > 0) {
+      const now = Date.now();
+      const dt = (now - _lastBytesTime) / 1000;
+      if (dt > 0.25) {
+        const speed = (bytesReceived - _lastBytes) / dt;
+        _speedSamples = [..._speedSamples.slice(-4), speed];
+        _lastBytesTime = now;
+        _lastBytes = bytesReceived;
+      }
+      const avg = _speedSamples.length
+        ? _speedSamples.reduce((a, b) => a + b) / _speedSamples.length
+        : 0;
+      bytesPerSec = avg;
+      etaSec = avg > 0 ? (bytesTotal - bytesReceived) / avg : -1;
+    }
+    onProgress?.({
+      msg,
+      pct,
+      stepId: currentStep?.id ?? null,
+      stepLabel: currentStep?.label ?? null,
+      stepIndex,
+      stepTotal: totalSteps,
+      stepPct: pct,
+      bytesDownloaded: bytesReceived ?? 0,
+      bytesTotal: bytesTotal ?? -1,
+      bytesPerSec,
+      etaSec,
+    });
+  };
 
   try {
     if (!ffmpegReady) {
-      step++;
+      currentStep = STEP_DEFS.find((s) => s.id === 'ffmpeg');
+      stepIndex++;
+      resetTracker();
       await downloadFFmpeg(tmp, stepCb);
     }
     if (!analyzerReady) {
-      step++;
+      currentStep = STEP_DEFS.find((s) => s.id === 'analyzer');
+      stepIndex++;
+      resetTracker();
       await downloadAnalyzer(tmp, stepCb);
     }
     if (!ytDlpReady) {
-      step++;
+      currentStep = STEP_DEFS.find((s) => s.id === 'ytdlp');
+      stepIndex++;
+      resetTracker();
       await downloadYtDlp(tmp, stepCb);
     }
     if (!tidalReady) {
-      step++;
+      currentStep = STEP_DEFS.find((s) => s.id === 'tidal');
+      stepIndex++;
+      resetTracker();
       stepCb('Installing tidal-dl-ng…', 0);
       try {
         await installTidalDlNgDep((msg) => stepCb(msg, -1));
@@ -673,7 +739,12 @@ export async function ensureDeps(onProgress) {
         stepCb('tidal-dl-ng install failed — Python 3.12+ may not be available.', -1);
       }
     }
-    onProgress?.('Setup complete.', 100);
+    onProgress?.({
+      msg: 'Setup complete.',
+      pct: 100,
+      stepIndex: totalSteps,
+      stepTotal: totalSteps,
+    });
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/src/main.js
+++ b/src/main.js
@@ -296,6 +296,15 @@ function cleanupLegacyNormalizedFiles() {
   );
 }
 
+let _lastDepLog = '';
+function sendDepsProgress(data) {
+  if (data && (data.pct === 0 || data.pct === 100) && data.msg !== _lastDepLog) {
+    _lastDepLog = data.msg;
+    console.log('[deps]', data.msg);
+  }
+  if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', data);
+}
+
 async function initApp() {
   initLogger();
   if (process.platform === 'win32') logDiagnostics();
@@ -319,26 +328,15 @@ async function initApp() {
   if (process.env.E2E_TEST === '1') return;
 
   // Download deps if not already present
-  let _lastDepLog = '';
-  ensureDeps((msg, pct) => {
-    if ((pct === 0 || pct === 100 || pct === undefined) && msg !== _lastDepLog) {
-      _lastDepLog = msg;
-      console.log('[deps]', msg);
-    }
-    if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', { msg, pct });
-  })
+  ensureDeps(sendDepsProgress)
     .then(() => {
-      if (global.mainWindow) global.mainWindow.webContents.send('deps-progress', null);
+      sendDepsProgress(null);
       // Auto-generate waveforms for any analyzed tracks missing overview data
       autoGenerateMissingWaveforms();
     })
     .catch((err) => {
       console.error('[deps] Failed to download FFmpeg:', err.message);
-      if (global.mainWindow)
-        global.mainWindow.webContents.send('deps-progress', {
-          msg: `Error: ${err.message}`,
-          pct: -1,
-        });
+      sendDepsProgress({ msg: `Error: ${err.message}`, pct: -1, error: err.message });
     });
 
   Menu.setApplicationMenu(null);
@@ -350,6 +348,14 @@ async function initApp() {
 
 // IPC Handlers
 ipcMain.handle('get-media-port', () => mediaServerPort);
+
+ipcMain.handle('retry-deps', () => {
+  ensureDeps(sendDepsProgress)
+    .then(() => sendDepsProgress(null))
+    .catch((err) =>
+      sendDepsProgress({ msg: `Error: ${err.message}`, pct: -1, error: err.message })
+    );
+});
 ipcMain.handle('get-tracks', (_, params) => getTracks(params));
 ipcMain.handle('get-track-ids', (_, params) => getTrackIds(params));
 ipcMain.handle('get-track-waveform', (_, trackId) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -252,6 +252,7 @@ contextBridge.exposeInMainWorld('api', {
   checkDepUpdates: () => ipcRenderer.invoke('check-dep-updates'),
   updateAnalyzer: () => ipcRenderer.invoke('update-analyzer'),
   updateAllDeps: () => ipcRenderer.invoke('update-all-deps'),
+  retryDeps: () => ipcRenderer.invoke('retry-deps'),
   onDepsProgress: (callback) => {
     const handler = (_, data) => callback(data);
     ipcRenderer.on('deps-progress', handler);


### PR DESCRIPTION
Closes #270

## What

Replaces the single-message first-run overlay with a proper step-list UI that shows download progress per tool.

## Why

The old overlay gave no sense of which tool was downloading, how far along it was, or how long it would take — especially painful on slow connections where FFmpeg alone is 80 MB.

## How

- **`deps.js`** — `ensureDeps` now emits a rich payload per tick: `stepId`, `stepLabel`, `stepIndex`, `stepTotal`, `stepPct`, `bytesDownloaded`, `bytesTotal`, `bytesPerSec`, `etaSec`. Speed/ETA uses a 5-sample rolling average, updated every 250 ms.
- **`main.js`** — `sendDepsProgress` moved to module scope; new `retry-deps` IPC handler re-runs `ensureDeps` on demand.
- **`preload.js`** — exposes `window.api.retryDeps()`.
- **`DepsOverlay.jsx` / `DepsOverlay.css`** — new component: vertical step list with ✓/↓/· icons, per-step bytes+speed+ETA, progress bar, overall step counter, error state with Retry button.
- **`App.jsx`** — uses `<DepsOverlay>` instead of inline JSX; old overlay CSS removed from `App.css`.

## Test flight checklist

- [ ] Fresh install (no `userData/bin/`) — overlay appears with step list; each tool shows its download progress with bytes and speed
- [ ] FFmpeg step shows MB downloaded / total MB · MB/s · ~Xs remaining
- [ ] Completed steps show ✓ icon in green; pending steps show · in grey
- [ ] When all deps already installed — overlay does not appear at all
- [ ] Simulate network error (disconnect mid-download) — overlay shows error message and Retry button; clicking Retry restarts download
- [ ] Update-deps flow (Settings → Update) still works — uses old `{ msg, pct }` path, overlay shows simple bar (no step list, no crash)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)