### PR TITLE
fix(anlz): EXT PCOB2 must stay empty — memory cues belong in PCO2 slot 2

### DIFF
--- a/protocol_rekordbox.md
+++ b/protocol_rekordbox.md
@@ -153,9 +153,10 @@ Two PCOB sections (slot 1 = hot cues, slot 2 = memory cues).
 **Slot 1 (hot cues, type = 1)** — contains PCPT sub-tags for hot cue slots A–C (indices 0–2).
 Hot cue slots D–H (indices 3–7) go in EXT PCOB slot 1 (see EXT section below).
 
-**Slot 2 (memory cues, type = 0)** — always the empty 24-byte stub.
-Memory cue format in PCOB2 is unconfirmed (non-empty PCOB2 causes Rekordbox to reject the
-entire file). Memory cues are stored in EXT PCO2 slot 2 instead.
+**Slot 2 (memory cues, type = 0)** — populated with PCPT sub-tags for memory cues when present.
+Confirmed from native capture 42: `mem_count` field (bytes 20–23) must be `0x00000000` when
+entries are present (not the `0xFFFFFFFF` sentinel used by hot-cue slots); writing the wrong
+value causes Rekordbox to reject the entire DAT file.
 
 #### PCOB header (24 bytes)
 

--- a/src/__tests__/anlzWriter.test.js
+++ b/src/__tests__/anlzWriter.test.js
@@ -578,12 +578,12 @@ describe('buildExtPcobSections', () => {
     expect(ext1.readUInt32BE(8)).toBe(24); // empty — no D-H cues
   });
 
-  it('EXT PCOB2 contains memory cues (#232)', () => {
+  it('EXT PCOB2 is always the empty stub, even when memory cues are present', () => {
+    // Native captures confirm EXT PCOB2 is never populated — memory cues go into PCO2 slot 2.
     const memoryCue = { position_ms: 5000, color: '#00ff00', hot_cue_index: -1 };
     const [, ext2] = buildExtPcobSections([memoryCue]);
-    expect(ext2.readUInt32BE(8)).toBe(24 + 56); // len_tag = header + 1 entry
-    expect(ext2.readUInt16BE(18)).toBe(1);
-    expect(ext2.readUInt32BE(24 + 12)).toBe(0); // hot_cue_num = 0 = memory
+    expect(ext2.readUInt32BE(8)).toBe(24); // always 24-byte empty stub
+    expect(ext2.readUInt16BE(18)).toBe(0); // num_cues = 0
   });
 
   it('EXT PCOB2 is empty when no memory cues', () => {

--- a/src/audio/anlzWriter.js
+++ b/src/audio/anlzWriter.js
@@ -476,7 +476,8 @@ export function buildPcobSections(cuePoints) {
 /**
  * Build PCOB buffers for the EXT file [slot1, slot2].
  * Verified split: hot_cue numbers 4-8 (D-H, hot_cue_index 3-7) go in EXT PCOB1.
- * Memory cues (hot_cue_num=0) go in PCOB2 (slotType=0) in both DAT and EXT (#232).
+ * EXT PCOB2 is always the empty stub — native captures confirm EXT PCOB is never populated.
+ * Memory cues in the EXT file go into PCO2 slot 2 (handled by buildPco2Sections).
  *
  * @param {Array<{position_ms, color, hot_cue_index}>} cuePoints
  * @returns {[Buffer, Buffer]}
@@ -485,8 +486,7 @@ export function buildExtPcobSections(cuePoints) {
   if (!cuePoints || cuePoints.length === 0) return [EMPTY_PCOB_1, EMPTY_PCOB_2];
   // hot_cue_index 3-7 → hot_cue numbers 4-8 (D-H) — EXT only
   const extHotCues = cuePoints.filter((c) => c.hot_cue_index >= 3 && c.hot_cue_index <= 7);
-  const memoryCues = cuePoints.filter((c) => c.hot_cue_index < 0);
-  return [buildPcobSlot(1, extHotCues), buildPcobSlot(0, memoryCues)];
+  return [buildPcobSlot(1, extHotCues), EMPTY_PCOB_2];
 }
 
 /**


### PR DESCRIPTION
Fixes a regression introduced in PR #234: `buildExtPcobSections` was incorrectly writing memory cues into EXT PCOB2. Native captures confirm EXT PCOB sections are always empty stubs — memory cues in the EXT file belong only in PCO2 slot 2, which `buildPco2Sections` already handles correctly.

A non-empty EXT PCOB2 caused the CDJ to reject the EXT file, dropping waveform, PQT2 beatgrid, and PCO2 cue colours from the track display.

Needs hardware verification on CDJ before merging into `fix/232-memory-cue-export`.

Refs #311

🤖 Generated with [Claude Code](https://claude.ai/claude-code)