### PR TITLE
fix(pdb): correct auto-gain reference constants from native capture analysis

### DIFF
--- a/src/__tests__/pdbWriter.test.js
+++ b/src/__tests__/pdbWriter.test.js
@@ -282,21 +282,21 @@ describe('buildTrackRow', () => {
     expect(buf.readUInt32LE(16)).toBe(5000000);
   });
 
-  it('auto_gain defaults (0x4A68 / 0x78F7) written at offsets 24/26 when no replayGain', () => {
+  it('auto_gain defaults (13940 / 17802) written at offsets 24/26 when no replayGain', () => {
     const buf = buildTrackRow(minimal);
-    expect(buf.readUInt16LE(24)).toBe(0x4a68); // 19048 — CDJ unanalyzed reference
-    expect(buf.readUInt16LE(26)).toBe(0x78f7); // 30967 — secondary unanalyzed reference
+    expect(buf.readUInt16LE(24)).toBe(13940); // ref7 back-calculated from native capture 20
+    expect(buf.readUInt16LE(26)).toBe(17802); // ref8 back-calculated from native capture 20
   });
 
   it('auto_gain computed from replayGain at offsets 24/26', () => {
     const buf = buildTrackRow({ ...minimal, replayGain: 0 });
-    expect(buf.readUInt16LE(24)).toBe(19048);
-    expect(buf.readUInt16LE(26)).toBe(30967);
+    expect(buf.readUInt16LE(24)).toBe(13940);
+    expect(buf.readUInt16LE(26)).toBe(17802);
 
     const bufMinus6 = buildTrackRow({ ...minimal, replayGain: -6 });
-    // 10^(-6/20) * 19048 ≈ 9546
-    expect(bufMinus6.readUInt16LE(24)).toBe(Math.round(10 ** (-6 / 20) * 19048));
-    expect(bufMinus6.readUInt16LE(26)).toBe(Math.round(10 ** (-6 / 20) * 30967));
+    // 10^(-6/20) * 13940 ≈ 6985
+    expect(bufMinus6.readUInt16LE(24)).toBe(Math.round(10 ** (-6 / 20) * 13940));
+    expect(bufMinus6.readUInt16LE(26)).toBe(Math.round(10 ** (-6 / 20) * 17802));
   });
 
   it('ArtistId at offset 68', () => {

--- a/src/usb/pdbWriter.js
+++ b/src/usb/pdbWriter.js
@@ -350,14 +350,16 @@ export function buildTrackRow(params) {
   } = params;
 
   // Converts replay_gain dB to the linear amplitude scale factor CDJs use for Auto Gain.
-  // Reference point 19048 (0x4A68) and 30967 (0x78F7) are the "unanalyzed" defaults
-  // written by native Rekordbox when no loudness analysis has run.
+  // Reference constants back-calculated from native Rekordbox capture 20 (+2.6 dB loudness):
+  //   Unnamed7 = 0x4975 = 18805 → ref7 = round(18805 / 10^(2.6/20)) = 13940
+  //   Unnamed8 = 0x5DC9 = 24009 → ref8 = round(24009 / 10^(2.6/20)) = 17802
+  // Falls back to the reference value (0 dB) when no loudness analysis has run.
   const gainToAutoGain = (ref) =>
     replayGain == null
       ? ref
       : Math.max(0, Math.min(0xffff, Math.round(10 ** (replayGain / 20) * ref)));
-  const autoGain7 = gainToAutoGain(19048); // offset 24 — CDJ-NXS2 auto-gain field
-  const autoGain8 = gainToAutoGain(30967); // offset 26 — second gain reference
+  const autoGain7 = gainToAutoGain(13940); // offset 24 — CDJ auto-gain field
+  const autoGain8 = gainToAutoGain(17802); // offset 26 — second gain reference
 
   // String encoding order matches rex track.go StringOffsets struct and MarshalBinary
   const strBufs = [


### PR DESCRIPTION
Corrects the CDJ auto-gain reference constants in `pdbWriter.js`.

Back-calculated from native Rekordbox capture 20 (track with +2.6 dB loudness):
- `ref7`: 19048 → **13940** (from `Unnamed7 = 0x4975 = 18805`)
- `ref8`: 30967 → **17802** (from `Unnamed8 = 0x5DC9 = 24009`)

Previous values were community-RE estimates that did not match observed native output. Two-track export verified: both fields agree to 2 decimal places, quiet/loud tracks produce correct boost/attenuation.

Needs hardware verification on CDJ-3000 to confirm trim knob position.

Closes #299

🤖 Generated with [Claude Code](https://claude.ai/claude-code)