### PR TITLE
fix: add renderer console logging + unlock DevTools in production for #361 diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dj_manager",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "DJ-focused music library manager",
   "main": "src/main.js",
   "scripts": {

--- a/renderer/src/SettingsModal.jsx
+++ b/renderer/src/SettingsModal.jsx
@@ -219,6 +219,10 @@ function SettingsModal({ onClose }) {
     await window.api.openLogDir();
   };
 
+  const handleOpenDevTools = async () => {
+    await window.api.openDevTools();
+  };
+
   const handleBrowseLibrary = async () => {
     const dir = await window.api.openDirDialog();
     if (dir) setConfirmMove(dir);
@@ -834,11 +838,24 @@ function SettingsModal({ onClose }) {
                   <div>
                     <div className="settings-action-label">Log Files</div>
                     <div className="settings-action-desc">
-                      Opens the folder containing runtime log files.
+                      Opens the folder containing runtime log files, including the renderer console
+                      log (renderer-console-*.log).
                     </div>
                   </div>
                   <button className="btn-secondary" onClick={handleOpenLogs}>
                     Open Log Folder
+                  </button>
+                </div>
+                <div className="settings-row settings-row-action" style={{ marginTop: '0.75rem' }}>
+                  <div>
+                    <div className="settings-action-label">DevTools Console</div>
+                    <div className="settings-action-desc">
+                      Opens the developer console (also reachable with Ctrl+Shift+I or F12) for live
+                      debugging while reporting a bug.
+                    </div>
+                  </div>
+                  <button className="btn-secondary" onClick={handleOpenDevTools}>
+                    Open DevTools Console
                   </button>
                 </div>
               </div>

--- a/src/logger.js
+++ b/src/logger.js
@@ -16,6 +16,7 @@ const LOG_RETENTION_DAYS = 7;
 
 let logStream = null;
 let logDir = null;
+let rendererLogStream = null;
 
 function pad(n) {
   return String(n).padStart(2, '0');
@@ -75,11 +76,11 @@ function patchConsole() {
   };
 }
 
-function pruneOldLogs() {
+function pruneOldLogs(prefix) {
   try {
     const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
     for (const f of fs.readdirSync(logDir)) {
-      if (!f.startsWith('app-') || !f.endsWith('.log')) continue;
+      if (!f.startsWith(prefix) || !f.endsWith('.log')) continue;
       const full = path.join(logDir, f);
       const stat = fs.statSync(full);
       if (stat.mtimeMs < cutoff) fs.unlinkSync(full);
@@ -93,7 +94,7 @@ export function initLogger() {
   logDir = path.join(app.getPath('userData'), 'logs');
   fs.mkdirSync(logDir, { recursive: true });
 
-  pruneOldLogs();
+  pruneOldLogs('app-');
 
   const logFile = path.join(logDir, `app-${today()}.log`);
   logStream = fs.createWriteStream(logFile, { flags: 'a' });
@@ -110,4 +111,28 @@ export function initLogger() {
 
 export function getLogDir() {
   return logDir;
+}
+
+/**
+ * Separate log file capturing the renderer's DevTools console (forwarded via
+ * webContents 'console-message'), so a bug reporter's browser-side errors are
+ * distinguishable from main-process logs without cross-referencing timestamps.
+ */
+export function initRendererLogger() {
+  pruneOldLogs('renderer-console-');
+
+  const logFile = path.join(logDir, `renderer-console-${today()}.log`);
+  rendererLogStream = fs.createWriteStream(logFile, { flags: 'a' });
+
+  rendererLogStream.write(`\n${'='.repeat(60)}\n`);
+  rendererLogStream.write(
+    `[${timestamp()}] [INFO]  DJ Manager renderer console log started — version ${app.getVersion()}\n`
+  );
+
+  return logFile;
+}
+
+export function logRendererMessage(level, message) {
+  const line = `[${timestamp()}] [${level.toUpperCase()}] ${message}\n`;
+  rendererLogStream?.write(line);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -192,10 +192,27 @@ function createWindow() {
   // Always forward the renderer's DevTools console into its own log file so a
   // bug reporter's console output (errors, our [diag]/[player] traces) can be
   // captured even when nobody is watching the DevTools window live.
-  mainWindow.webContents.on('console-message', (_e, level, msg) => {
-    const levelName = ['verbose', 'info', 'warn', 'error'][level] ?? 'info';
-    logRendererMessage(levelName, msg);
-    if (!app.isPackaged) console.log(`[renderer:${levelName}]`, msg);
+  mainWindow.webContents.on('console-message', ({ level, message }) => {
+    logRendererMessage(level, message);
+    if (!app.isPackaged) console.log(`[renderer:${level}]`, message);
+  });
+
+  // "Failed to load resource" lines (network-level errors, and HTTP error
+  // statuses like the media server's 403) show up in the DevTools console but
+  // are NOT delivered via 'console-message' — Chromium reports them through
+  // webRequest instead. Capture both so a 404/403 on an audio file (the likely
+  // shape of #361) actually lands in the log.
+  const requestLogSession = mainWindow.webContents.session;
+  requestLogSession.webRequest.onErrorOccurred((details) => {
+    if (details.error.includes('ERR_ABORTED')) return; // benign: cancelled in-flight requests (e.g. track skip)
+    logRendererMessage('error', `Failed to load resource: ${details.error} ${details.url}`);
+  });
+  requestLogSession.webRequest.onCompleted((details) => {
+    if (details.statusCode < 400) return;
+    logRendererMessage(
+      'error',
+      `Failed to load resource: the server responded with a status of ${details.statusCode} ${details.url}`
+    );
   });
 
   if (process.env.E2E_TEST === '1') {

--- a/src/main.js
+++ b/src/main.js
@@ -108,7 +108,7 @@ import {
   ensureTidalDlNg,
   updateAll,
 } from './deps.js';
-import { initLogger, getLogDir } from './logger.js';
+import { initLogger, getLogDir, initRendererLogger, logRendererMessage } from './logger.js';
 import { detectFilesystem, formatDrive, describeFilesystem } from './usb/usbUtils.js';
 import { writeAnlz, getAnlzFolder } from './audio/anlzWriter.js';
 import { writeSettingFiles } from './usb/settingWriter.js';
@@ -189,23 +189,33 @@ function createWindow() {
     if (menu.items.length > 0) menu.popup();
   });
 
+  // Always forward the renderer's DevTools console into its own log file so a
+  // bug reporter's console output (errors, our [diag]/[player] traces) can be
+  // captured even when nobody is watching the DevTools window live.
+  mainWindow.webContents.on('console-message', (_e, level, msg) => {
+    const levelName = ['verbose', 'info', 'warn', 'error'][level] ?? 'info';
+    logRendererMessage(levelName, msg);
+    if (!app.isPackaged) console.log(`[renderer:${levelName}]`, msg);
+  });
+
   if (process.env.E2E_TEST === '1') {
     mainWindow.loadFile(path.join(__dirname, '../renderer/dist/index.html'));
   } else if (!app.isPackaged) {
     mainWindow.loadURL(fs.readFileSync(path.join(__dirname, '../.dev-url'), 'utf8').trim());
     mainWindow.webContents.openDevTools();
-    // Forward renderer console to terminal so we can debug without DevTools window
-    mainWindow.webContents.on('console-message', (_e, level, msg) => {
-      const tag =
-        ['[renderer:verbose]', '[renderer:info]', '[renderer:warn]', '[renderer:error]'][level] ??
-        '[renderer]';
-      console.log(tag, msg);
-    });
   } else {
     mainWindow.loadFile(path.join(__dirname, '../renderer/dist/index.html'));
+    // DevTools is intentionally reachable in production too (Ctrl+Shift+I / F12 or
+    // Settings → Advanced → Open DevTools Console) so users can capture diagnostics
+    // for bug reports without a custom debug build.
     mainWindow.webContents.on('before-input-event', (event, input) => {
-      if (input.key === 'F12' || (input.control && input.shift && input.key === 'I')) {
+      if (input.type !== 'keyDown') return;
+      if (
+        input.key === 'F12' ||
+        (input.control && input.shift && input.key.toUpperCase() === 'I')
+      ) {
         event.preventDefault();
+        mainWindow.webContents.toggleDevTools();
       }
     });
   }
@@ -307,6 +317,7 @@ function sendDepsProgress(data) {
 
 async function initApp() {
   initLogger();
+  initRendererLogger();
   if (process.platform === 'win32') logDiagnostics();
   console.log('Initializing database...');
   initDB();
@@ -844,6 +855,7 @@ ipcMain.on('renderer-log', (_, { level, msg }) => {
 
 ipcMain.handle('get-log-dir', () => getLogDir());
 ipcMain.handle('open-log-dir', () => shell.openPath(getLogDir()));
+ipcMain.handle('open-devtools', () => mainWindow?.webContents.openDevTools());
 ipcMain.handle('get-dep-versions', () => getInstalledVersions());
 ipcMain.handle('check-dep-updates', () => checkForUpdates());
 ipcMain.handle('update-analyzer', async (_event) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -247,6 +247,7 @@ contextBridge.exposeInMainWorld('api', {
   clearUserData: () => ipcRenderer.invoke('clear-user-data'),
   getLogDir: () => ipcRenderer.invoke('get-log-dir'),
   openLogDir: () => ipcRenderer.invoke('open-log-dir'),
+  openDevTools: () => ipcRenderer.invoke('open-devtools'),
   log: (level, ...args) => ipcRenderer.send('renderer-log', { level, msg: args.join(' ') }),
   getDepVersions: () => ipcRenderer.invoke('get-dep-versions'),
   checkDepUpdates: () => ipcRenderer.invoke('check-dep-updates'),


### PR DESCRIPTION
## Summary
- #361 (Windows 11 playback broken) could not be reproduced locally across stock library playback, yt-dlp playlist download/playback, or a relocated library + directly-imported MP3 (simulating the reporter's setup).
- Since local repro has failed, this ships better diagnostics so the reporter can capture their own logs:
  - Renderer DevTools console output is now always forwarded into a dedicated `renderer-console-YYYY-MM-DD.log` (same folder/retention as the existing main-process log), regardless of dev/production.
  - DevTools is now reachable in production builds via Ctrl+Shift+I / F12 (previously blocked outside dev), plus a new **Settings → Advanced → Open DevTools Console** button.
- Version bumped to 1.0.19.

## Test plan
- [x] `npm run lint` / `npm run lint:all` clean
- [x] `npm test` — no new failures (pre-existing unrelated `anlzWriter` failures from uncommitted tree state, not touched by this PR)
- [x] Manually verified in a Windows 11 VM: stock library playback, yt-dlp playlist download+playback, and relocated-library + direct-MP3-import playback all succeed with zero errors
- [ ] Build and smoke-test the packaged Windows installer (`npm run dist:win`) to confirm DevTools opens via shortcut/Settings button in a real production build
