### PR TITLE
Add Link button for reference-only track import

### DIFF
--- a/renderer/src/ImportPlaylistDialog.jsx
+++ b/renderer/src/ImportPlaylistDialog.jsx
@@ -1,7 +1,13 @@
 import { useState, useEffect, useRef } from 'react';
 import './ImportPlaylistDialog.css';
 
-export default function ImportPlaylistDialog({ playlists, onConfirm, onCancel }) {
+export default function ImportPlaylistDialog({
+  playlists,
+  onConfirm,
+  onCancel,
+  title = 'Import to Playlist',
+  confirmLabel = 'Import',
+}) {
   const [selected, setSelected] = useState('library');
   const [createName, setCreateName] = useState('');
   const [showCreate, setShowCreate] = useState(false);
@@ -24,7 +30,7 @@ export default function ImportPlaylistDialog({ playlists, onConfirm, onCancel })
   return (
     <div className="ipd-backdrop" onClick={onCancel}>
       <div className="ipd-modal" onClick={(e) => e.stopPropagation()}>
-        <h3 className="ipd-title">Import to Playlist</h3>
+        <h3 className="ipd-title">{title}</h3>
         <p className="ipd-desc">Choose where to add the imported tracks:</p>
 
         <div className="ipd-list">
@@ -98,7 +104,7 @@ export default function ImportPlaylistDialog({ playlists, onConfirm, onCancel })
             onClick={handleConfirm}
             disabled={showCreate && !createName.trim()}
           >
-            Import
+            {confirmLabel}
           </button>
         </div>
       </div>

--- a/renderer/src/Sidebar.css
+++ b/renderer/src/Sidebar.css
@@ -161,7 +161,7 @@ button.normalize-progress-wrap.ytdlp-progress-clickable:focus-visible {
 
 .import-button {
   margin-top: 12px;
-  margin-bottom: 25px;
+  margin-bottom: 8px;
   width: 100%;
   padding: 10px;
   background-color: #1db9542f;
@@ -181,6 +181,30 @@ button.normalize-progress-wrap.ytdlp-progress-clickable:focus-visible {
 .import-button:hover {
   background-color: #1db95455;
   border-color: #10c44f;
+}
+
+.link-button {
+  margin-top: 0;
+  margin-bottom: 25px;
+  width: 100%;
+  padding: 10px;
+  background-color: #457b9d2f;
+  border: 2px solid #457b9d;
+  color: #ffffff;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.2s ease;
+}
+
+.link-button:active,
+.link-button:focus {
+  outline: none;
+}
+
+.link-button:hover {
+  background-color: #457b9d55;
+  border-color: #5a94bd;
 }
 
 .playlists-header {

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -46,6 +46,8 @@ function Sidebar({
   const [renameValue, setRenameValue] = useState('');
   const [dragOverPlaylistId, setDragOverPlaylistId] = useState(null);
   const [importDialogFiles, setImportDialogFiles] = useState(null); // pending files waiting for playlist selection
+  const [linkDialogFiles, setLinkDialogFiles] = useState(null); // pending files waiting for playlist selection (link mode)
+  const [linking, setLinking] = useState(false);
   const newInputRef = useRef(null);
   const renameInputRef = useRef(null);
 
@@ -102,6 +104,31 @@ function Sidebar({
     await window.api.importAudioFiles(files, playlistId);
     // Small delay so the user sees 100% before the bar disappears
     setTimeout(() => setImportProgress({ total: 0, completed: 0 }), 800);
+  };
+
+  const handleLink = async () => {
+    const files = await window.api.selectAudioFiles();
+    if (!files.length) return;
+    setLinkDialogFiles(files);
+  };
+
+  const handleLinkConfirm = async (choice) => {
+    const files = linkDialogFiles;
+    setLinkDialogFiles(null);
+    if (!files?.length) return;
+
+    let playlistId = null;
+
+    if (choice.type === 'create') {
+      const result = await window.api.createPlaylist(choice.name);
+      playlistId = result?.id ?? null;
+    } else if (choice.type === 'existing') {
+      playlistId = choice.id;
+    }
+
+    setLinking(true);
+    await window.api.linkAudioFiles(files, playlistId);
+    setLinking(false);
   };
 
   const handleCreatePlaylist = async (e) => {
@@ -347,6 +374,7 @@ function Sidebar({
             Importing {importProgress.completed} / {importProgress.total}…
           </div>
         )}
+        {linking && <div className="import-progress">Linking files…</div>}
         {analysisProgress && (
           <div className="normalize-progress-wrap">
             <div className="normalize-progress-label">
@@ -501,7 +529,14 @@ function Sidebar({
           </div>
         )}
         <button className="import-button" onClick={handleImport}>
-          Import Audio Files
+          Import
+        </button>
+        <button
+          className="link-button"
+          onClick={handleLink}
+          title="Reference files without copying them into the library"
+        >
+          Link
         </button>
       </div>
 
@@ -573,6 +608,16 @@ function Sidebar({
           playlists={playlists}
           onConfirm={handleImportConfirm}
           onCancel={() => setImportDialogFiles(null)}
+        />
+      )}
+
+      {linkDialogFiles && (
+        <ImportPlaylistDialog
+          playlists={playlists}
+          onConfirm={handleLinkConfirm}
+          onCancel={() => setLinkDialogFiles(null)}
+          title="Link to Playlist"
+          confirmLabel="Link"
         />
       )}
     </div>

--- a/renderer/src/__tests__/Sidebar.test.jsx
+++ b/renderer/src/__tests__/Sidebar.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, within, fireEvent, waitFor, act } from '@testing-library/react';
 import Sidebar from '../Sidebar.jsx';
 import { DownloadProvider } from '../DownloadContext.jsx';
 import { TidalDownloadProvider } from '../TidalDownloadContext.jsx';
@@ -156,15 +156,17 @@ describe('Sidebar — import dialog playlist association', () => {
     window.api.createPlaylist.mockResolvedValueOnce({ id: 7 });
 
     renderSidebar({ ...defaultProps });
-    fireEvent.click(screen.getByText('Import Audio Files'));
+    fireEvent.click(screen.getByText('Import'));
 
-    await waitFor(() => screen.getByText('Import to Playlist'));
+    const dialog = (await waitFor(() => screen.getByText('Import to Playlist'))).closest(
+      '.ipd-modal'
+    );
 
     fireEvent.click(screen.getByRole('radio', { name: /Create new playlist/ }));
     fireEvent.change(screen.getByPlaceholderText('New playlist name'), {
       target: { value: 'My New Set' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Import' }));
 
     await waitFor(() => {
       expect(window.api.createPlaylist).toHaveBeenCalledWith('My New Set');
@@ -182,11 +184,13 @@ describe('Sidebar — import dialog playlist association', () => {
     renderSidebar({ ...defaultProps });
     await waitFor(() => screen.getByText('Techno Set'));
 
-    fireEvent.click(screen.getByText('Import Audio Files'));
-    await waitFor(() => screen.getByText('Import to Playlist'));
+    fireEvent.click(screen.getByText('Import'));
+    const dialog = (await waitFor(() => screen.getByText('Import to Playlist'))).closest(
+      '.ipd-modal'
+    );
 
     fireEvent.click(screen.getByRole('radio', { name: /Techno Set/ }));
-    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Import' }));
 
     await waitFor(() => {
       expect(window.api.importAudioFiles).toHaveBeenCalledWith(['/tmp/track.mp3'], 42);
@@ -197,11 +201,13 @@ describe('Sidebar — import dialog playlist association', () => {
     window.api.selectAudioFiles.mockResolvedValueOnce(['/tmp/track.mp3']);
 
     renderSidebar({ ...defaultProps });
-    fireEvent.click(screen.getByText('Import Audio Files'));
-    await waitFor(() => screen.getByText('Import to Playlist'));
+    fireEvent.click(screen.getByText('Import'));
+    const dialog = (await waitFor(() => screen.getByText('Import to Playlist'))).closest(
+      '.ipd-modal'
+    );
 
     // "Library only" is the default — just click Import
-    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Import' }));
 
     await waitFor(() => {
       expect(window.api.importAudioFiles).toHaveBeenCalledWith(['/tmp/track.mp3'], null);


### PR DESCRIPTION
## Summary
- Renames the sidebar "Import Audio Files" button to "Import" and adds a "Link" button beside it
- "Link" references a track at its original file path instead of copying it into the managed audio library, reusing the existing `linkAudioFile`/`is_linked` backend (previously wired only into the File Explorer view) rather than duplicating it
- `ImportPlaylistDialog` now takes optional `title`/`confirmLabel` props so the same playlist-picker dialog serves both the Import and Link flows

## Test plan
- [x] `cd renderer && npx vitest run` — 138/138 passing
- [x] `npm run lint` (root) and `cd renderer && npm run lint` — clean
- [x] Manually verified in the running dev app (user-confirmed): Import and Link buttons both work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)