### PR TITLE
feat: gracefully handle offline/missing linked tracks

### DIFF
--- a/renderer/src/MusicLibrary.css
+++ b/renderer/src/MusicLibrary.css
@@ -290,6 +290,29 @@
   opacity: 0.45;
 }
 
+/* Linked track whose backing file can't currently be found (e.g. USB unplugged) */
+.row--unavailable {
+  opacity: 0.45;
+  font-style: italic;
+}
+
+.hide-unavailable-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: #f4a261;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.cell-linked-badge--offline {
+  opacity: 1;
+  color: #f4a261;
+}
+
 /* New row: space slides open (scaleY), then content fades in */
 @keyframes rowSlideIn {
   0% {

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -34,6 +34,8 @@ import './MusicLibrary.css';
 const PAGE_SIZE = 50;
 const ROW_HEIGHT = 50;
 const PRELOAD_TRIGGER = 3;
+// Stable fallback so tests/mocks that stub usePlayer() without this field don't crash.
+const EMPTY_SET = new Set();
 
 const LS_COL_KEY = 'djman_column_visibility';
 const LS_ORDER_KEY = 'djman_column_order';
@@ -225,6 +227,7 @@ function LibraryRow({
   mediaPort,
   newTrackIds,
   onAnimationEnd,
+  unavailableLinkedIds,
 }) {
   const t = tracks[index];
   if (!t) {
@@ -240,14 +243,17 @@ function LibraryRow({
   const isSelected = selectedIds.has(t.id);
   const isPlaying = currentTrackId === t.id;
   const isNew = newTrackIds?.has(t.id);
+  const isUnavailable = t.is_linked && unavailableLinkedIds?.has(t.id);
   return (
     <div
       style={{ ...style, gridTemplateColumns: gridTemplate, minWidth: minScrollWidth }}
-      className={`row ${index % 2 === 0 ? 'row-even' : 'row-odd'}${isSelected ? ' row--selected' : ''}${isPlaying ? ' row--playing' : ''}${t.analyzed === 0 ? ' row--analyzing' : ''}${isNew ? ' row--new' : ''}`}
+      className={`row ${index % 2 === 0 ? 'row-even' : 'row-odd'}${isSelected ? ' row--selected' : ''}${isPlaying ? ' row--playing' : ''}${t.analyzed === 0 ? ' row--analyzing' : ''}${isNew ? ' row--new' : ''}${isUnavailable ? ' row--unavailable' : ''}`}
       title={
-        t.analyzed === 0
-          ? `⏳ Analyzing / processing — "${t.title}" will be available shortly`
-          : `${t.title} - ${t.artist || 'Unknown'}`
+        isUnavailable
+          ? `⚠ File not found — "${t.title}" may be on a disconnected drive`
+          : t.analyzed === 0
+            ? `⏳ Analyzing / processing — "${t.title}" will be available shortly`
+            : `${t.title} - ${t.artist || 'Unknown'}`
       }
       draggable={true}
       onDragStart={(e) => onDragStart(e, t)}
@@ -309,8 +315,15 @@ function LibraryRow({
               <span className="cell-artwork cell-artwork--placeholder">♪</span>
             )}
             {t.is_linked ? (
-              <span className="cell-linked-badge" title="Explorer-linked file">
-                🔗
+              <span
+                className={`cell-linked-badge${isUnavailable ? ' cell-linked-badge--offline' : ''}`}
+                title={
+                  isUnavailable
+                    ? 'File not found — may be on a disconnected drive'
+                    : 'Explorer-linked file'
+                }
+              >
+                {isUnavailable ? '🔗⚠' : '🔗'}
               </span>
             ) : null}
             <span className="cell-title-text">{t.title}</span>
@@ -342,6 +355,7 @@ function SortableRow({
   mediaPort,
   isNew,
   onAnimationEnd,
+  isUnavailable,
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: t.id,
@@ -357,11 +371,13 @@ function SortableRow({
     <div
       ref={setNodeRef}
       style={style}
-      className={`row ${index % 2 === 0 ? 'row-even' : 'row-odd'}${isSelected ? ' row--selected' : ''}${isPlaying ? ' row--playing' : ''}${t.analyzed === 0 ? ' row--analyzing' : ''}${isNew ? ' row--new' : ''}`}
+      className={`row ${index % 2 === 0 ? 'row-even' : 'row-odd'}${isSelected ? ' row--selected' : ''}${isPlaying ? ' row--playing' : ''}${t.analyzed === 0 ? ' row--analyzing' : ''}${isNew ? ' row--new' : ''}${isUnavailable ? ' row--unavailable' : ''}`}
       title={
-        t.analyzed === 0
-          ? `⏳ Analyzing / processing — "${t.title}" will be available shortly`
-          : `${t.title} - ${t.artist || 'Unknown'}`
+        isUnavailable
+          ? `⚠ File not found — "${t.title}" may be on a disconnected drive`
+          : t.analyzed === 0
+            ? `⏳ Analyzing / processing — "${t.title}" will be available shortly`
+            : `${t.title} - ${t.artist || 'Unknown'}`
       }
       onClick={(e) => onRowClick(e, t, index)}
       onDoubleClick={() => onDoubleClick(t, index)}
@@ -421,8 +437,15 @@ function SortableRow({
               <span className="cell-artwork cell-artwork--placeholder">♪</span>
             )}
             {t.is_linked ? (
-              <span className="cell-linked-badge" title="Explorer-linked file">
-                🔗
+              <span
+                className={`cell-linked-badge${isUnavailable ? ' cell-linked-badge--offline' : ''}`}
+                title={
+                  isUnavailable
+                    ? 'File not found — may be on a disconnected drive'
+                    : 'Explorer-linked file'
+                }
+              >
+                {isUnavailable ? '🔗⚠' : '🔗'}
               </span>
             ) : null}
             <span className="cell-title-text">{t.title}</span>
@@ -469,7 +492,15 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
     patchCurrentTrack,
     reloadCurrentTrack,
     updateQueue,
+    unavailableLinkedIds = EMPTY_SET,
   } = usePlayer();
+
+  const [hideUnavailable, setHideUnavailable] = useState(
+    () => localStorage.getItem('djman_hide_unavailable') === 'true'
+  );
+  useEffect(() => {
+    localStorage.setItem('djman_hide_unavailable', String(hideUnavailable));
+  }, [hideUnavailable]);
 
   // Only highlight a track as "playing" when the source context matches this view.
   // Library view: only highlight when played from library (currentPlaylistId === null).
@@ -615,7 +646,10 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   }, [search, selectedPlaylist]); // no hasMore in deps — we use hasMoreRef
 
   const sortedTracks = useMemo(() => {
-    const sorted = [...tracks].sort((a, b) => {
+    const base = hideUnavailable
+      ? tracks.filter((t) => !(t.is_linked && unavailableLinkedIds.has(t.id)))
+      : tracks;
+    const sorted = [...base].sort((a, b) => {
       if (sortBy.key === 'index') return 0;
       // For BPM, prefer the override value
       const va = sortBy.key === 'bpm' ? (a.bpm_override ?? a.bpm ?? '') : (a[sortBy.key] ?? '');
@@ -630,7 +664,7 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
     });
     sortedTracksRef.current = sorted;
     return sorted;
-  }, [tracks, sortBy]);
+  }, [tracks, sortBy, hideUnavailable, unavailableLinkedIds]);
 
   useEffect(() => {
     // Snapshot IDs currently visible so loadTracks can diff truly-new rows
@@ -1305,6 +1339,16 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
       className={`music-library${detailsTrack || detailsBulkTracks ? ' music-library--with-panel' : ''}`}
     >
       <div className="music-library__main">
+        {unavailableLinkedIds.size > 0 && (
+          <label className="hide-unavailable-toggle">
+            <input
+              type="checkbox"
+              checked={hideUnavailable}
+              onChange={(e) => setHideUnavailable(e.target.checked)}
+            />
+            Hide unavailable tracks ({unavailableLinkedIds.size})
+          </label>
+        )}
         {/* Playlist header bar */}
         {isPlaylistView && playlistInfo && (
           <div className="playlist-header-bar">
@@ -1432,6 +1476,7 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
                         mediaPort={mediaPort}
                         isNew={newTrackIds.has(t.id)}
                         onAnimationEnd={handleRowAnimationEnd}
+                        isUnavailable={t.is_linked && unavailableLinkedIds.has(t.id)}
                       />
                     ))}
                   </div>
@@ -1479,6 +1524,7 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
                 mediaPort,
                 newTrackIds,
                 onAnimationEnd: handleRowAnimationEnd,
+                unavailableLinkedIds,
               }}
             />
           )}

--- a/renderer/src/PlayerBar.css
+++ b/renderer/src/PlayerBar.css
@@ -1,4 +1,5 @@
 .player-bar {
+  position: relative;
   height: 88px;
   flex-shrink: 0;
   background: #111;
@@ -8,6 +9,28 @@
   padding: 0 20px;
   gap: 16px;
   user-select: none;
+}
+
+.player-bar-toast {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 8px;
+  background: #2a2a2a;
+  color: #e0e0e0;
+  font-size: 13px;
+  padding: 8px 16px;
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  z-index: 2000;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.player-bar-toast--warn {
+  border: 1px solid #f4a261;
+  color: #f4a261;
 }
 
 /* ── Left ─────────────────────────────── */

--- a/renderer/src/PlayerBar.jsx
+++ b/renderer/src/PlayerBar.jsx
@@ -25,6 +25,8 @@ export default function PlayerBar({ onNavigateToPlaylist, onArtistSearch }) {
     outputDeviceId,
     volume,
     history,
+    playbackError,
+    clearPlaybackError,
     togglePlay,
     next,
     prev,
@@ -66,6 +68,13 @@ export default function PlayerBar({ onNavigateToPlaylist, onArtistSearch }) {
     }
     loadDevices();
   }, []);
+
+  // Auto-dismiss the playback-error toast
+  useEffect(() => {
+    if (!playbackError) return;
+    const timer = setTimeout(() => clearPlaybackError(), 4500);
+    return () => clearTimeout(timer);
+  }, [playbackError, clearPlaybackError]);
 
   // Load cue points whenever the playing track changes
   useEffect(() => {
@@ -333,6 +342,15 @@ export default function PlayerBar({ onNavigateToPlaylist, onArtistSearch }) {
 
   return (
     <div className="player-bar">
+      {playbackError && (
+        <div
+          className="player-bar-toast player-bar-toast--warn"
+          onClick={clearPlaybackError}
+          title="Dismiss"
+        >
+          ⚠ {playbackError}
+        </div>
+      )}
       {/* Left: album art + current track info */}
       <div className="player-left">
         {artSrc ? (

--- a/renderer/src/PlayerContext.jsx
+++ b/renderer/src/PlayerContext.jsx
@@ -43,6 +43,8 @@ export function PlayerProvider({ children }) {
   const [outputDeviceId, setOutputDeviceId] = useState('');
   const [volume, setVolumeState] = useState(1.0);
   const [history, setHistory] = useState([]); // ring buffer, newest first
+  const [playbackError, setPlaybackError] = useState(null); // { message } | null — surfaced by PlayerBar
+  const [unavailableLinkedIds, setUnavailableLinkedIds] = useState(() => new Set());
 
   // Port of the local HTTP media server (started in main process before window opens).
   const mediaPortRef = useRef(null);
@@ -71,6 +73,26 @@ export function PlayerProvider({ children }) {
       });
     }
   }, []);
+
+  // Track availability for linked (Explorer-referenced) files, which point at
+  // arbitrary — often removable — paths. Re-check on mount, whenever the window
+  // regains focus (e.g. the user just plugged a drive back in), and on a slow
+  // background interval so the "grayed out" state doesn't require an action.
+  const refreshAvailability = useCallback(() => {
+    window.api
+      .getUnavailableLinkedTracks()
+      .then((ids) => setUnavailableLinkedIds(new Set(ids)))
+      .catch((err) => console.warn('[player] availability check failed:', err.message));
+  }, []);
+  useEffect(() => {
+    refreshAvailability();
+    window.addEventListener('focus', refreshAvailability);
+    const interval = setInterval(refreshAvailability, 20000);
+    return () => {
+      window.removeEventListener('focus', refreshAvailability);
+      clearInterval(interval);
+    };
+  }, [refreshAvailability]);
 
   // Web Audio graph is built lazily on first play() call — see buildAudioGraph() below.
   // Building it at mount time creates the AudioContext without a user gesture, leaving it
@@ -119,6 +141,7 @@ export function PlayerProvider({ children }) {
   const currentPlaylistNameRef = useRef(currentPlaylistName);
   const currentTrackRef = useRef(currentTrack);
   const volumeRef = useRef(volume);
+  const unavailableLinkedIdsRef = useRef(unavailableLinkedIds);
   useEffect(() => {
     queueRef.current = queue;
   }, [queue]);
@@ -143,16 +166,30 @@ export function PlayerProvider({ children }) {
   useEffect(() => {
     volumeRef.current = volume;
   }, [volume]);
+  useEffect(() => {
+    unavailableLinkedIdsRef.current = unavailableLinkedIds;
+  }, [unavailableLinkedIds]);
 
   // Generation counter — incremented on every track switch so stale play() rejections are ignored
   const playGenRef = useRef(0);
 
   // Stable play-at-index — exposed via ref so handleEnded can call it without stale closure
   const playAtIndexRef = useRef(null);
+  // `next` is defined further down (after playAtIndex) but playAtIndex's own
+  // failure handler needs to call it — same ref-indirection pattern as above,
+  // since `next` isn't in scope yet at the point playAtIndex is defined.
+  const nextRef = useRef(null);
   const playAtIndex = useCallback(
     async (newQueue, index, playlistId = null, playlistName = null) => {
       const track = newQueue[index];
       if (!track) return;
+      // Known-unavailable linked track (e.g. its USB drive isn't mounted right
+      // now) — skip the round trip to the media server and move on immediately.
+      if (track.is_linked && unavailableLinkedIdsRef.current.has(track.id)) {
+        setPlaybackError(`"${track.title}" is unavailable — the file could not be found.`);
+        nextRef.current?.();
+        return;
+      }
       const gen = ++playGenRef.current;
       const port = mediaPortRef.current;
       if (!port) {
@@ -201,18 +238,25 @@ export function PlayerProvider({ children }) {
         })
         .catch((err) => {
           // AbortError is expected when we switch tracks before play() resolves
-          if (gen === playGenRef.current && err.name !== 'AbortError')
-            console.error(
-              '[diag] play() FAILED:',
-              err.name,
-              err.message,
-              'readyState=',
-              audio.readyState,
-              'networkState=',
-              audio.networkState,
-              'src=',
-              audio.src
-            );
+          if (gen !== playGenRef.current || err.name === 'AbortError') return;
+          console.error(
+            '[diag] play() FAILED:',
+            err.name,
+            err.message,
+            'readyState=',
+            audio.readyState,
+            'networkState=',
+            audio.networkState,
+            'src=',
+            audio.src
+          );
+          // NotSupportedError is what the browser reports when the media server
+          // 404s/403s the source (file missing, e.g. its USB drive was unplugged) —
+          // surface it and move on instead of leaving playback silently stalled.
+          if (err.name === 'NotSupportedError') {
+            setPlaybackError(`"${track.title}" is unavailable — the file could not be found.`);
+            nextRef.current?.();
+          }
         });
       setCurrentTrack(track);
       setQueue(newQueue);
@@ -325,6 +369,9 @@ export function PlayerProvider({ children }) {
       playAtIndexRef.current(q, 0, plId, plName);
     }
   }, []);
+  useLayoutEffect(() => {
+    nextRef.current = next;
+  });
 
   const prev = useCallback(() => {
     if (audio.currentTime > 3) {
@@ -535,6 +582,10 @@ export function PlayerProvider({ children }) {
         outputDeviceId,
         volume,
         history,
+        playbackError,
+        clearPlaybackError: () => setPlaybackError(null),
+        unavailableLinkedIds,
+        refreshAvailability,
         play,
         togglePlay,
         stop,

--- a/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
+++ b/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
@@ -24,6 +24,7 @@ vi.mock('../PlayerContext.jsx', () => ({
     currentTrack: null,
     currentPlaylistId: null,
     updateQueue: vi.fn(),
+    unavailableLinkedIds: new Set(),
   }),
 }));
 

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -6,6 +6,7 @@ const noop = () => () => {}; // returns unsubscribe fn
 window.api = {
   getTracks: vi.fn().mockResolvedValue([]),
   getTrackIds: vi.fn().mockResolvedValue([]),
+  getUnavailableLinkedTracks: vi.fn().mockResolvedValue([]),
   getCuePoints: vi.fn().mockResolvedValue([]),
   addCuePoint: vi.fn().mockResolvedValue({ id: 1 }),
   updateCuePoint: vi.fn().mockResolvedValue({ ok: true }),

--- a/src/__tests__/mediaServer.test.js
+++ b/src/__tests__/mediaServer.test.js
@@ -3,7 +3,8 @@ import fs from 'fs';
 import http from 'http';
 import os from 'os';
 import path from 'path';
-import { startMediaServer, AUDIO_MIME } from '../audio/mediaServer.js';
+import { EventEmitter } from 'events';
+import { startMediaServer, streamFile, AUDIO_MIME } from '../audio/mediaServer.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -165,5 +166,26 @@ describe('GET — missing file', () => {
     const missing = path.join(audioBase, 'nope.mp3');
     const res = await httpGet(`http://127.0.0.1:${port}${toUrlPath(missing)}`);
     expect(res.status).toBe(404);
+  });
+});
+
+// ── File disappears mid-stream (e.g. USB unplugged while playing) ──────────────
+// A real fs race (delete-during-read) is too timing-sensitive to reproduce
+// reliably in CI, so this exercises streamFile() directly with a fake stream
+// that errors after piping has started — the exact shape of the real failure.
+
+describe('streamFile — read stream errors mid-transfer', () => {
+  it('destroys the response instead of throwing an uncaught error', () => {
+    const fakeStream = new EventEmitter();
+    fakeStream.pipe = () => {}; // stub — we only care about error handling here
+    let destroyed = false;
+    const fakeRes = { destroy: () => (destroyed = true) };
+
+    expect(() => {
+      streamFile(fakeStream, fakeRes);
+      fakeStream.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    }).not.toThrow();
+
+    expect(destroyed).toBe(true);
   });
 });

--- a/src/audio/mediaServer.js
+++ b/src/audio/mediaServer.js
@@ -19,6 +19,20 @@ const IMAGE_MIME = {
 };
 
 /**
+ * Pipe a file stream to the HTTP response, destroying the response instead of
+ * crashing the process if the file disappears mid-read (e.g. a USB drive is
+ * unplugged while a track is streaming). Headers are already sent by this
+ * point, so the only option on error is to end the connection cleanly.
+ */
+export function streamFile(stream, res) {
+  stream.on('error', (err) => {
+    if (err.code !== 'ENOENT') console.error('[media-server] stream error:', err.message);
+    res.destroy();
+  });
+  stream.pipe(res);
+}
+
+/**
  * Build the HTTP request handler that serves audio files from `audioBase`
  * and optionally artwork files from `artworkBase`.
  * `allowedBases` is a mutable array; entries added at runtime are respected immediately.
@@ -72,7 +86,7 @@ export function createMediaRequestHandler(audioBase, artworkBase = null, allowed
           'Accept-Ranges': 'bytes',
           'Content-Length': String(end - start + 1),
         });
-        fs.createReadStream(urlPath, { start, end }).pipe(res);
+        streamFile(fs.createReadStream(urlPath, { start, end }), res);
       } else {
         res.writeHead(200, {
           ...corsHeaders,
@@ -80,7 +94,7 @@ export function createMediaRequestHandler(audioBase, artworkBase = null, allowed
           'Accept-Ranges': 'bytes',
           'Content-Length': String(total),
         });
-        fs.createReadStream(urlPath).pipe(res);
+        streamFile(fs.createReadStream(urlPath), res);
       }
     } catch (err) {
       if (err.code !== 'ENOENT') console.error('[media-server] error:', err.message);

--- a/src/main.js
+++ b/src/main.js
@@ -390,6 +390,14 @@ ipcMain.handle('retry-deps', () => {
 });
 ipcMain.handle('get-tracks', (_, params) => getTracks(params));
 ipcMain.handle('get-track-ids', (_, params) => getTrackIds(params));
+// Linked (Explorer-referenced) tracks point at arbitrary, often removable paths
+// (USB drives, etc.) — check which ones are currently unreachable so the UI can
+// gray them out instead of failing playback with no explanation.
+ipcMain.handle('get-unavailable-linked-tracks', () =>
+  getLinkedTracksBasic()
+    .filter((t) => !fs.existsSync(t.file_path))
+    .map((t) => t.id)
+);
 ipcMain.handle('get-track-waveform', (_, trackId) => {
   const buf = getTrackWaveform(trackId);
   return buf ? new Uint8Array(buf) : null;

--- a/src/preload.js
+++ b/src/preload.js
@@ -4,6 +4,7 @@ contextBridge.exposeInMainWorld('api', {
   // Track library
   getTracks: (params) => ipcRenderer.invoke('get-tracks', params),
   getTrackIds: (params) => ipcRenderer.invoke('get-track-ids', params),
+  getUnavailableLinkedTracks: () => ipcRenderer.invoke('get-unavailable-linked-tracks'),
   getTrackWaveform: (trackId) => ipcRenderer.invoke('get-track-waveform', trackId),
   onWaveformReady: (cb) => {
     const handler = (_, data) => cb(data);


### PR DESCRIPTION
Fixes #389.

Linked (Explorer-referenced) tracks point at arbitrary, often removable paths — most commonly a USB drive. Previously, if that source disappeared:
- The UI gave no indication a track was unreachable.
- Playback failed silently: `MEDIA_ERR_SRC_NOT_SUPPORTED` was explicitly suppressed, and `NotSupportedError` from `play()` was logged but nothing else happened — the player just stalled.
- If a file vanished mid-stream, the media server's unhandled stream `error` event would have crashed the whole Electron main process.

### Changes
- `mediaServer.js`: wrap file streaming in `streamFile()`, which destroys the response instead of crashing on a mid-read stream error.
- `main.js`/`preload.js`: new `get-unavailable-linked-tracks` IPC, checking `fs.existsSync` for every `is_linked` track.
- `PlayerContext.jsx`: polls availability on mount/focus/interval, skips known-unavailable tracks immediately, and on a genuine `NotSupportedError` surfaces a toast and auto-advances to the next track instead of stalling.
- `PlayerBar.jsx`: renders the playback-error toast.
- `MusicLibrary.jsx`: grays out unavailable linked tracks (row + badge), with a "Hide unavailable tracks" filter toggle.

### Testing
Full lint + test suite pass (main: 398 tests, renderer: 138 tests), including a new `streamFile` regression test that proves the mid-stream crash is actually fixed — verified it fails without the change (using a controlled fake stream rather than a timing-sensitive real fs race, which proved unreliable).