### PR TITLE
feat: multiple libraries (switchable profiles) + storage format choice

### DIFF
--- a/renderer/src/SettingsModal.css
+++ b/renderer/src/SettingsModal.css
@@ -430,3 +430,67 @@
   font-size: 12px;
   line-height: 1.4;
 }
+
+/* Storage format radios */
+.settings-radio {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #cdd6f4;
+  cursor: pointer;
+  margin-right: 20px;
+}
+.settings-radio input[type='radio'] {
+  accent-color: #1db954;
+  cursor: pointer;
+}
+
+/* Libraries list */
+.library-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.library-list-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  background: #1e1e2e;
+  border: 1px solid #313244;
+  border-radius: 6px;
+}
+.library-list-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #cdd6f4;
+}
+.library-active-badge {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #1db954;
+  border: 1px solid #1db954;
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+.library-list-actions {
+  display: flex;
+  gap: 6px;
+}
+.library-rename-input {
+  flex: 1;
+  padding: 6px 8px;
+  background: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 5px;
+  color: #f0f0f0;
+  font-size: 13px;
+}
+.library-rename-input:focus {
+  outline: none;
+  border-color: #2d6aa0;
+}

--- a/renderer/src/SettingsModal.jsx
+++ b/renderer/src/SettingsModal.jsx
@@ -46,6 +46,19 @@ function SettingsModal({ onClose }) {
   const [moveProgress, setMoveProgress] = useState(null); // { moved, total, pct } | null
   const [confirmMove, setConfirmMove] = useState(null); // pending new dir path
 
+  // Storage format (hashed vs. readable)
+  const [storageFormat, setStorageFormat] = useState('hashed');
+  const [convertProgress, setConvertProgress] = useState(null); // { moved, total, pct } | null
+  const [confirmFormat, setConfirmFormat] = useState(null); // pending target format
+
+  // Multiple libraries
+  const [libraries, setLibraries] = useState([]);
+  const [activeLibraryId, setActiveLibraryId] = useState(null);
+  const [newLibraryName, setNewLibraryName] = useState('');
+  const [confirmSwitchId, setConfirmSwitchId] = useState(null); // pending library id
+  const [renamingId, setRenamingId] = useState(null);
+  const [renameInput, setRenameInput] = useState('');
+
   // Escape key closes dialog
   const handleKeyDown = useCallback(
     (e) => {
@@ -75,6 +88,9 @@ function SettingsModal({ onClose }) {
   useEffect(() => {
     if (activeSection === 'library') {
       window.api.getLibraryPath().then(setLibraryPath);
+      window.api.getStorageFormat().then(setStorageFormat);
+      window.api.listLibraries().then(setLibraries);
+      window.api.getActiveLibrary().then((lib) => setActiveLibraryId(lib?.id ?? null));
     }
     if (activeSection === 'updates') {
       window.api.getDepVersions().then(setDepVersions);
@@ -242,6 +258,44 @@ function SettingsModal({ onClose }) {
     }
   };
 
+  const handleConfirmFormatChange = async () => {
+    const newFormat = confirmFormat;
+    setConfirmFormat(null);
+    setConvertProgress({ moved: 0, total: 0, pct: 0 });
+    const unsub = window.api.onConvertStorageFormatProgress((data) => setConvertProgress(data));
+    try {
+      await window.api.convertStorageFormat(newFormat);
+      setStorageFormat(newFormat);
+      setConvertProgress(null);
+    } finally {
+      unsub?.();
+    }
+  };
+
+  const handleCreateLibrary = async () => {
+    if (!newLibraryName.trim()) return;
+    const created = await window.api.createLibrary(newLibraryName.trim());
+    setNewLibraryName('');
+    setLibraries(await window.api.listLibraries());
+    setConfirmSwitchId(created.id);
+  };
+
+  const handleConfirmSwitch = async () => {
+    const id = confirmSwitchId;
+    setConfirmSwitchId(null);
+    await window.api.switchLibrary(id); // restarts the app
+  };
+
+  const handleConfirmRename = async () => {
+    if (!renameInput.trim()) {
+      setRenamingId(null);
+      return;
+    }
+    await window.api.renameLibrary(renamingId, renameInput.trim());
+    setLibraries(await window.api.listLibraries());
+    setRenamingId(null);
+  };
+
   const sections = [
     { id: 'library', label: 'Library' },
     { id: 'normalization', label: 'Normalization' },
@@ -309,6 +363,137 @@ function SettingsModal({ onClose }) {
                       Move
                     </button>
                     <button className="btn-secondary" onClick={() => setConfirmMove(null)}>
+                      Cancel
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              <div className="settings-group">
+                <div className="settings-group-title">Storage Format</div>
+                <p className="settings-group-desc">
+                  <b>Hashed</b> stores files under a content-hash name (opaque, but
+                  collision/duplicate-proof). <b>Readable</b> uses an "Artist - Title" folder
+                  layout instead, while still hashing content to avoid storing true duplicates
+                  twice. Changing this reorganizes every file already in the library.
+                </p>
+                <div className="settings-row">
+                  <label className="settings-radio">
+                    <input
+                      type="radio"
+                      checked={storageFormat === 'hashed'}
+                      disabled={!!convertProgress}
+                      onChange={() => storageFormat !== 'hashed' && setConfirmFormat('hashed')}
+                    />
+                    Hashed (default)
+                  </label>
+                  <label className="settings-radio">
+                    <input
+                      type="radio"
+                      checked={storageFormat === 'readable'}
+                      disabled={!!convertProgress}
+                      onChange={() => storageFormat !== 'readable' && setConfirmFormat('readable')}
+                    />
+                    Readable
+                  </label>
+                </div>
+                {convertProgress && (
+                  <div className="move-progress">
+                    <div className="move-progress-label">
+                      Reorganizing files… {convertProgress.moved}/{convertProgress.total} (
+                      {convertProgress.pct}%)
+                    </div>
+                    <div className="deps-bar-track">
+                      <div className="deps-bar-fill" style={{ width: `${convertProgress.pct}%` }} />
+                    </div>
+                  </div>
+                )}
+                {confirmFormat && (
+                  <div className="settings-confirm-row" style={{ marginTop: '0.75rem' }}>
+                    <span>
+                      Convert every file to <b>{confirmFormat}</b> layout?
+                    </span>
+                    <button className="btn-primary" onClick={handleConfirmFormatChange}>
+                      Convert
+                    </button>
+                    <button className="btn-secondary" onClick={() => setConfirmFormat(null)}>
+                      Cancel
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              <div className="settings-group">
+                <div className="settings-group-title">Libraries</div>
+                <p className="settings-group-desc">
+                  Each library is fully separate — its own tracks, playlists, and cue points.
+                  Switching libraries restarts the app.
+                </p>
+                <div className="library-list">
+                  {libraries.map((lib) => (
+                    <div key={lib.id} className="library-list-row">
+                      {renamingId === lib.id ? (
+                        <input
+                          autoFocus
+                          className="library-rename-input"
+                          value={renameInput}
+                          onChange={(e) => setRenameInput(e.target.value)}
+                          onKeyDown={(e) => e.key === 'Enter' && handleConfirmRename()}
+                          onBlur={handleConfirmRename}
+                        />
+                      ) : (
+                        <span className="library-list-name">
+                          {lib.name}
+                          {lib.id === activeLibraryId && (
+                            <span className="library-active-badge">active</span>
+                          )}
+                        </span>
+                      )}
+                      <div className="library-list-actions">
+                        <button
+                          className="btn-secondary"
+                          onClick={() => {
+                            setRenamingId(lib.id);
+                            setRenameInput(lib.name);
+                          }}
+                        >
+                          Rename
+                        </button>
+                        {lib.id !== activeLibraryId && (
+                          <button
+                            className="btn-secondary"
+                            onClick={() => setConfirmSwitchId(lib.id)}
+                          >
+                            Switch to…
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="settings-row settings-row-action" style={{ marginTop: '0.75rem' }}>
+                  <input
+                    className="library-rename-input"
+                    placeholder="New library name…"
+                    value={newLibraryName}
+                    onChange={(e) => setNewLibraryName(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && handleCreateLibrary()}
+                  />
+                  <button className="btn-secondary" onClick={handleCreateLibrary}>
+                    + New Library
+                  </button>
+                </div>
+                {confirmSwitchId && (
+                  <div className="settings-confirm-row" style={{ marginTop: '0.75rem' }}>
+                    <span>
+                      Switch to{' '}
+                      <b>{libraries.find((l) => l.id === confirmSwitchId)?.name ?? '…'}</b>? The
+                      app will restart.
+                    </span>
+                    <button className="btn-primary" onClick={handleConfirmSwitch}>
+                      Switch &amp; Restart
+                    </button>
+                    <button className="btn-secondary" onClick={() => setConfirmSwitchId(null)}>
                       Cancel
                     </button>
                   </div>

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -41,6 +41,15 @@ window.api = {
   getNormalizedCount: vi.fn().mockResolvedValue(0),
   getLibraryPath: vi.fn().mockResolvedValue('/tmp/audio'),
   moveLibrary: vi.fn().mockResolvedValue({ moved: 0, total: 0 }),
+  getStorageFormat: vi.fn().mockResolvedValue('hashed'),
+  convertStorageFormat: vi.fn().mockResolvedValue({ moved: 0, total: 0 }),
+  listLibraries: vi.fn().mockResolvedValue([{ id: 'default', name: 'Default', dbFile: 'library.db' }]),
+  getActiveLibrary: vi
+    .fn()
+    .mockResolvedValue({ id: 'default', name: 'Default', dbFile: 'library.db' }),
+  createLibrary: vi.fn().mockResolvedValue({ id: 'new', name: 'New Library', dbFile: 'library-new.db' }),
+  renameLibrary: vi.fn().mockResolvedValue({ id: 'default', name: 'Renamed', dbFile: 'library.db' }),
+  switchLibrary: vi.fn().mockResolvedValue(undefined),
   openDirDialog: vi.fn().mockResolvedValue(null),
   getDepVersions: vi.fn().mockResolvedValue({}),
   checkDepUpdates: vi.fn().mockResolvedValue({}),
@@ -59,6 +68,7 @@ window.api = {
   onOpenSettings: vi.fn().mockImplementation(noop),
   onDepsProgress: vi.fn().mockImplementation(noop),
   onMoveLibraryProgress: vi.fn().mockImplementation(noop),
+  onConvertStorageFormatProgress: vi.fn().mockImplementation(noop),
   onExportM3UProgress: vi.fn().mockImplementation(noop),
   onImportProgress: vi.fn().mockImplementation(noop),
   onNormalizeProgress: vi.fn().mockImplementation(noop),

--- a/src/__tests__/importManager.test.js
+++ b/src/__tests__/importManager.test.js
@@ -39,8 +39,10 @@ vi.mock('child_process', () => ({
   execFile: (...args) => mockExecFile(...args),
 }));
 
+const mockGetSetting = vi.fn().mockReturnValue(null);
 vi.mock('../db/settingsRepository.js', () => ({
-  getSetting: vi.fn().mockReturnValue(null),
+  getSetting: (...args) => mockGetSetting(...args),
+  setSetting: vi.fn(),
 }));
 
 vi.mock('../db/cuePointRepository.js', () => ({
@@ -109,6 +111,8 @@ vi.mock('../db/trackRepository.js', () => ({
 }));
 
 // Import AFTER mocks so the module picks up all stubs
+import path from 'path';
+import fs from 'fs';
 import { importAudioFile } from '../audio/importManager.js';
 import cryptoDefault from 'crypto';
 
@@ -118,6 +122,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockAddTrack.mockReturnValue(99);
   mockGetTrackByHash.mockReturnValue(undefined);
+  mockGetSetting.mockReturnValue(null);
   mockExecFile.mockImplementation((bin, args, cb) => cb(null, '', ''));
   // Restore default hash implementation after clearAllMocks
   cryptoDefault.createHash.mockImplementation(() => ({
@@ -319,5 +324,51 @@ describe('importAudioFile — artist detection from filename', () => {
     expect(mockAddTrack.mock.calls[0][0].artist).toBe('Filename Artist');
     // ID3 title wins over filename-derived title
     expect(mockAddTrack.mock.calls[0][0].title).toBe('ID3 Title');
+  });
+});
+
+describe('importAudioFile — readable storage format', () => {
+  beforeEach(() => {
+    mockGetSetting.mockImplementation((key, def) => (key === 'storage_format' ? 'readable' : def));
+  });
+
+  it('names the file "<artist>/<artist> - <title>.<ext>" instead of a hash path', async () => {
+    await importAudioFile('/music/song.mp3');
+
+    const destPath = mockAddTrack.mock.calls[0][0].file_path;
+    expect(destPath).toBe(path.join('/tmp/djman-test', 'audio', 'Test Artist', 'Test Artist - Test Song.mp3'));
+  });
+
+  it('sanitizes filesystem-unsafe characters in artist/title', async () => {
+    ffprobe.mockResolvedValueOnce({
+      format: {
+        format_name: 'mp3',
+        duration: '180.0',
+        bit_rate: '320000',
+        tags: { title: 'Track: Part 2?', artist: 'A/B*C' },
+      },
+      streams: [],
+    });
+
+    await importAudioFile('/music/song.mp3');
+
+    const destPath = mockAddTrack.mock.calls[0][0].file_path;
+    expect(destPath).toBe(
+      path.join('/tmp/djman-test', 'audio', 'A_B_C', 'A_B_C - Track_ Part 2_.mp3')
+    );
+  });
+
+  it('disambiguates a filename collision with a different track', async () => {
+    // Simulate: the plain "Artist - Title.mp3" path already exists (a
+    // different track, since true duplicates are caught by the hash check
+    // before this point), so it should fall back to the "(2)" suffix.
+    fs.existsSync.mockImplementation((p) => !p.includes('(2)'));
+
+    await importAudioFile('/music/song.mp3');
+
+    const destPath = mockAddTrack.mock.calls[0][0].file_path;
+    expect(destPath).toBe(
+      path.join('/tmp/djman-test', 'audio', 'Test Artist', 'Test Artist - Test Song (2).mp3')
+    );
   });
 });

--- a/src/__tests__/libraryRegistry.test.js
+++ b/src/__tests__/libraryRegistry.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// These tests exercise the real filesystem via USER_DATA_DIR (mirroring
+// database.js's DB_PATH escape hatch) rather than mocking fs — the module's
+// whole job is reading/writing a real JSON file, so that's what's worth
+// verifying. USER_DATA_DIR also bypasses the VITEST short-circuit in
+// getActiveLibrary() that every other test relies on to avoid touching disk.
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dj_library_registry_test_'));
+  process.env.USER_DATA_DIR = tmpDir;
+  const registry = await import('../db/libraryRegistry.js');
+  registry._resetRegistryCache();
+});
+
+afterEach(() => {
+  delete process.env.USER_DATA_DIR;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('libraryRegistry — first run', () => {
+  it('creates a default library pointing at the legacy library.db filename', async () => {
+    const { listLibraries, getActiveLibrary } = await import('../db/libraryRegistry.js');
+
+    const libraries = await listLibraries();
+    expect(libraries).toEqual([{ id: 'default', name: 'Default', dbFile: 'library.db' }]);
+
+    const active = await getActiveLibrary();
+    expect(active.id).toBe('default');
+  });
+
+  it('persists the default registry to disk so it survives a restart', async () => {
+    const { loadRegistry } = await import('../db/libraryRegistry.js');
+    await loadRegistry();
+
+    const onDisk = JSON.parse(fs.readFileSync(path.join(tmpDir, 'libraries.json'), 'utf8'));
+    expect(onDisk.activeId).toBe('default');
+    expect(onDisk.libraries).toHaveLength(1);
+  });
+});
+
+describe('libraryRegistry — create/switch/rename', () => {
+  it('createLibrary adds a new entry with a unique dbFile and does not change the active library', async () => {
+    const { createLibrary, listLibraries, getActiveLibrary } = await import(
+      '../db/libraryRegistry.js'
+    );
+
+    const created = await createLibrary('Gigs USB');
+    expect(created.name).toBe('Gigs USB');
+    expect(created.dbFile).toMatch(/^library-.+\.db$/);
+    expect(created.dbFile).not.toBe('library.db');
+
+    const libraries = await listLibraries();
+    expect(libraries).toHaveLength(2);
+
+    // Still on the original default library until explicitly switched
+    expect((await getActiveLibrary()).id).toBe('default');
+  });
+
+  it('setActiveLibrary changes which library is active', async () => {
+    const { createLibrary, setActiveLibrary, getActiveLibrary } = await import(
+      '../db/libraryRegistry.js'
+    );
+
+    const created = await createLibrary('Gigs USB');
+    await setActiveLibrary(created.id);
+
+    expect((await getActiveLibrary()).id).toBe(created.id);
+  });
+
+  it('setActiveLibrary throws for an unknown id', async () => {
+    const { setActiveLibrary } = await import('../db/libraryRegistry.js');
+    await expect(setActiveLibrary('does-not-exist')).rejects.toThrow('Library not found.');
+  });
+
+  it('renameLibrary updates the display name only', async () => {
+    const { createLibrary, renameLibrary, listLibraries } = await import(
+      '../db/libraryRegistry.js'
+    );
+
+    const created = await createLibrary('Gigs USB');
+    const renamed = await renameLibrary(created.id, 'Renamed');
+    expect(renamed.name).toBe('Renamed');
+    expect(renamed.dbFile).toBe(created.dbFile); // unchanged
+
+    const libraries = await listLibraries();
+    expect(libraries.find((l) => l.id === created.id).name).toBe('Renamed');
+  });
+
+  it('renameLibrary throws for an unknown id', async () => {
+    const { renameLibrary } = await import('../db/libraryRegistry.js');
+    await expect(renameLibrary('does-not-exist', 'x')).rejects.toThrow('Library not found.');
+  });
+});
+
+describe('libraryRegistry — corrupt/missing registry file recovery', () => {
+  it('falls back to a fresh default registry if the JSON file is corrupt', async () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'libraries.json'), '{ not valid json');
+
+    const { listLibraries } = await import('../db/libraryRegistry.js');
+    const libraries = await listLibraries();
+    expect(libraries).toEqual([{ id: 'default', name: 'Default', dbFile: 'library.db' }]);
+  });
+});

--- a/src/audio/importManager.js
+++ b/src/audio/importManager.js
@@ -14,14 +14,22 @@ import {
   getTrackByHash,
   getTracksByPaths,
   updateTrackWaveform,
+  getTracks,
 } from '../db/trackRepository.js';
 import { getAnalyzerRuntimePath } from '../deps.js';
-import { getSetting } from '../db/settingsRepository.js';
+import { getSetting, setSetting } from '../db/settingsRepository.js';
+import { moveFileSafe } from '../utils/fsMove.js';
+import { getActiveLibrary } from '../db/libraryRegistry.js';
 import { generateCuePoints } from './cueGen.js';
 import { getCuePoints, addCuePoint } from '../db/cuePointRepository.js';
 import { generateWaveformOverview } from './waveformGenerator.js';
 
 const execFileAsync = promisify(execFile);
+
+// Resolved once at process startup, same as database.js's own dbPath — the
+// active library doesn't change without a full app restart (see
+// libraryRegistry.js and database.js).
+const activeLibrary = await getActiveLibrary();
 
 // ─── Analysis progress tracking ─────────────────────────────────────────────
 
@@ -63,20 +71,118 @@ function hashFile(filePath) {
   });
 }
 
+// The 'default' library keeps the original, unscoped default paths so
+// existing installs see no change on upgrade. Any additional library gets
+// its own scoped default so two libraries never silently share a folder.
+function defaultAudioBase() {
+  if (activeLibrary.id === 'default') return path.join(app.getPath('userData'), 'audio');
+  return path.join(app.getPath('userData'), 'libraries', activeLibrary.id, 'audio');
+}
+
+function defaultArtworkBase() {
+  if (activeLibrary.id === 'default') return path.join(app.getPath('userData'), 'artwork');
+  return path.join(app.getPath('userData'), 'libraries', activeLibrary.id, 'artwork');
+}
+
 export function getLibraryBase() {
   const custom = getSetting('library_path');
-  return custom || path.join(app.getPath('userData'), 'audio');
+  return custom || defaultAudioBase();
 }
 
 export function getArtworkBase() {
-  return path.join(app.getPath('userData'), 'artwork');
+  return defaultArtworkBase();
 }
 
-function getAudioStoragePath(hash, ext) {
+export function getStorageFormat() {
+  return getSetting('storage_format', 'hashed') === 'readable' ? 'readable' : 'hashed';
+}
+
+// Windows/macOS/Linux all reject at least these characters in filenames.
+function sanitizeForFilename(s) {
+  const cleaned = (s || '').replace(/[\\/:*?"<>|]/g, '_').trim();
+  return cleaned || 'Unknown';
+}
+
+/**
+ * Where a track's audio file should live, given the library's current storage
+ * format setting. `meta.artist`/`meta.title` are only used for 'readable'
+ * mode — true duplicate content is already caught by the file-hash check in
+ * importAudioFile before this is called, so a filename collision here means
+ * a *different* track happens to share the same artist/title and just needs
+ * a disambiguating suffix.
+ */
+function getAudioStoragePath(hash, ext, meta = {}) {
   const base = getLibraryBase();
+  if (getStorageFormat() === 'readable') {
+    const artist = sanitizeForFilename(meta.artist);
+    const title = sanitizeForFilename(meta.title);
+    const artistDir = path.join(base, artist);
+    fs.mkdirSync(artistDir, { recursive: true });
+    let candidate = path.join(artistDir, `${artist} - ${title}${ext}`);
+    for (let n = 2; fs.existsSync(candidate); n++) {
+      candidate = path.join(artistDir, `${artist} - ${title} (${n})${ext}`);
+    }
+    return candidate;
+  }
   const shard = hash.slice(0, 2);
   fs.mkdirSync(path.join(base, shard), { recursive: true });
   return path.join(base, shard, `${hash}${ext}`);
+}
+
+/**
+ * Re-lay-out every track's physical file to match `newFormat`, reusing the
+ * same move-with-EXDEV-fallback approach as moving a library. Reported
+ * progress mirrors the move-library IPC event shape.
+ */
+export function convertStorageFormat(newFormat) {
+  if (newFormat !== 'hashed' && newFormat !== 'readable') {
+    throw new Error(`Unknown storage format: ${newFormat}`);
+  }
+  if (newFormat === getStorageFormat()) return { moved: 0, total: 0 };
+
+  const tracks = getTracks({ limit: 999999 });
+  const total = tracks.length;
+  let moved = 0;
+
+  const oldBase = getLibraryBase();
+  // Persist first so getAudioStoragePath() (called below via getStorageFormat())
+  // computes every destination in the new layout.
+  setSetting('storage_format', newFormat);
+
+  for (const track of tracks) {
+    const oldPath = track.file_path;
+    if (fs.existsSync(oldPath)) {
+      const ext = path.extname(oldPath);
+      const newPath = getAudioStoragePath(track.file_hash, ext, {
+        artist: track.artist,
+        title: track.title,
+      });
+      if (newPath !== oldPath) {
+        moveFileSafe(oldPath, newPath);
+        updateTrack(track.id, { file_path: newPath });
+      }
+    }
+    moved++;
+    if (global.mainWindow) {
+      global.mainWindow.webContents.send('convert-storage-format-progress', {
+        moved,
+        total,
+        pct: Math.round((moved / total) * 100),
+      });
+    }
+  }
+
+  // Remove now-empty shard/artist dirs left behind (best-effort)
+  try {
+    for (const entry of fs.readdirSync(oldBase)) {
+      const d = path.join(oldBase, entry);
+      if (fs.statSync(d).isDirectory() && fs.readdirSync(d).length === 0) fs.rmdirSync(d);
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return { moved, total };
 }
 
 async function extractArtwork(srcPath, hash) {
@@ -251,13 +357,10 @@ export async function importAudioFile(filePath, sourceMeta = {}) {
     return existing.id;
   }
 
-  const dest = getAudioStoragePath(hash, ext);
-
-  if (!fs.existsSync(dest)) {
-    fs.copyFileSync(filePath, dest);
-  }
-
-  const probe = await ffprobe(dest);
+  // Probe the SOURCE file (not yet copied) — 'readable' storage format needs
+  // artist/title to name the destination file, so tags must be known before
+  // getAudioStoragePath() is called.
+  const probe = await ffprobe(filePath);
   const format = ext.slice(1).toLowerCase();
   const duration = Number(probe.format.duration);
   const bitrate = Number(probe.format.bit_rate);
@@ -280,6 +383,15 @@ export async function importAudioFile(filePath, sourceMeta = {}) {
   // Last-resort fallback: use channel/uploader name as artist when still empty
   if (!resolvedArtist && sourceMeta.channel) {
     resolvedArtist = sourceMeta.channel;
+  }
+
+  const dest = getAudioStoragePath(hash, ext, {
+    artist: resolvedArtist,
+    title: resolvedTitle || basename,
+  });
+
+  if (!fs.existsSync(dest)) {
+    fs.copyFileSync(filePath, dest);
   }
 
   // Extract embedded album art (best-effort, non-blocking)

--- a/src/db/database.js
+++ b/src/db/database.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import Database from 'better-sqlite3';
+import { getActiveLibrary } from './libraryRegistry.js';
 
 let dbPath;
 
@@ -11,7 +12,11 @@ if (process.env.DB_PATH) {
   // Try to use Electron's app.getPath('userData') if available
   try {
     const { app } = await import('electron');
-    dbPath = path.join(app.getPath('userData'), 'library.db');
+    // Multiple libraries are separate DB files (see libraryRegistry.js) — the
+    // active one is chosen once at startup; switching libraries restarts the
+    // app rather than re-opening this module's connection at runtime.
+    const active = await getActiveLibrary();
+    dbPath = path.join(app.getPath('userData'), active.dbFile);
   } catch {
     // Node test mode: put database in project folder
     dbPath = path.join(process.cwd(), 'library.db');

--- a/src/db/libraryRegistry.js
+++ b/src/db/libraryRegistry.js
@@ -1,0 +1,114 @@
+import path from 'path';
+import fs from 'fs';
+import crypto from 'crypto';
+
+// Registry lives in userData as a small JSON file — deliberately OUTSIDE any
+// per-library database, since we need to know which DB file to open before
+// any database connection exists. Each library is otherwise just a name plus
+// a DB filename; the library's root folder and storage format are ordinary
+// settings *inside* that library's own database (settingsRepository.js), so
+// switching libraries automatically switches those too — no separate sync
+// needed between the registry and per-library settings.
+
+async function userDataDir() {
+  if (process.env.USER_DATA_DIR) return process.env.USER_DATA_DIR;
+  try {
+    const { app } = await import('electron');
+    return app.getPath('userData');
+  } catch {
+    return process.cwd();
+  }
+}
+
+function defaultRegistry() {
+  // Preserve existing installs: the first library points at the pre-existing
+  // library.db filename so upgrading doesn't orphan anyone's data.
+  return {
+    libraries: [{ id: 'default', name: 'Default', dbFile: 'library.db' }],
+    activeId: 'default',
+  };
+}
+
+let cachedDir = null;
+let cachedRegistry = null;
+
+async function registryPath() {
+  if (!cachedDir) cachedDir = await userDataDir();
+  return path.join(cachedDir, 'libraries.json');
+}
+
+function readRegistryFile(p) {
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null; // corrupt file — treat as absent rather than crashing the app
+  }
+}
+
+function writeRegistryFile(p, registry) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(registry, null, 2));
+}
+
+export async function loadRegistry() {
+  if (cachedRegistry) return cachedRegistry;
+  const p = await registryPath();
+  cachedRegistry = readRegistryFile(p) ?? defaultRegistry();
+  writeRegistryFile(p, cachedRegistry);
+  return cachedRegistry;
+}
+
+async function saveRegistry(registry) {
+  cachedRegistry = registry;
+  writeRegistryFile(await registryPath(), registry);
+}
+
+/** Test-only: drop the in-memory cache so the next call re-reads from disk. */
+export function _resetRegistryCache() {
+  cachedDir = null;
+  cachedRegistry = null;
+}
+
+export async function listLibraries() {
+  return (await loadRegistry()).libraries;
+}
+
+export async function getActiveLibrary() {
+  // Vitest sets this for every test run, regardless of which project/config
+  // is active — short-circuit before any real disk I/O so importManager.js's
+  // (and database.js's) top-level lookup never touches a real userData path
+  // during tests, even ones that don't set DB_PATH/USER_DATA_DIR themselves.
+  if (process.env.VITEST && !process.env.USER_DATA_DIR) {
+    return defaultRegistry().libraries[0];
+  }
+  const registry = await loadRegistry();
+  return (
+    registry.libraries.find((l) => l.id === registry.activeId) ?? registry.libraries[0] ?? null
+  );
+}
+
+export async function createLibrary(name) {
+  const registry = await loadRegistry();
+  const id = crypto.randomUUID();
+  const entry = { id, name: name?.trim() || 'New Library', dbFile: `library-${id}.db` };
+  registry.libraries.push(entry);
+  await saveRegistry(registry);
+  return entry;
+}
+
+export async function renameLibrary(id, name) {
+  const registry = await loadRegistry();
+  const entry = registry.libraries.find((l) => l.id === id);
+  if (!entry) throw new Error('Library not found.');
+  entry.name = name?.trim() || entry.name;
+  await saveRegistry(registry);
+  return entry;
+}
+
+export async function setActiveLibrary(id) {
+  const registry = await loadRegistry();
+  if (!registry.libraries.some((l) => l.id === id)) throw new Error('Library not found.');
+  registry.activeId = id;
+  await saveRegistry(registry);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -77,7 +77,16 @@ import {
   spawnAnalysis,
   cancelAnalysis,
   getLibraryBase,
+  getStorageFormat,
+  convertStorageFormat,
 } from './audio/importManager.js';
+import {
+  listLibraries,
+  createLibrary,
+  renameLibrary,
+  setActiveLibrary,
+  getActiveLibrary,
+} from './db/libraryRegistry.js';
 import { convertAudio } from './audio/ffmpeg.js';
 
 import {
@@ -131,6 +140,7 @@ const __dirname = path.dirname(__filename);
 let mainWindow;
 
 import { startMediaServer as _startMediaServer } from './audio/mediaServer.js';
+import { moveFileSafe } from './utils/fsMove.js';
 import { getArtworkBase } from './audio/importManager.js';
 import { writeId3Tags } from './audio/id3Writer.js';
 
@@ -424,16 +434,7 @@ ipcMain.handle('move-library', async (event, newDir) => {
     const rel = path.relative(oldBase, oldPath);
     const newPath = path.join(newDir, rel);
     fs.mkdirSync(path.dirname(newPath), { recursive: true });
-    try {
-      fs.renameSync(oldPath, newPath);
-    } catch (err) {
-      // rename() is a same-filesystem metadata op — it can't cross drive
-      // letters (e.g. moving the library to an external drive), so fall
-      // back to copy + delete whenever the destination is a different volume.
-      if (err.code !== 'EXDEV') throw err;
-      fs.copyFileSync(oldPath, newPath);
-      fs.unlinkSync(oldPath);
-    }
+    moveFileSafe(oldPath, newPath);
     updateTrack(track.id, { file_path: newPath });
     moved++;
 
@@ -459,6 +460,26 @@ ipcMain.handle('move-library', async (event, newDir) => {
   if (!explorerAllowedBases.includes(newDir)) explorerAllowedBases.push(newDir);
   return { moved, total };
 });
+
+// ── Multiple libraries ───────────────────────────────────────────────────────
+// Each library is a fully separate database file (see libraryRegistry.js and
+// database.js) — only one is open per process, so switching requires a full
+// app restart. The library's own root folder and storage format are ordinary
+// settings *inside* that library's database, so they switch automatically
+// with no separate bookkeeping here.
+
+ipcMain.handle('list-libraries', () => listLibraries());
+ipcMain.handle('get-active-library', () => getActiveLibrary());
+ipcMain.handle('create-library', (_, name) => createLibrary(name));
+ipcMain.handle('rename-library', (_, id, name) => renameLibrary(id, name));
+ipcMain.handle('switch-library', async (_, id) => {
+  await setActiveLibrary(id);
+  app.relaunch();
+  app.exit(0);
+});
+
+ipcMain.handle('get-storage-format', () => getStorageFormat());
+ipcMain.handle('convert-storage-format', (_, newFormat) => convertStorageFormat(newFormat));
 
 ipcMain.handle('normalize-library', () => {
   const targetLufs = Number(getSetting('normalize_target_lufs', '-9'));
@@ -857,7 +878,9 @@ ipcMain.handle('import-audio-files', async (event, filePaths, playlistId) => {
 });
 
 ipcMain.handle('clear-library', async () => {
-  const audioBase = path.join(app.getPath('userData'), 'audio');
+  // getLibraryBase(), not a hardcoded path — the active library may be using
+  // a custom or per-library-scoped folder (see libraryRegistry.js).
+  const audioBase = getLibraryBase();
   clearTracks();
   clearPlaylists();
   if (fs.existsSync(audioBase)) fs.rmSync(audioBase, { recursive: true, force: true });

--- a/src/preload.js
+++ b/src/preload.js
@@ -90,6 +90,17 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.on('move-library-progress', (_, data) => cb(data));
     return () => ipcRenderer.removeAllListeners('move-library-progress');
   },
+  listLibraries: () => ipcRenderer.invoke('list-libraries'),
+  getActiveLibrary: () => ipcRenderer.invoke('get-active-library'),
+  createLibrary: (name) => ipcRenderer.invoke('create-library', name),
+  renameLibrary: (id, name) => ipcRenderer.invoke('rename-library', id, name),
+  switchLibrary: (id) => ipcRenderer.invoke('switch-library', id),
+  getStorageFormat: () => ipcRenderer.invoke('get-storage-format'),
+  convertStorageFormat: (newFormat) => ipcRenderer.invoke('convert-storage-format', newFormat),
+  onConvertStorageFormatProgress: (cb) => {
+    ipcRenderer.on('convert-storage-format-progress', (_, data) => cb(data));
+    return () => ipcRenderer.removeAllListeners('convert-storage-format-progress');
+  },
   normalizeLibrary: () => ipcRenderer.invoke('normalize-library'),
   getNormalizedCount: () => ipcRenderer.invoke('get-normalized-count'),
   normalizeTracksAudio: (payload) => ipcRenderer.invoke('normalize-tracks-audio', payload),

--- a/src/utils/fsMove.js
+++ b/src/utils/fsMove.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+
+/**
+ * Move a file, falling back to copy+delete when the destination is on a
+ * different filesystem/drive. `fs.renameSync` is a same-filesystem metadata
+ * op and throws EXDEV across drive letters (e.g. relocating a library to an
+ * external drive, or converting its storage layout onto a different volume).
+ */
+export function moveFileSafe(oldPath, newPath) {
+  try {
+    fs.renameSync(oldPath, newPath);
+  } catch (err) {
+    if (err.code !== 'EXDEV') throw err;
+    fs.copyFileSync(oldPath, newPath);
+    fs.unlinkSync(oldPath);
+  }
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -36,6 +36,7 @@ export default defineConfig({
           environment: 'node',
           include: [
             'src/__tests__/importManager.test.js',
+            'src/__tests__/libraryRegistry.test.js',
             'src/__tests__/ytDlpManager.test.js',
             'src/__tests__/mediaServer.test.js',
             'src/__tests__/anlzWriter.test.js',


### PR DESCRIPTION
Fixes #390.

### Architecture
- Each library is a fully separate SQLite database file. A small JSON registry (`libraryRegistry.js`) in `userData` tracks which DB files exist, their display names, and which one is active — deliberately outside any per-library DB, since we need to know which file to open before any connection exists.
- Switching libraries updates the registry then restarts the app. `database.js` opens its connection once at module load (existing design); refactoring every repository module to a dynamic getter to support live-switching was out of scope and far riskier than a restart, which is also what you asked for ("switching may require a restart or reload").
- A library's root folder and storage format are ordinary settings *inside* that library's own database, so they already scope per-library for free — no schema changes needed for that part.
- **Zero behavior change for existing installs**: the pre-existing library is preserved as a registry entry pointing at the original `library.db` filename and default audio/artwork paths. Additional libraries get their own scoped default paths so two libraries never silently share a folder.

### Storage format
- `hashed` (default, unchanged): `<base>/<hash[0:2]>/<hash>.ext`
- `readable` (new): `<base>/<Artist>/<Artist> - <Title>.ext`, still hashing content on import to catch true duplicates; a same-name-different-hash collision gets a `(2)` suffix.
- `importAudioFile` now probes the source file before copying (was: after), since readable naming needs artist/title before the destination path can be computed.
- `convertStorageFormat()` reorganizes every existing track's file when the setting changes, reusing the same move-with-EXDEV-fallback helper as `move-library` (extracted to `utils/fsMove.js`).

### UI
Settings → Library gains a Storage Format control and a Libraries section (list, rename, create, switch-with-restart-confirmation).

### Deliberately out of scope (noted for follow-up)
- Library deletion — a destructive op on real audio files, better as its own reviewed change.
- A dedicated first-run setup wizard — the app doesn't have an onboarding wizard to hook into yet (only `DepsOverlay.jsx`, which is deps-download progress, not library config); management is available in Settings immediately, including on first run.

### Testing
408 main-process tests (15 files, incl. new `libraryRegistry.test.js` and readable-format-naming cases in `importManager.test.js`) and 138 renderer tests pass; full lint clean; coverage thresholds met.

I wasn't able to do a live GUI smoke-test of this PR specifically — while investigating I found that `better-sqlite3` currently fails to compile from source on this machine (`error MSB8020: build tools for ClangCL cannot be found`), reproducible on plain `dev` HEAD with zero changes, so it's an unrelated local VS2019 toolchain gap (missing the Clang component), not something this PR introduces or something affecting CI.