### PR TITLE
fix: unbounded recursion crash in unavailable-track auto-skip

### DIFF
--- a/renderer/src/PlayerContext.jsx
+++ b/renderer/src/PlayerContext.jsx
@@ -179,6 +179,13 @@ export function PlayerProvider({ children }) {
   // failure handler needs to call it — same ref-indirection pattern as above,
   // since `next` isn't in scope yet at the point playAtIndex is defined.
   const nextRef = useRef(null);
+  // Counts consecutive auto-skips caused by unavailable tracks (not resolved
+  // until a track actually starts playing — see the play().then() below).
+  // Without this, a queue where several/all tracks are unavailable makes
+  // playAtIndex → next() → playAtIndex recurse synchronously with no bound,
+  // which blows the call stack (a real crash hit in testing — see #389).
+  const skipStreakRef = useRef(0);
+  const MAX_CONSECUTIVE_SKIPS = 25;
   const playAtIndex = useCallback(
     async (newQueue, index, playlistId = null, playlistName = null) => {
       const track = newQueue[index];
@@ -186,8 +193,24 @@ export function PlayerProvider({ children }) {
       // Known-unavailable linked track (e.g. its USB drive isn't mounted right
       // now) — skip the round trip to the media server and move on immediately.
       if (track.is_linked && unavailableLinkedIdsRef.current.has(track.id)) {
+        skipStreakRef.current += 1;
+        if (skipStreakRef.current > MAX_CONSECUTIVE_SKIPS) {
+          setPlaybackError('Too many unavailable tracks in a row — stopping playback.');
+          setIsPlaying(false);
+          skipStreakRef.current = 0;
+          return;
+        }
         setPlaybackError(`"${track.title}" is unavailable — the file could not be found.`);
-        nextRef.current?.();
+        // next() reads the CURRENT queue/index from refs (synced from this
+        // state) to compute "the one after this" — without updating them
+        // here, next() would keep recomputing from the previous track's
+        // index and retry this same unavailable track forever instead of
+        // advancing past it.
+        setQueue(newQueue);
+        setQueueIndex(index);
+        // Defer rather than call synchronously — keeps this off the call
+        // stack entirely regardless of the cap above.
+        setTimeout(() => nextRef.current?.(), 0);
         return;
       }
       const gen = ++playGenRef.current;
@@ -235,6 +258,7 @@ export function PlayerProvider({ children }) {
         .play()
         .then(() => {
           console.log('[diag] play() resolved OK  readyState=', audio.readyState);
+          skipStreakRef.current = 0;
         })
         .catch((err) => {
           // AbortError is expected when we switch tracks before play() resolves
@@ -254,8 +278,15 @@ export function PlayerProvider({ children }) {
           // 404s/403s the source (file missing, e.g. its USB drive was unplugged) —
           // surface it and move on instead of leaving playback silently stalled.
           if (err.name === 'NotSupportedError') {
+            skipStreakRef.current += 1;
+            if (skipStreakRef.current > MAX_CONSECUTIVE_SKIPS) {
+              setPlaybackError('Too many unavailable tracks in a row — stopping playback.');
+              setIsPlaying(false);
+              skipStreakRef.current = 0;
+              return;
+            }
             setPlaybackError(`"${track.title}" is unavailable — the file could not be found.`);
-            nextRef.current?.();
+            setTimeout(() => nextRef.current?.(), 0);
           }
         });
       setCurrentTrack(track);

--- a/renderer/src/__tests__/PlayerContext.test.jsx
+++ b/renderer/src/__tests__/PlayerContext.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { PlayerProvider, usePlayer } from '../PlayerContext.jsx';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -150,5 +150,42 @@ describe('PlayerProvider — AudioContext crash guard', () => {
 
     renderProvider();
     await waitFor(() => expect(window.api.getMediaPort).toHaveBeenCalledTimes(1));
+  });
+});
+
+// ── Unbounded-recursion regression (crash hit in manual testing of #389) ──────
+// A queue where every track is a known-unavailable linked track made
+// playAtIndex → next() → playAtIndex recurse synchronously with no bound,
+// crashing the renderer with "RangeError: Maximum call stack size exceeded".
+
+describe('PlayerProvider — bounded auto-skip on unavailable tracks', () => {
+  it('does not recurse infinitely (and eventually stops) when every track in the queue is unavailable', async () => {
+    const badIds = Array.from({ length: 40 }, (_, i) => i + 1);
+    window.api.getUnavailableLinkedTracks.mockResolvedValue(badIds);
+
+    const { result } = renderProvider();
+    await waitFor(() => expect(result.current.unavailableLinkedIds.size).toBe(40));
+
+    const queue = badIds.map((id) => ({
+      id,
+      title: `Track ${id}`,
+      is_linked: true,
+      file_path: `/music/${id}.mp3`,
+    }));
+
+    await act(async () => {
+      result.current.play(queue[0], queue, 0);
+    });
+
+    // Each retry is deferred one macrotask (setTimeout(0)) — step through
+    // with real timers, giving each hop room to land.
+    for (let i = 0; i < 60 && !/too many/i.test(result.current.playbackError ?? ''); i++) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+    }
+
+    expect(result.current.playbackError).toMatch(/too many/i);
+    expect(result.current.isPlaying).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to #391 (already merged) — found via live manual testing of that PR, not caught by the automated suite at the time.

### The crash
`Uncaught (in promise) RangeError: Maximum call stack size exceeded`, reproduced live: playing through a queue containing several unavailable linked tracks crashed the renderer.

### Root cause
`playAtIndex`'s auto-skip-on-unavailable called `next()` synchronously, which called `playAtIndex` again — with no async boundary and no bound. When enough consecutive tracks in the queue are unavailable, this recurses on the JS call stack until it overflows. This is the exact "catastrophic failure" #389/#391 was supposed to prevent, just relocated.

A second bug compounded it: the known-unavailable branch never updated `queue`/`queueIndex` before deferring to `next()`, so `next()` recomputed from a stale index and kept retrying the *same* track instead of advancing through the queue.

### Fix
- Defer the retry via `setTimeout(0)` so it can never grow the call stack, regardless of how many consecutive tracks are unavailable.
- Update `queue`/`queueIndex` before deferring, so `next()` correctly advances past each bad track instead of looping on one.
- Added a bounded skip-streak counter (reset on an actual successful play) that stops auto-advancing and surfaces a clear error after 25 consecutive failures, so a queue that's entirely unavailable degrades to "stopped with a message" instead of spinning forever.

### Testing
Added a regression test — confirmed it fails without this fix (verified via `git stash`) and passes with it. Full renderer suite (139 tests) passes on top of current `dev`, lint clean. Also re-verified live: replayed the exact sequence that crashed before, now completes cleanly with no crash.