### PR TITLE
fix: remove warning styling from unavailable-track badge

### DIFF
--- a/renderer/src/MusicLibrary.css
+++ b/renderer/src/MusicLibrary.css
@@ -308,11 +308,6 @@
   flex-shrink: 0;
 }
 
-.cell-linked-badge--offline {
-  opacity: 1;
-  color: #f4a261;
-}
-
 /* New row: space slides open (scaleY), then content fades in */
 @keyframes rowSlideIn {
   0% {

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -316,14 +316,14 @@ function LibraryRow({
             )}
             {t.is_linked ? (
               <span
-                className={`cell-linked-badge${isUnavailable ? ' cell-linked-badge--offline' : ''}`}
+                className="cell-linked-badge"
                 title={
                   isUnavailable
                     ? 'File not found — may be on a disconnected drive'
                     : 'Explorer-linked file'
                 }
               >
-                {isUnavailable ? '🔗⚠' : '🔗'}
+                🔗
               </span>
             ) : null}
             <span className="cell-title-text">{t.title}</span>
@@ -438,14 +438,14 @@ function SortableRow({
             )}
             {t.is_linked ? (
               <span
-                className={`cell-linked-badge${isUnavailable ? ' cell-linked-badge--offline' : ''}`}
+                className="cell-linked-badge"
                 title={
                   isUnavailable
                     ? 'File not found — may be on a disconnected drive'
                     : 'Explorer-linked file'
                 }
               >
-                {isUnavailable ? '🔗⚠' : '🔗'}
+                🔗
               </span>
             ) : null}
             <span className="cell-title-text">{t.title}</span>


### PR DESCRIPTION
## Summary
- Removes the orange/warning treatment from the linked-track badge when a file is unavailable
- Keeps the existing grayed-out row (row--unavailable) and the hover tooltip explaining why the badge shows unavailable
- Badge is now always the plain link icon; only the title attribute differs based on availability

## Why
Per feedback, the extra warning color/icon was too alarming - graying out the row plus a hover tooltip is enough signal.

## Test plan
- [x] npm run lint (renderer) - clean
- [x] npx prettier --check - clean
- [x] npx vitest run (renderer) - 139/139 passed