### PR TITLE
feat: Cloud Search - search & download Tidal/YouTube tracks by keyword

### DIFF
--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -4,6 +4,7 @@ import Sidebar from './Sidebar.jsx';
 import MusicLibrary from './MusicLibrary.jsx';
 import DownloadView from './DownloadView.jsx';
 import TidalDownloadView from './TidalDownloadView.jsx';
+import CloudSearchView from './CloudSearchView.jsx';
 import FileExplorerView from './FileExplorerView.jsx';
 import SettingsModal from './SettingsModal.jsx';
 import ExportModal from './ExportModal.jsx';
@@ -134,11 +135,17 @@ function App() {
                 onGoToLibrary={() => setSelectedPlaylistId('music')}
                 onGoToPlaylist={(id) => setSelectedPlaylistId(id)}
               />
+              <CloudSearchView
+                style={{ display: selectedPlaylistId === 'cloud-search' ? '' : 'none' }}
+                onGoToLibrary={() => setSelectedPlaylistId('music')}
+                onGoToTidalSetup={() => setSelectedPlaylistId('tidal')}
+              />
               <FileExplorerView
                 style={{ display: selectedPlaylistId === 'explorer' ? '' : 'none' }}
               />
               {selectedPlaylistId !== 'download' &&
                 selectedPlaylistId !== 'tidal' &&
+                selectedPlaylistId !== 'cloud-search' &&
                 selectedPlaylistId !== 'explorer' && (
                   <MusicLibrary
                     selectedPlaylist={selectedPlaylistId}

--- a/renderer/src/CloudSearchView.css
+++ b/renderer/src/CloudSearchView.css
@@ -1,0 +1,232 @@
+.cloud-search-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 20px 24px;
+  overflow-y: auto;
+  background: var(--bg-primary, #111);
+  color: var(--text-primary, #e0e0e0);
+}
+
+.cloud-search-header h2 {
+  margin: 0 0 4px;
+  font-size: 18px;
+}
+
+.cloud-search-subtitle {
+  margin: 0 0 16px;
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+}
+
+.cloud-search-source-toggle {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.cloud-search-source-btn {
+  background: var(--bg-secondary, #1e1e1e);
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: var(--text-secondary, #aaa);
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.cloud-search-source-btn.active {
+  background: var(--accent, #7c5cfc);
+  color: #fff;
+  border-color: var(--accent, #7c5cfc);
+}
+
+.cloud-search-bar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.cloud-search-input {
+  flex: 1;
+  background: var(--bg-secondary, #1e1e1e);
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: var(--text-primary, #e0e0e0);
+  padding: 8px 12px;
+  font-size: 13px;
+  outline: none;
+}
+
+.cloud-search-input:focus {
+  border-color: var(--accent, #7c5cfc);
+}
+
+.cloud-search-type-select {
+  background: var(--bg-secondary, #1e1e1e);
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: var(--text-primary, #e0e0e0);
+  padding: 8px 10px;
+  font-size: 13px;
+}
+
+.cloud-search-submit-btn {
+  background: var(--accent, #7c5cfc);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  padding: 8px 18px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.cloud-search-submit-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.cloud-search-notice {
+  background: var(--bg-secondary, #1e1e1e);
+  border: 1px solid #444;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+  margin-bottom: 12px;
+  color: var(--text-secondary, #ccc);
+}
+
+.cloud-search-link-btn {
+  background: none;
+  border: none;
+  color: var(--accent, #89b4fa);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.cloud-search-error {
+  color: #ff6b6b;
+  font-size: 12px;
+  margin-bottom: 12px;
+}
+
+.cloud-search-empty {
+  color: var(--text-secondary, #666);
+  font-size: 13px;
+  padding: 24px 0;
+  text-align: center;
+}
+
+.cloud-search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+}
+
+.cloud-search-results-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+}
+
+.cloud-search-select-all {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary, #aaa);
+  cursor: pointer;
+}
+
+.cloud-search-download-btn {
+  background: var(--accent, #7c5cfc);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  padding: 6px 14px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.cloud-search-download-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.cloud-search-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.cloud-search-row {
+  display: grid;
+  grid-template-columns:
+    28px minmax(160px, 2fr) minmax(100px, 1fr) minmax(100px, 1fr)
+    70px 110px 20px;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  font-size: 12px;
+  border-bottom: 1px solid #222;
+  cursor: pointer;
+}
+
+.cloud-search-row:last-child {
+  border-bottom: none;
+}
+
+.cloud-search-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.cloud-search-row--head {
+  cursor: default;
+  color: var(--text-secondary, #888);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  background: var(--bg-secondary, #1a1a1a);
+}
+
+.cloud-search-row--head:hover {
+  background: var(--bg-secondary, #1a1a1a);
+}
+
+.cloud-search-row--selected {
+  background: rgba(124, 92, 252, 0.12);
+}
+
+.cloud-search-title,
+.cloud-search-row span:nth-child(3),
+.cloud-search-row span:nth-child(4) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cloud-search-source-badge {
+  color: var(--text-secondary, #999);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cloud-search-status--done {
+  color: #6bd68b;
+}
+
+.cloud-search-status--failed {
+  color: #ff6b6b;
+}
+
+.cloud-search-status--downloading,
+.cloud-search-status--pending {
+  color: var(--text-secondary, #888);
+}

--- a/renderer/src/CloudSearchView.jsx
+++ b/renderer/src/CloudSearchView.jsx
@@ -1,0 +1,311 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import './CloudSearchView.css';
+
+const SOURCES = [
+  { id: 'youtube', label: 'YouTube', icon: '▶️' },
+  { id: 'tidal', label: 'TIDAL', icon: '🌊' },
+];
+
+const TIDAL_TYPES = [
+  { id: 'track', label: 'Track' },
+  { id: 'album', label: 'Album' },
+  { id: 'playlist', label: 'Playlist' },
+];
+
+function fmtDuration(secs) {
+  if (!secs && secs !== 0) return '—';
+  const m = Math.floor(secs / 60);
+  const s = Math.floor(secs % 60);
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+function resultKey(r) {
+  return `${r.source}:${r.id}`;
+}
+
+export default function CloudSearchView({ onGoToLibrary, onGoToTidalSetup, style }) {
+  const [source, setSource] = useState('youtube');
+  const [tidalType, setTidalType] = useState('track');
+  const [query, setQuery] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState(null);
+  const [results, setResults] = useState([]);
+  const [selected, setSelected] = useState(new Set());
+  const [tidalSetup, setTidalSetup] = useState(null); // null = unknown | { installed, loggedIn }
+  const [downloading, setDownloading] = useState(false);
+  const [downloadStatus, setDownloadStatus] = useState(new Map()); // key -> 'pending'|'downloading'|'done'|'failed'
+  const [downloadError, setDownloadError] = useState(null);
+  const [downloadDone, setDownloadDone] = useState(false);
+  const inputRef = useRef(null);
+  const searchSeq = useRef(0);
+
+  useEffect(() => {
+    window.api.tidalCheck?.().then(setTidalSetup);
+  }, []);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const runSearch = useCallback(async () => {
+    const q = query.trim();
+    if (!q) return;
+    const seq = ++searchSeq.current;
+    setSearching(true);
+    setSearchError(null);
+    setSelected(new Set());
+    setDownloadStatus(new Map());
+    setDownloadError(null);
+    setDownloadDone(false);
+    try {
+      const res = await window.api.cloudSearch({
+        source,
+        query: q,
+        types: source === 'tidal' ? [tidalType] : undefined,
+        limit: 25,
+      });
+      if (seq !== searchSeq.current) return; // stale response — a newer search started
+      if (!res.ok) {
+        setSearchError(res.error || 'Search failed');
+        setResults([]);
+      } else {
+        setResults(res.results);
+      }
+    } catch (e) {
+      if (seq !== searchSeq.current) return;
+      setSearchError(e.message ?? 'Search failed');
+      setResults([]);
+    } finally {
+      if (seq === searchSeq.current) setSearching(false);
+    }
+  }, [query, source, tidalType]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    runSearch();
+  };
+
+  const toggleSelected = (r) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      const k = resultKey(r);
+      if (next.has(k)) next.delete(k);
+      else next.add(k);
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    setSelected((prev) =>
+      prev.size === results.length ? new Set() : new Set(results.map(resultKey))
+    );
+  };
+
+  const selectedResults = results.filter((r) => selected.has(resultKey(r)));
+
+  const handleDownload = async () => {
+    if (selectedResults.length === 0 || downloading) return;
+    setDownloading(true);
+    setDownloadError(null);
+    setDownloadDone(false);
+    const statuses = new Map(selectedResults.map((r) => [resultKey(r), 'pending']));
+    setDownloadStatus(new Map(statuses));
+
+    const byYoutube = selectedResults.filter((r) => r.source === 'youtube');
+    const byTidal = selectedResults.filter((r) => r.source === 'tidal');
+
+    // YouTube results are independent videos — download one at a time, reusing
+    // the same IPC channel the URL-paste flow uses.
+    for (const r of byYoutube) {
+      const k = resultKey(r);
+      statuses.set(k, 'downloading');
+      setDownloadStatus(new Map(statuses));
+      try {
+        const res = await window.api.ytDlpDownloadUrl({ url: r.url });
+        statuses.set(k, res.ok ? 'done' : 'failed');
+      } catch {
+        statuses.set(k, 'failed');
+      }
+      setDownloadStatus(new Map(statuses));
+    }
+
+    // TIDAL supports a batch of selectedEntries in a single call.
+    if (byTidal.length > 0) {
+      for (const r of byTidal) statuses.set(resultKey(r), 'downloading');
+      setDownloadStatus(new Map(statuses));
+      try {
+        const res = await window.api.tidalDownloadUrl({
+          url: byTidal[0].url,
+          selectedEntries: byTidal.map((r) => ({ id: r.id, title: r.title, artist: r.artist })),
+        });
+        for (const r of byTidal) statuses.set(resultKey(r), res.ok ? 'done' : 'failed');
+        if (!res.ok) setDownloadError(res.error || 'TIDAL download failed');
+      } catch (e) {
+        for (const r of byTidal) statuses.set(resultKey(r), 'failed');
+        setDownloadError(e.message ?? 'TIDAL download failed');
+      }
+      setDownloadStatus(new Map(statuses));
+    }
+
+    setDownloading(false);
+    if ([...statuses.values()].some((s) => s === 'done')) {
+      setDownloadDone(true);
+    }
+  };
+
+  const tidalUnavailable =
+    source === 'tidal' && tidalSetup && (!tidalSetup.installed || !tidalSetup.loggedIn);
+
+  return (
+    <div className="cloud-search-view" style={style}>
+      <div className="cloud-search-header">
+        <h2>Cloud Search</h2>
+        <p className="cloud-search-subtitle">
+          Search YouTube or TIDAL by keyword and download straight into your library.
+        </p>
+      </div>
+
+      <div className="cloud-search-source-toggle">
+        {SOURCES.map((s) => (
+          <button
+            key={s.id}
+            className={`cloud-search-source-btn${source === s.id ? ' active' : ''}`}
+            onClick={() => setSource(s.id)}
+            type="button"
+          >
+            <span>{s.icon}</span> {s.label}
+          </button>
+        ))}
+      </div>
+
+      <form className="cloud-search-bar" onSubmit={handleSubmit}>
+        <input
+          ref={inputRef}
+          className="cloud-search-input"
+          type="text"
+          placeholder={`Search ${source === 'youtube' ? 'YouTube' : 'TIDAL'}…`}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        {source === 'tidal' && (
+          <select
+            className="cloud-search-type-select"
+            value={tidalType}
+            onChange={(e) => setTidalType(e.target.value)}
+          >
+            {TIDAL_TYPES.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        )}
+        <button
+          className="cloud-search-submit-btn"
+          type="submit"
+          disabled={!query.trim() || searching || tidalUnavailable}
+        >
+          {searching ? 'Searching…' : 'Search'}
+        </button>
+      </form>
+
+      {tidalUnavailable && (
+        <div className="cloud-search-notice">
+          {!tidalSetup.installed
+            ? 'TIDAL is not set up yet.'
+            : 'You need to log in to TIDAL first.'}{' '}
+          <button
+            className="cloud-search-link-btn"
+            type="button"
+            onClick={() => onGoToTidalSetup?.()}
+          >
+            Go to the TIDAL tab
+          </button>
+        </div>
+      )}
+
+      {searchError && <div className="cloud-search-error">{searchError}</div>}
+      {downloadError && <div className="cloud-search-error">{downloadError}</div>}
+      {downloadDone && !downloading && (
+        <div className="cloud-search-notice">
+          Download finished.{' '}
+          <button className="cloud-search-link-btn" type="button" onClick={() => onGoToLibrary?.()}>
+            Go to Library
+          </button>
+        </div>
+      )}
+
+      {results.length > 0 && (
+        <div className="cloud-search-results">
+          <div className="cloud-search-results-header">
+            <label className="cloud-search-select-all">
+              <input
+                type="checkbox"
+                checked={selected.size === results.length && results.length > 0}
+                onChange={toggleSelectAll}
+              />
+              Select all ({results.length})
+            </label>
+            <button
+              className="cloud-search-download-btn"
+              type="button"
+              disabled={selectedResults.length === 0 || downloading}
+              onClick={handleDownload}
+            >
+              {downloading ? 'Downloading…' : `Download Selected (${selectedResults.length})`}
+            </button>
+          </div>
+
+          <div className="cloud-search-table">
+            <div className="cloud-search-row cloud-search-row--head">
+              <span />
+              <span>Title</span>
+              <span>Artist</span>
+              <span>Album</span>
+              <span>Duration</span>
+              <span>Source</span>
+              <span />
+            </div>
+            {results.map((r) => {
+              const k = resultKey(r);
+              const status = downloadStatus.get(k);
+              return (
+                <div
+                  key={k}
+                  className={`cloud-search-row${selected.has(k) ? ' cloud-search-row--selected' : ''}`}
+                  onClick={() => toggleSelected(r)}
+                >
+                  <span onClick={(e) => e.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      checked={selected.has(k)}
+                      onChange={() => toggleSelected(r)}
+                    />
+                  </span>
+                  <span className="cloud-search-title" title={r.title}>
+                    {r.title}
+                  </span>
+                  <span title={r.artist}>{r.artist || '—'}</span>
+                  <span title={r.album}>{r.album || '—'}</span>
+                  <span>{fmtDuration(r.durationSec)}</span>
+                  <span className="cloud-search-source-badge">
+                    {r.source === 'youtube' ? '▶️' : '🌊'} {r.quality || r.type}
+                  </span>
+                  <span
+                    className={status ? `cloud-search-status cloud-search-status--${status}` : ''}
+                  >
+                    {status ? (status === 'done' ? '✓' : status === 'failed' ? '✗' : '⋯') : ''}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {!searching && results.length === 0 && !searchError && query.trim() && (
+        <div className="cloud-search-empty">No results yet — press Search.</div>
+      )}
+    </div>
+  );
+}

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -7,6 +7,7 @@ import ImportPlaylistDialog from './ImportPlaylistDialog';
 const MENU_ITEMS = [
   { id: 'music', name: 'Music', icon: '🎵' },
   { id: 'explorer', name: 'Explorer', icon: '📁' },
+  { id: 'cloud-search', name: 'Cloud Search', icon: '🔎' },
   { id: 'download', name: 'YT-DLP', icon: '⬇️' },
   { id: 'tidal', name: 'TIDAL', icon: '🌊' },
 ];

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -84,6 +84,7 @@ window.api = {
   tidalFetchInfo: vi.fn().mockResolvedValue({ ok: false, error: 'not configured' }),
   tidalLogin: vi.fn().mockResolvedValue({ ok: true }),
   tidalDownloadUrl: vi.fn().mockResolvedValue({ ok: true, trackIds: [], playlistId: null }),
+  cloudSearch: vi.fn().mockResolvedValue({ ok: true, results: [] }),
   onTidalProgress: vi.fn().mockImplementation(() => () => {}),
   onTidalLoginUrl: vi.fn().mockImplementation(() => () => {}),
   onTidalInstallProgress: vi.fn().mockImplementation(() => () => {}),

--- a/src/__tests__/tidalDlManager.test.js
+++ b/src/__tests__/tidalDlManager.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('os', () => ({
+  default: { homedir: () => '/home/test', tmpdir: () => '/tmp' },
+  homedir: () => '/home/test',
+  tmpdir: () => '/tmp',
+}));
+
+const mockExistsSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+const mockReadFileSync = vi.fn();
+vi.mock('fs', () => ({
+  default: {
+    existsSync: (...args) => mockExistsSync(...args),
+    writeFileSync: (...args) => mockWriteFileSync(...args),
+    readFileSync: (...args) => mockReadFileSync(...args),
+  },
+  existsSync: (...args) => mockExistsSync(...args),
+  writeFileSync: (...args) => mockWriteFileSync(...args),
+  readFileSync: (...args) => mockReadFileSync(...args),
+}));
+
+let lastSpawnBin = null;
+let lastSpawnArgs = null;
+let fakeProc;
+vi.mock('child_process', () => ({
+  spawn: vi.fn((bin, args) => {
+    lastSpawnBin = bin;
+    lastSpawnArgs = args;
+    return fakeProc;
+  }),
+  execSync: vi.fn(() => {
+    throw new Error('not found');
+  }),
+}));
+
+function makeFakeProc() {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  return proc;
+}
+
+import { searchTidal } from '../audio/tidalDlManager.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fakeProc = makeFakeProc();
+});
+
+describe('searchTidal', () => {
+  it('errors when no Python interpreter can be found', async () => {
+    mockExistsSync.mockReturnValue(false); // no uv env, no token
+    const result = await searchTidal('daft punk');
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Python interpreter not found/);
+  });
+
+  it('errors when not logged in to TIDAL', async () => {
+    // Python interpreter found, but no token.json
+    mockExistsSync.mockImplementation((p) => p.includes('python') || p.includes('bin'));
+    const result = await searchTidal('daft punk');
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Not logged in/);
+  });
+
+  it('spawns the search script with query, token path, types, and limit', async () => {
+    mockExistsSync.mockReturnValue(true); // python found, token found
+    const resultPromise = searchTidal('daft punk', { types: ['track', 'album'], limit: 10 });
+
+    fakeProc.stdout.emit(
+      'data',
+      JSON.stringify({
+        ok: true,
+        results: [
+          {
+            type: 'track',
+            id: '123',
+            title: 'One More Time',
+            artist: 'Daft Punk',
+            album: 'Discovery',
+            duration: 320,
+            quality: 'HiRes_Lossless',
+            url: 'https://tidal.com/browse/track/123',
+          },
+        ],
+      })
+    );
+    fakeProc.emit('close', 0);
+
+    const result = await resultPromise;
+
+    expect(lastSpawnBin).toMatch(/python/);
+    expect(lastSpawnArgs).toContain('daft punk');
+    expect(lastSpawnArgs).toContain('track,album');
+    expect(lastSpawnArgs).toContain('10');
+    expect(result.ok).toBe(true);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].title).toBe('One More Time');
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+
+  it('defaults to type "track" and limit 20 when not specified', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const resultPromise = searchTidal('some query');
+    fakeProc.stdout.emit('data', JSON.stringify({ ok: true, results: [] }));
+    fakeProc.emit('close', 0);
+    await resultPromise;
+
+    expect(lastSpawnArgs).toContain('track');
+    expect(lastSpawnArgs).toContain('20');
+  });
+
+  it('resolves with an error when the script prints unparseable output', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const resultPromise = searchTidal('daft punk');
+    fakeProc.stderr.emit('data', 'Traceback: something went wrong');
+    fakeProc.emit('close', 1);
+
+    const result = await resultPromise;
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/something went wrong/);
+  });
+
+  it('resolves with an error when spawning the interpreter fails', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const resultPromise = searchTidal('daft punk');
+    fakeProc.emit('error', new Error('ENOENT'));
+
+    const result = await resultPromise;
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ENOENT');
+  });
+});

--- a/src/__tests__/ytDlpManager.test.js
+++ b/src/__tests__/ytDlpManager.test.js
@@ -1,9 +1,36 @@
 import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'events';
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
-vi.mock('../deps.js', () => ({ getYtDlpRuntimePath: () => '/usr/bin/yt-dlp' }));
+vi.mock('../deps.js', () => ({
+  getYtDlpRuntimePath: () => '/usr/bin/yt-dlp',
+  getFfmpegRuntimePath: () => '/usr/bin/ffmpeg',
+}));
 
-import { detectPlatform } from '../audio/ytDlpManager.js';
+vi.mock('fs', () => ({
+  default: { existsSync: vi.fn().mockReturnValue(true) },
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
+// child_process.spawn mock — captures the args it was called with and lets
+// each test control stdout/exit behavior via a fake EventEmitter-based process.
+let lastSpawnArgs = null;
+let fakeProc;
+vi.mock('child_process', () => ({
+  spawn: vi.fn((bin, args) => {
+    lastSpawnArgs = args;
+    return fakeProc;
+  }),
+}));
+
+function makeFakeProc() {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  return proc;
+}
+
+import { detectPlatform, searchYouTube } from '../audio/ytDlpManager.js';
 
 describe('detectPlatform', () => {
   it('returns youtube for youtube.com URLs', () => {
@@ -32,5 +59,78 @@ describe('detectPlatform', () => {
     expect(detectPlatform('not-a-url')).toBe('other');
     expect(detectPlatform('')).toBe('other');
     expect(detectPlatform('just some text')).toBe('other');
+  });
+});
+
+// ── Cloud Search (#376) — YouTube side ────────────────────────────────────────
+
+describe('searchYouTube', () => {
+  it('spawns yt-dlp with a ytsearchN: pseudo-URL and maps results to the shared result shape', async () => {
+    fakeProc = makeFakeProc();
+    const resultPromise = searchYouTube('daft punk', { limit: 5 });
+
+    fakeProc.stdout.emit(
+      'data',
+      JSON.stringify({
+        entries: [
+          {
+            id: 'abc123',
+            title: 'Daft Punk - One More Time',
+            url: 'https://youtu.be/abc123',
+            duration: 320,
+          },
+          {
+            id: 'def456',
+            title: 'Daft Punk - Harder Better Faster Stronger',
+            url: 'https://youtu.be/def456',
+            duration: 224,
+          },
+        ],
+      })
+    );
+    fakeProc.emit('close', 0);
+
+    const results = await resultPromise;
+
+    expect(lastSpawnArgs).toContain('ytsearch5:daft punk');
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      source: 'youtube',
+      type: 'track',
+      id: 'abc123',
+      title: 'Daft Punk - One More Time',
+      durationSec: 320,
+      url: 'https://youtu.be/abc123',
+    });
+  });
+
+  it('filters out unavailable entries', async () => {
+    fakeProc = makeFakeProc();
+    const resultPromise = searchYouTube('some query');
+
+    fakeProc.stdout.emit(
+      'data',
+      JSON.stringify({
+        entries: [
+          { id: '1', title: 'Available Track', url: 'https://youtu.be/1', duration: 100 },
+          { id: '2', title: '[Private video]', url: 'https://youtu.be/2', duration: 100 },
+        ],
+      })
+    );
+    fakeProc.emit('close', 0);
+
+    const results = await resultPromise;
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('1');
+  });
+
+  it('defaults to a limit of 20 results when none is specified', async () => {
+    fakeProc = makeFakeProc();
+    const resultPromise = searchYouTube('some query');
+    fakeProc.stdout.emit('data', JSON.stringify({ entries: [] }));
+    fakeProc.emit('close', 0);
+    await resultPromise;
+
+    expect(lastSpawnArgs).toContain('ytsearch20:some query');
   });
 });

--- a/src/audio/tidalDlManager.js
+++ b/src/audio/tidalDlManager.js
@@ -103,6 +103,97 @@ except Exception as e:
     sys.exit(1)
 `;
 
+// Embedded Python script for searching TIDAL via tidalapi's session search.
+// Same approach as FETCH_INFO_SCRIPT above — no upstream `tdn` CLI changes
+// needed since tidalapi is already a direct dependency of this fork.
+const SEARCH_SCRIPT = `
+import sys, json
+try:
+    import tidalapi
+except ImportError:
+    print(json.dumps({'ok': False, 'error': 'tidalapi not installed'}))
+    sys.exit(1)
+
+if len(sys.argv) < 3:
+    print(json.dumps({'ok': False, 'error': 'Usage: script.py <query> <token_path> [types] [limit]'}))
+    sys.exit(1)
+
+query = sys.argv[1]
+token_path = sys.argv[2]
+types_arg = sys.argv[3] if len(sys.argv) > 3 else 'track'
+limit = int(sys.argv[4]) if len(sys.argv) > 4 else 20
+
+try:
+    with open(token_path) as f:
+        token = json.load(f)
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': f'Token error: {str(e)}'}))
+    sys.exit(1)
+
+try:
+    session = tidalapi.Session()
+    session.load_oauth_session(
+        token.get('token_type', 'Bearer'),
+        token['access_token'],
+        token.get('refresh_token')
+    )
+    if not session.check_login():
+        print(json.dumps({'ok': False, 'error': 'Not logged in to TIDAL'}))
+        sys.exit(1)
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': f'Session error: {str(e)}'}))
+    sys.exit(1)
+
+type_map = {
+    'track': tidalapi.media.Track,
+    'album': tidalapi.album.Album,
+    'playlist': tidalapi.playlist.Playlist,
+}
+requested_types = [t.strip() for t in types_arg.split(',') if t.strip() in type_map]
+models = [type_map[t] for t in requested_types] if requested_types else None
+
+try:
+    results = session.search(query, models=models, limit=limit)
+    out = []
+    for t in (results.get('tracks') or []):
+        out.append({
+            'type': 'track',
+            'id': str(t.id),
+            'title': t.name,
+            'artist': t.artist.name if t.artist else '',
+            'album': t.album.name if t.album else '',
+            'duration': t.duration,
+            'quality': getattr(t, 'audio_quality', None) or '',
+            'url': f'https://tidal.com/browse/track/{t.id}',
+        })
+    for a in (results.get('albums') or []):
+        out.append({
+            'type': 'album',
+            'id': str(a.id),
+            'title': a.name,
+            'artist': a.artist.name if a.artist else '',
+            'album': a.name,
+            'duration': None,
+            'quality': getattr(a, 'audio_quality', None) or '',
+            'url': f'https://tidal.com/browse/album/{a.id}',
+        })
+    for p in (results.get('playlists') or []):
+        out.append({
+            'type': 'playlist',
+            'id': str(p.id),
+            'title': p.name,
+            'artist': '',
+            'album': '',
+            'duration': None,
+            'quality': '',
+            'url': f'https://tidal.com/browse/playlist/{p.id}',
+        })
+    print(json.dumps({'ok': True, 'results': out}))
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': str(e)}))
+    sys.exit(1)
+`;
+
 // Strip ANSI escape codes from terminal output
 function stripAnsi(str) {
   return str.replace(/\x1B\[[0-9;]*[mGKHFABCDST]/g, '');
@@ -233,6 +324,63 @@ export async function fetchTidalInfo(url) {
       try {
         const result = JSON.parse(stdout.trim());
         resolve(result);
+      } catch {
+        resolve({ ok: false, error: stderr.trim() || stdout.trim() || 'Failed to parse response' });
+      }
+    });
+
+    proc.on('error', (err) => {
+      resolve({ ok: false, error: err.message });
+    });
+  });
+}
+
+/**
+ * Search TIDAL by keyword using tidalapi's session search.
+ * @param {string} query
+ * @param {{ types?: string[], limit?: number }} [opts]
+ * @returns {Promise<{ ok: boolean, results?: Array, error?: string }>}
+ */
+export async function searchTidal(query, opts = {}) {
+  const pythonPath = findTidalPython();
+  if (!pythonPath) {
+    return { ok: false, error: 'Python interpreter not found. Ensure tidal-dl-ng is installed.' };
+  }
+
+  const tokenPath = getTokenPath();
+  if (!fs.existsSync(tokenPath)) {
+    return { ok: false, error: 'Not logged in to TIDAL. Please connect your account first.' };
+  }
+
+  const scriptPath = path.join(os.tmpdir(), 'dj_manager_tidal_search.py');
+  try {
+    fs.writeFileSync(scriptPath, SEARCH_SCRIPT.trimStart());
+  } catch (e) {
+    return { ok: false, error: `Failed to write search script: ${e.message}` };
+  }
+
+  const types = opts.types?.length ? opts.types.join(',') : 'track';
+  const limit = opts.limit ?? 20;
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+
+    const proc = spawn(pythonPath, [scriptPath, query, tokenPath, types, String(limit)], {
+      env: { ...process.env, PYTHONUNBUFFERED: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on('close', () => {
+      try {
+        resolve(JSON.parse(stdout.trim()));
       } catch {
         resolve({ ok: false, error: stderr.trim() || stdout.trim() || 'Failed to parse response' });
       }

--- a/src/audio/ytDlpManager.js
+++ b/src/audio/ytDlpManager.js
@@ -356,6 +356,33 @@ function _fetchPlaylistInfoOnce(url, options = {}) {
 }
 
 /**
+ * Search YouTube by keyword using yt-dlp's `ytsearchN:` pseudo-URL support
+ * (no extra binary/config needed — --flat-playlist already returns entries
+ * for a search "playlist" the same way it does for a real one).
+ *
+ * @param {string} query
+ * @param {{ limit?: number }} [options]
+ * @returns {Promise<Array<{source:'youtube', type:'track', id, title, artist, album, durationSec, quality, url}>>}
+ */
+export async function searchYouTube(query, options = {}) {
+  const limit = options.limit ?? 20;
+  const info = await fetchPlaylistInfo(`ytsearch${limit}:${query}`);
+  return info.entries
+    .filter((e) => !e.unavailable)
+    .map((e) => ({
+      source: 'youtube',
+      type: 'track',
+      id: e.id,
+      title: e.title,
+      artist: '',
+      album: '',
+      durationSec: e.duration ?? null,
+      quality: '',
+      url: e.url,
+    }));
+}
+
+/**
  * Download audio from a URL using yt-dlp.
  * Supports both single tracks and playlists — always resolves with an array of file results.
  *

--- a/src/main.js
+++ b/src/main.js
@@ -89,12 +89,14 @@ import {
 import {
   downloadUrl as ytDlpDownloadUrl,
   fetchPlaylistInfo as ytDlpFetchPlaylistInfo,
+  searchYouTube,
 } from './audio/ytDlpManager.js';
 import {
   checkTidalSetup,
   startLogin as tidalStartLogin,
   downloadTidal,
   fetchTidalInfo,
+  searchTidal,
 } from './audio/tidalDlManager.js';
 import { generateWaveformOverview } from './audio/waveformGenerator.js';
 import { ensureDeps, getFfmpegRuntimePath } from './deps.js';
@@ -1242,6 +1244,38 @@ ipcMain.handle('tidal-fetch-info', async (_event, url) => {
     return info;
   } catch (err) {
     console.error('[tidal-fetch-info] error:', err.message);
+    return { ok: false, error: err.message };
+  }
+});
+
+ipcMain.handle('cloud-search', async (_event, { source, query, types, limit }) => {
+  if (!query?.trim()) return { ok: false, error: 'Empty query' };
+  try {
+    if (source === 'youtube') {
+      const results = await searchYouTube(query, { limit });
+      return { ok: true, results };
+    }
+    if (source === 'tidal') {
+      const res = await searchTidal(query, { types, limit });
+      if (!res.ok) return res;
+      return {
+        ok: true,
+        results: res.results.map((r) => ({
+          source: 'tidal',
+          type: r.type,
+          id: r.id,
+          title: r.title,
+          artist: r.artist,
+          album: r.album,
+          durationSec: r.duration,
+          quality: r.quality,
+          url: r.url,
+        })),
+      };
+    }
+    return { ok: false, error: `Unknown source: ${source}` };
+  } catch (err) {
+    console.error('[cloud-search] error:', err.message);
     return { ok: false, error: err.message };
   }
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -193,6 +193,8 @@ contextBridge.exposeInMainWorld('api', {
   tidalInstall: () => ipcRenderer.invoke('tidal-install'),
   tidalFetchInfo: (url) => ipcRenderer.invoke('tidal-fetch-info', url),
   tidalLogin: () => ipcRenderer.invoke('tidal-login'),
+  cloudSearch: ({ source, query, types, limit }) =>
+    ipcRenderer.invoke('cloud-search', { source, query, types, limit }),
   tidalDownloadUrl: (opts) => ipcRenderer.invoke('tidal-download-url', opts),
   onTidalProgress: (cb) => {
     const handler = (_, data) => cb(data);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -37,6 +37,7 @@ export default defineConfig({
           include: [
             'src/__tests__/importManager.test.js',
             'src/__tests__/ytDlpManager.test.js',
+            'src/__tests__/tidalDlManager.test.js',
             'src/__tests__/mediaServer.test.js',
             'src/__tests__/anlzWriter.test.js',
             'src/__tests__/waveformGenerator.test.js',


### PR DESCRIPTION
Closes #376.

## What changed

Before this, downloading from Tidal or YouTube required an existing URL. This adds a "Cloud Search" tab: type a query, pick a source (YouTube / TIDAL) and type filter, get a results list, select one or more, download straight into the library.

### YouTube side - no yt-dlp changes needed
`searchYouTube(query, opts)` in `src/audio/ytDlpManager.js` calls the existing `fetchPlaylistInfo()` with a `ytsearchN:<query>` pseudo-URL instead of a real URL. `--flat-playlist --dump-single-json` already treats a search as a playlist of results, so this needed zero changes to the yt-dlp invocation itself - just a thin wrapper that maps entries into the shared result shape and filters out unavailable ones.

### TIDAL side - turns out no upstream CLI change was needed either
The issue proposed adding a `tdn search` subcommand to the `tidal-dl-ng-For-DJ` fork. Looking at `tidalDlManager.js` more closely: `fetchTidalInfo()` doesn't shell out to `tdn` for info lookups at all - it writes an embedded Python script to a temp file and runs it with the uv-managed interpreter, calling `tidalapi` directly (session.load_oauth_session + session.track/album/playlist). `searchTidal(query, opts)` follows the exact same pattern, calling `tidalapi`'s `session.search()` instead. Since `tidalapi` is already a direct dependency of that environment, this works today with no upstream fork changes.

### Shared result shape
```js
{ source: 'tidal'|'youtube', type: 'track'|'album'|'playlist', id, title, artist, album, durationSec, quality, url }
```

### IPC
One new `cloud-search` channel (`main.js`/`preload.js`) normalizes both sources into that shape.

### Downloads reuse existing infra
No new download plumbing - selecting results and clicking Download calls the same `ytdlp-download-url` (one call per YouTube result, sequential) and `tidal-download-url` (one batched call with `selectedEntries` for all selected TIDAL results) channels the existing URL-paste flows already use, so import/playlist behavior is unchanged.

### UI
New `CloudSearchView.jsx` + `Sidebar.jsx` entry + `App.jsx` branch, following the existing always-mounted-with-display-toggle pattern used by `DownloadView`/`TidalDownloadView`. Gracefully points to the TIDAL tab when TIDAL isn't installed/logged in yet instead of blocking the whole view.

### Deliberately scoped down for a first pass
- YouTube downloads are sequential (one result = one independent video), not parallel.
- No dedicated sidebar progress indicator for Cloud Search downloads (the existing YT-DLP/TIDAL sidebar indicators are per-view, not global) - status is shown inline in the results table instead.
- No playlist-assignment option on download (always goes straight to the library, same as a single-track URL download would).

## Testing
407 main-process tests (added `tidalDlManager.test.js` and new `searchYouTube` cases in `ytDlpManager.test.js`, both mocking `child_process.spawn`) and 139 renderer tests pass; lint clean; `vite build` succeeds. UI was not interactively tested in a running Electron window this pass (no live session available) - please give it a spin before merging.