### PR TITLE
chore: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A DJ-focused music library manager built with Electron. Manage your tracks, analyze BPM and key, export to Pioneer CDJ USB drives, and download from streaming platforms — all in one offline-first desktop app.
 
+[![CI](https://github.com/Radexito/DjManager/actions/workflows/ci.yml/badge.svg)](https://github.com/Radexito/DjManager/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/Radexito/DjManager?include_prereleases)](https://github.com/Radexito/DjManager/releases)
+[![Open issues](https://img.shields.io/github/issues/Radexito/DjManager)](https://github.com/Radexito/DjManager/issues)
+[![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)](#download)
+
 ![DJ Manager screenshot](screenshot.png)
 
 ---
@@ -199,6 +205,12 @@ npm run dist:linux          # or :mac / :win
 ---
 
 ## Tech Stack
+
+![Electron](https://img.shields.io/badge/Electron-191970?style=for-the-badge&logo=electron&logoColor=white)
+![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)
+![Vite](https://img.shields.io/badge/Vite-646CFF?style=for-the-badge&logo=vite&logoColor=white)
+![SQLite](https://img.shields.io/badge/SQLite-07405E?style=for-the-badge&logo=sqlite&logoColor=white)
+![FFmpeg](https://img.shields.io/badge/FFmpeg-007808?style=for-the-badge&logo=ffmpeg&logoColor=white)
 
 | Layer            | Technology                                        |
 | ---------------- | ------------------------------------------------- |


### PR DESCRIPTION
Closes #297.

Adds a row of badges under the title:
- CI workflow status (`ci.yml`)
- License (MIT)
- Latest release version
- Open issues count
- Supported platforms (Windows / macOS / Linux)

And a row of tech-stack badges (Electron, React, Vite, SQLite, FFmpeg) above the existing Tech Stack table, in the same shields.io style referenced by the linked [markdown-badges](https://github.com/Ileriayo/markdown-badges) repo.

Deliberately skipped: a stars/social badge (a bit self-promotional for the top of the README) and per-download-count badges (no releases with binary assets attached yet, so it'd just show 0). Happy to add either if you want them.

All badge URLs verified to return HTTP 200 before opening this PR. Docs-only change - no source files touched, nothing to test.