### PR TITLE
fix: prevent explorer_favourites JSON.parse crash on corrupt setting

### DIFF
--- a/renderer/src/FileExplorerView.jsx
+++ b/renderer/src/FileExplorerView.jsx
@@ -343,7 +343,14 @@ export default function FileExplorerView({ style }) {
     });
     window.api.getPlaylists().then(setPlaylists);
     window.api.getSetting('explorer_favourites', []).then((favs) => {
-      const parsed = typeof favs === 'string' ? JSON.parse(favs) : favs;
+      let parsed = favs;
+      if (typeof favs === 'string') {
+        try {
+          parsed = favs ? JSON.parse(favs) : [];
+        } catch {
+          parsed = []; // corrupt/legacy stored value — reset rather than crash
+        }
+      }
       setFavourites(Array.isArray(parsed) ? parsed : []);
     });
     const unsub = window.api.onPlaylistsUpdated(() => window.api.getPlaylists().then(setPlaylists));
@@ -355,7 +362,7 @@ export default function FileExplorerView({ style }) {
     setFavourites((prev) => {
       if (prev.some((f) => f.path === path)) return prev;
       const next = [...prev, { path, name }];
-      window.api.setSetting('explorer_favourites', next);
+      window.api.setSetting('explorer_favourites', JSON.stringify(next));
       return next;
     });
   }, []);
@@ -363,7 +370,7 @@ export default function FileExplorerView({ style }) {
   const removeFavourite = useCallback((path) => {
     setFavourites((prev) => {
       const next = prev.filter((f) => f.path !== path);
-      window.api.setSetting('explorer_favourites', next);
+      window.api.setSetting('explorer_favourites', JSON.stringify(next));
       return next;
     });
   }, []);

--- a/renderer/src/__tests__/FileExplorerView.favourites.test.jsx
+++ b/renderer/src/__tests__/FileExplorerView.favourites.test.jsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import FileExplorerView from '../FileExplorerView.jsx';
+import { PlayerProvider } from '../PlayerContext.jsx';
+
+// jsdom has no ResizeObserver; FileExplorerView uses one to size its virtualized list.
+globalThis.ResizeObserver =
+  globalThis.ResizeObserver ||
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+function renderExplorer() {
+  return render(
+    <PlayerProvider>
+      <FileExplorerView />
+    </PlayerProvider>
+  );
+}
+
+describe('FileExplorerView — favourites persistence (regression for #400)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not crash when the stored setting is a corrupt empty string', async () => {
+    // String([]) coerces to '' — the exact bad value that used to be persisted
+    // by setSetting() before it was JSON.stringify'd.
+    window.api.getSetting.mockImplementation((key, def) =>
+      Promise.resolve(key === 'explorer_favourites' ? '' : def)
+    );
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(window.api.getSetting).toHaveBeenCalledWith('explorer_favourites', []);
+    });
+    // No uncaught JSON.parse SyntaxError — component renders normally.
+    expect(screen.getAllByText(/Favourites/i).length).toBeGreaterThan(0);
+  });
+
+  it('does not crash when the stored setting is malformed non-JSON text', async () => {
+    window.api.getSetting.mockImplementation((key, def) =>
+      Promise.resolve(key === 'explorer_favourites' ? '[object Object]' : def)
+    );
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(window.api.getSetting).toHaveBeenCalledWith('explorer_favourites', []);
+    });
+  });
+
+  it('loads a well-formed JSON-stringified favourites array', async () => {
+    const favs = [{ path: '/music/a', name: 'a' }];
+    window.api.getSetting.mockImplementation((key, def) =>
+      Promise.resolve(key === 'explorer_favourites' ? JSON.stringify(favs) : def)
+    );
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(window.api.getSetting).toHaveBeenCalledWith('explorer_favourites', []);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `setSetting()` persists non-string values via `String(value)`, which is not JSON-safe — `String([])` collapses to `''` and `String([{...}])` becomes the literal text `[object Object]`.
- `FileExplorerView`'s init effect calls `JSON.parse()` unconditionally on any string value returned from `getSetting('explorer_favourites', [])`, so once the setting was ever persisted from an array (e.g. removing the last favourite), the next load throws an uncaught `SyntaxError: Unexpected end of JSON input` and the Explorer view breaks.
- Reproduced and confirmed against a real corrupted row: `sqlite3 library.db "SELECT quote(value) FROM settings WHERE key='explorer_favourites'"` → `''`.
- Not platform-specific — plain JS coercion bug, reproducible on any OS once the favourites list is ever saved empty.

## Fix
- `addFavourite`/`removeFavourite` now `JSON.stringify()` before calling `setSetting`, so future writes are valid JSON.
- The read path wraps `JSON.parse` in try/catch and falls back to `[]` on any malformed/legacy stored value, so it self-heals instead of crashing (covers users who already have the corrupted value persisted).

## Test plan
- [x] Added `renderer/src/__tests__/FileExplorerView.favourites.test.jsx` — regression tests for empty-string, malformed-string, and well-formed-JSON stored values.
- [x] `cd renderer && npx vitest run src/__tests__/FileExplorerView.favourites.test.jsx` — 3/3 passing.
- [x] `npx eslint` on changed files — clean.
- [x] Full renderer suite run — pre-existing unrelated failures in `MusicLibrary.contextmenu.test.jsx` (jsdom `localStorage` undefined) confirmed present on `dev` before this change too (verified via `git stash`).

Closes #400