### PR TITLE
fix: add CORS headers to media server error responses (403/404/500)

### DIFF
--- a/src/__tests__/mediaServer.test.js
+++ b/src/__tests__/mediaServer.test.js
@@ -157,6 +157,16 @@ describe('Security — path restriction', () => {
     const res = await httpGet(`http://127.0.0.1:${port}/${encoded}`);
     expect(res.status).toBe(403);
   });
+
+  // Regression for #401: the renderer's reachability probe (PlayerContext.jsx)
+  // deliberately hits a path outside any allowed base and expects a *resolved*
+  // response (any status) rather than a browser-level CORS network error. That
+  // only holds if error responses carry the same CORS header successful ones do.
+  it('includes Access-Control-Allow-Origin on a 403 response', async () => {
+    const outsidePath = path.join(tmpDir, '..', 'etc', 'passwd');
+    const res = await httpGet(`http://127.0.0.1:${port}${toUrlPath(outsidePath)}`);
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+  });
 });
 
 // ── Not found ─────────────────────────────────────────────────────────────────
@@ -166,6 +176,12 @@ describe('GET — missing file', () => {
     const missing = path.join(audioBase, 'nope.mp3');
     const res = await httpGet(`http://127.0.0.1:${port}${toUrlPath(missing)}`);
     expect(res.status).toBe(404);
+  });
+
+  it('includes Access-Control-Allow-Origin on a 404 response', async () => {
+    const missing = path.join(audioBase, 'nope.mp3');
+    const res = await httpGet(`http://127.0.0.1:${port}${toUrlPath(missing)}`);
+    expect(res.headers['access-control-allow-origin']).toBe('*');
   });
 });
 

--- a/src/audio/mediaServer.js
+++ b/src/audio/mediaServer.js
@@ -40,6 +40,15 @@ export function streamFile(stream, res) {
  */
 export function createMediaRequestHandler(audioBase, artworkBase = null, allowedBases = []) {
   return (req, res) => {
+    // Allow Web Audio API (createMediaElementSource) to process audio from any
+    // renderer origin. In dev mode the renderer runs at localhost:517x while the
+    // server is 127.0.0.1:PORT — different origins — so without this header
+    // Chromium outputs zeroes and the user hears silence. Applied to every
+    // response (including errors, declared outside the try so the catch block
+    // can use it too) so cross-origin callers — e.g. the reachability probe in
+    // PlayerContext.jsx — get a readable status instead of an opaque
+    // CORS-blocked network error.
+    const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
     try {
       let urlPath = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
       if (process.platform === 'win32') {
@@ -52,7 +61,7 @@ export function createMediaRequestHandler(audioBase, artworkBase = null, allowed
       const inArtwork = artworkBase && urlPath.startsWith(artworkBase);
       const inAllowed = allowedBases.some((base) => urlPath.startsWith(base));
       if (!inAudio && !inArtwork && !inAllowed) {
-        res.writeHead(403);
+        res.writeHead(403, corsHeaders);
         res.end();
         return;
       }
@@ -62,12 +71,6 @@ export function createMediaRequestHandler(audioBase, artworkBase = null, allowed
       const ext = path.extname(urlPath).toLowerCase();
       const mime = IMAGE_MIME[ext] || AUDIO_MIME[ext] || (inArtwork ? 'image/jpeg' : 'audio/mpeg');
       const rangeHeader = req.headers['range'];
-
-      // Allow Web Audio API (createMediaElementSource) to process audio from any
-      // renderer origin. In dev mode the renderer runs at localhost:517x while the
-      // server is 127.0.0.1:PORT — different origins — so without this header
-      // Chromium outputs zeroes and the user hears silence.
-      const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
 
       if (req.method === 'OPTIONS') {
         res.writeHead(204, corsHeaders);
@@ -98,7 +101,7 @@ export function createMediaRequestHandler(audioBase, artworkBase = null, allowed
       }
     } catch (err) {
       if (err.code !== 'ENOENT') console.error('[media-server] error:', err.message);
-      res.writeHead(err.code === 'ENOENT' ? 404 : 500);
+      res.writeHead(err.code === 'ENOENT' ? 404 : 500, corsHeaders);
       res.end();
     }
   };


### PR DESCRIPTION
## Summary
- The media server's `Access-Control-Allow-Origin` header was only applied to successful (200/206/204) responses, not to error responses (403/404/500).
- The renderer's reachability probe (`PlayerContext.jsx`) does a cross-origin `fetch` to the media server (renderer dev server vs `127.0.0.1:PORT`) and expects a resolved response with a status code. Without CORS headers on the error paths, Chromium blocks the response entirely and the fetch promise rejects with an opaque network error instead of resolving with the actual status.

## Fix
- Hoisted `const corsHeaders = { 'Access-Control-Allow-Origin': '*' }` above the `try` block in `createMediaRequestHandler` so it's in scope for every response path.
- Applied `corsHeaders` to the 403 (outside allowed bases) and to the catch block's 404/500 responses, matching what was already done for 200/206/204.

## Test plan
- [x] Added regression tests asserting `Access-Control-Allow-Origin: *` is present on both 403 and 404 responses.
- [x] `npx vitest run src/__tests__/mediaServer.test.js` — 14/14 passed.
- [x] Full root suite `npx vitest run` — 400/400 passed, no regressions.
- [x] `npx eslint` and `npx prettier --check` clean on changed files.

Closes #401