### PR TITLE
fix: use android_vr,web extractor client for YouTube availability check

### DIFF
--- a/src/__tests__/ytDlpManager.test.js
+++ b/src/__tests__/ytDlpManager.test.js
@@ -1,9 +1,54 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
-vi.mock('../deps.js', () => ({ getYtDlpRuntimePath: () => '/usr/bin/yt-dlp' }));
+vi.mock('../deps.js', () => ({
+  getYtDlpRuntimePath: () => '/usr/bin/yt-dlp',
+  getFfmpegRuntimePath: () => '/usr/bin/ffmpeg',
+}));
 
-import { detectPlatform } from '../audio/ytDlpManager.js';
+const spawnCalls = [];
+vi.mock('child_process', () => ({
+  spawn: vi.fn((_cmd, args) => {
+    spawnCalls.push(args);
+    const proc = new EventEmitter();
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+
+    // Respond like the real yt-dlp binary would for each call this suite makes:
+    // --dump-single-json for the initial playlist fetch, --print availability
+    // for the per-entry check that runs afterwards.
+    queueMicrotask(() => {
+      if (args.includes('--dump-single-json')) {
+        proc.stdout.emit(
+          'data',
+          Buffer.from(
+            JSON.stringify({
+              title: 'Test Playlist',
+              entries: [
+                {
+                  id: 'abc123',
+                  title: 'Track 1',
+                  webpage_url: 'https://youtube.com/watch?v=abc123',
+                  duration: 100,
+                },
+              ],
+            })
+          )
+        );
+      } else if (args.includes('availability')) {
+        proc.stdout.emit('data', Buffer.from('public'));
+      }
+      proc.emit('close', 0);
+    });
+
+    return proc;
+  }),
+}));
+
+import fs from 'fs';
+import { detectPlatform, fetchPlaylistInfo } from '../audio/ytDlpManager.js';
 
 describe('detectPlatform', () => {
   it('returns youtube for youtube.com URLs', () => {
@@ -32,5 +77,29 @@ describe('detectPlatform', () => {
     expect(detectPlatform('not-a-url')).toBe('other');
     expect(detectPlatform('')).toBe('other');
     expect(detectPlatform('just some text')).toBe('other');
+  });
+});
+
+// Regression for #404: the per-entry availability check used player_client=web
+// only, which fails format resolution for most videos (YouTube's SABR-streaming/
+// PO-token enforcement on the web client) and was misread as "unavailable".
+describe('checkYouTubeAvailability (via fetchPlaylistInfo)', () => {
+  beforeEach(() => {
+    spawnCalls.length = 0;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  });
+
+  it('probes availability using the android_vr,web extractor client', async () => {
+    await fetchPlaylistInfo('https://www.youtube.com/playlist?list=xyz');
+
+    const availabilityCall = spawnCalls.find((args) => args.includes('availability'));
+    expect(availabilityCall).toBeDefined();
+    const clientArgIndex = availabilityCall.indexOf('--extractor-args');
+    expect(availabilityCall[clientArgIndex + 1]).toBe('youtube:player_client=android_vr,web');
+  });
+
+  it('does not flag a publicly-available entry as unavailable', async () => {
+    const info = await fetchPlaylistInfo('https://www.youtube.com/playlist?list=xyz');
+    expect(info.entries[0].unavailable).toBe(false);
   });
 });

--- a/src/audio/ytDlpManager.js
+++ b/src/audio/ytDlpManager.js
@@ -182,7 +182,7 @@ async function checkYouTubeAvailability(entries, onProgress, onEntryChecked) {
         'availability',
         '--no-warnings',
         '--extractor-args',
-        'youtube:player_client=web',
+        'youtube:player_client=android_vr,web',
         `https://www.youtube.com/watch?v=${entry.id}`,
       ];
       const proc = spawn(ytDlp, args);


### PR DESCRIPTION
## Summary
- The per-video availability probe in `checkYouTubeAvailability()` used `--extractor-args youtube:player_client=web` only, which is subject to YouTube's SABR-streaming/PO-token enforcement and fails format resolution for most videos with `Requested format is not available` (exit code 1).
- `checkOne()` treated any non-zero exit code as "unavailable", so playlists loaded with the vast majority of entries falsely flagged as private/deleted/unavailable — reproduced with 12/13 and 25/27 entries wrongly flagged on real playlists.
- `_fetchPlaylistInfoOnce()` a few lines above already works around this exact issue by using `player_client=android_vr,web`. This PR applies the same extractor-args to the availability check.

## Fix
- Changed the `--extractor-args` value in `checkOne()` from `youtube:player_client=web` to `youtube:player_client=android_vr,web`, matching the main info-fetch call.

## Test plan
- [x] Manually reproduced against several falsely-flagged video IDs: `player_client=web` fails with the format error, `player_client=android_vr,web` returns `public` for the same IDs.
- [x] Added regression tests to `ytDlpManager.test.js` asserting the availability probe is spawned with `youtube:player_client=android_vr,web`, and that a publicly-available entry isn't flagged unavailable. Verified the new test fails against the old `player_client=web` value before the fix and passes after.
- [x] `npx vitest run src/__tests__/ytDlpManager.test.js` — 8/8 passed.
- [x] Full root suite `npx vitest run` — 400/400 passed, no regressions.
- [x] `npx eslint` and `npx prettier --check` clean on changed files.

Closes #404