### PR TITLE
fix: rename Tidal track-row CSS classes to stop clobbering DownloadView's

### DIFF
--- a/renderer/src/TidalDownloadView.css
+++ b/renderer/src/TidalDownloadView.css
@@ -326,7 +326,7 @@
   margin-bottom: 12px;
 }
 
-.dl-track-row {
+.tidal-track-row {
   display: grid;
   grid-template-columns: 20px 1fr auto;
   align-items: center;
@@ -335,7 +335,7 @@
   border-bottom: 1px solid var(--border, #1e1e1e);
 }
 
-.dl-track-row:last-child {
+.tidal-track-row:last-child {
   border-bottom: none;
 }
 
@@ -361,10 +361,10 @@
   color: #fc8181;
 }
 
-.dl-track-row--done {
+.tidal-track-row--done {
   background: rgba(104, 211, 145, 0.04);
 }
-.dl-track-row--failed {
+.tidal-track-row--failed {
   background: rgba(252, 129, 129, 0.04);
 }
 
@@ -374,7 +374,7 @@
   text-overflow: ellipsis;
 }
 
-.dl-track-title {
+.tidal-track-title {
   font-size: 13px;
   color: var(--text-primary, #ddd);
 }

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -801,12 +801,12 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
           {trackStatuses.map((s) => {
             const si = STATUS_ICON[s.status] ?? STATUS_ICON.pending;
             return (
-              <div key={s.index} className={`dl-track-row dl-track-row--${s.status}`}>
+              <div key={s.index} className={`tidal-track-row tidal-track-row--${s.status}`}>
                 <span className={`dl-track-icon dl-track-icon--${s.status}`} title={si.label}>
                   {si.icon}
                 </span>
                 <span className="dl-track-info">
-                  <span className="dl-track-title">{s.title}</span>
+                  <span className="tidal-track-title">{s.title}</span>
                   {s.artist && <span className="dl-track-artist"> — {s.artist}</span>}
                 </span>
                 {s.error && <span className="dl-track-error">{s.error}</span>}

--- a/renderer/src/__tests__/DownloadView.cssCollision.test.js
+++ b/renderer/src/__tests__/DownloadView.cssCollision.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const downloadCss = fs.readFileSync(path.join(dirname, '../DownloadView.css'), 'utf8');
+const tidalCss = fs.readFileSync(path.join(dirname, '../TidalDownloadView.css'), 'utf8');
+const tidalJsx = fs.readFileSync(path.join(dirname, '../TidalDownloadView.jsx'), 'utf8');
+
+// Regression for #406: TidalDownloadView.jsx imports both DownloadView.css and
+// TidalDownloadView.css into the same global stylesheet cascade (plain CSS, not
+// scoped per-component). Reusing a class name across the two files with
+// conflicting rules lets one silently clobber the other app-wide, not just
+// within the owning component. `.dl-track-row`/`.dl-track-title` collided this
+// way — Tidal's 3-column grid overrode DownloadView's 2-column grid, squeezing
+// the YT-DLP download progress table's title column down to 20px and truncating
+// names to 1-2 characters.
+describe('DownloadView / TidalDownloadView CSS — no track-row class collisions', () => {
+  it('TidalDownloadView.css does not redefine .dl-track-row or .dl-track-title', () => {
+    expect(tidalCss.includes('.dl-track-row')).toBe(false);
+    expect(tidalCss.includes('.dl-track-title')).toBe(false);
+  });
+
+  it('DownloadView.css still owns .dl-track-row and .dl-track-title', () => {
+    expect(downloadCss.includes('.dl-track-row')).toBe(true);
+    expect(downloadCss.includes('.dl-track-title')).toBe(true);
+  });
+
+  it('TidalDownloadView.jsx uses tidal-prefixed classes instead of the shared names', () => {
+    expect(tidalJsx.includes('dl-track-row')).toBe(false);
+    expect(tidalJsx.includes('dl-track-title')).toBe(false);
+    expect(tidalJsx.includes('tidal-track-row')).toBe(true);
+    expect(tidalJsx.includes('tidal-track-title')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `DownloadView.css` and `TidalDownloadView.css` both defined `.dl-track-row` and `.dl-track-title` with conflicting rules (a 2-column grid for the YT-DLP progress table vs. a 3-column grid for the Tidal track list).
- `TidalDownloadView.jsx` imports both stylesheets. CSS here is global (not scoped per-component), so once the Tidal view has been mounted in a session, `TidalDownloadView.css`'s rules (imported later) win the cascade for these class names everywhere — including the unrelated YT-DLP download progress table.
- Since that table's row only has 2 children, its title span landed in Tidal's 3-column template's first column — only 20px wide — truncating track names to 1-2 characters.

## Fix
- Renamed the Tidal-only versions of these classes to `tidal-track-row`/`tidal-track-title` (and the `--done`/`--failed` modifiers), matching the `tidal-` prefix already used for other Tidal-specific classes in that file (`.tidal-install-box`, `.tidal-login-box`, etc.).

## Test plan
- [x] Added `renderer/src/__tests__/DownloadView.cssCollision.test.js` asserting `.dl-track-row`/`.dl-track-title` are no longer defined in `TidalDownloadView.css` and that `TidalDownloadView.jsx` uses the `tidal-` prefixed names. Verified it fails against the pre-fix code and passes after.
- [x] `npx vitest run` in `renderer/` — no new failures (pre-existing unrelated failures in `MusicLibrary.contextmenu.test.jsx` confirmed present on clean `dev` too).
- [x] `npx eslint` / `npx prettier --check` clean on changed files.
- [x] Manually verified in the running dev app: track titles in the YT-DLP download progress table render in full instead of truncating to 1-2 characters.

Note: a few other class names (`.dl-progress-fill`, `.dl-select-count`, `.dl-select-header`, `.dl-select-list`) are also duplicated between the two stylesheets with minor cosmetic (non-breaking) differences — tracked separately as a lower-priority follow-up.

Closes #406