### PR TITLE
fix: skip unnecessary native rebuild during release npm ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           cache: npm
 
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install renderer dependencies
         run: cd renderer && npm ci --legacy-peer-deps


### PR DESCRIPTION
## Summary

Fixes #409 — the `Build & Release` workflow was failing on macOS and Windows in the "Install root dependencies" step.

## Root cause

`npm ci` at the root implicitly triggers a native rebuild of `better-sqlite3` (npm auto-runs `node-gyp rebuild` for any dependency with a `binding.gyp` and no install script), using npm's own bundled, outdated `node-gyp@9.4.1`:

- **macOS**: that node-gyp depends on Python's `distutils`, which was removed in Python 3.13+. The `macos-latest` runner now defaults to Homebrew Python 3.14, so the build fails with `ModuleNotFoundError: No module named 'distutils'`.
- **Windows**: that node-gyp's Visual Studio detector doesn't recognize the VS version now preinstalled on `windows-latest` runners, so it fails with `could not find a version of Visual Studio 2017 or newer to use`.

Linux was unaffected because its toolchain wasn't yet incompatible with the old node-gyp.

This build is unnecessary in the first place: the packaged release only ships the **Electron**-ABI build of `better-sqlite3`, which `electron-builder` correctly rebuilds later during the "Build Electron app" step, via `@electron/rebuild` — a project devDependency that bundles its own modern `node-gyp@12.4.0`, unaffected by either issue.

`.github/workflows/ci.yml` already avoids this exact trap: it runs `npm ci --ignore-scripts` for the root install, then does an explicit, correctly-targeted rebuild (`npm rebuild better-sqlite3` for Node/tests, `npx @electron/rebuild -f -w better-sqlite3` for Electron/e2e). `release.yml` never got that treatment and worked by luck until GitHub's hosted mac/windows runner images moved to newer Python/Visual Studio versions.

## Fix

One-line change: `npm ci` → `npm ci --ignore-scripts` for the root install in `release.yml`, matching `ci.yml`. No extra rebuild step is needed afterward — `electron-builder`'s packaging step (`npx electron-builder --<platform> --publish never`) already rebuilds native modules for the correct Electron ABI by default (`npmRebuild: true`), via `@electron/rebuild`'s modern node-gyp.

## Test plan

- This is a GitHub Actions hosted-runner toolchain issue (Python 3.14 on macOS, newer Visual Studio on Windows) that cannot be reproduced or verified on Linux. Confirmed the YAML is syntactically valid; the real validation is the CI run on this PR itself (mac/windows `Build & Release` — note: that workflow only triggers on push to `master`/`staging`, not on PRs to `dev`, so mac/windows will need to be verified via a `staging` push or the next `dev` → `master` merge).
- Local unit test suite unaffected by this change (workflow-only diff).
