### PR TITLE
Merge dev into master — release #409 fix (validated on staging)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           cache: npm
 
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install renderer dependencies
         run: cd renderer && npm ci --legacy-peer-deps


### PR DESCRIPTION
## Summary

Follow-up integration PR merging `dev` into `master`, containing the fix for #409 (mac/windows `Build & Release` failures) that landed on `dev` after the previous integration ([#408](https://github.com/Radexito/DjManager/pull/408)).

## What's included

- **#409 — mac/windows release build failures** ([#410](https://github.com/Radexito/DjManager/pull/410)): `npm ci` at the root was implicitly triggering a native rebuild of `better-sqlite3` using npm's outdated bundled `node-gyp@9.4.1`, which broke on the mac runner's Python 3.14 (`distutils` removed) and the windows runner's newer Visual Studio version. Fixed by adding `--ignore-scripts` to the root `npm ci` step in `release.yml`, matching `ci.yml`'s existing pattern — `electron-builder` already rebuilds the native module correctly for the Electron ABI later via a modern, compatible `node-gyp`.

## Validation

This exact fix was already validated end-to-end by creating a `staging` branch from this `dev` HEAD and letting `release.yml` run for real on GitHub's hosted runners ([run 30388105917](https://github.com/Radexito/DjManager/actions/runs/30388105917)):

| Platform | Result | Duration |
|---|---|---|
| Linux | ✅ success | 50s |
| macOS | ✅ success | 73s |
| Windows | ✅ success | 5m 46s |

All three platform builds and `create-release` succeeded. This PR just brings the same, already-verified commits into `master`.

## Note

While investigating, filed [#411](https://github.com/Radexito/DjManager/issues/411) to look into why the Windows build job is consistently much slower than mac/linux (non-blocking, separate follow-up).
