### PR TITLE
perf(ci): cache electron-builder tool downloads to speed up Windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,17 @@ jobs:
       - name: Install renderer dependencies
         run: cd renderer && npm ci --legacy-peer-deps
 
+      - name: Cache electron-builder tools
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron-builder
+            ~/Library/Caches/electron-builder
+            ~/AppData/Local/electron-builder/Cache
+          key: electron-builder-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-builder-${{ runner.os }}-
+
       - name: Build renderer
         run: npm run build-renderer
 


### PR DESCRIPTION
## Summary

Addresses #411 — the `Build & Release` workflow's Windows job consistently runs several minutes longer than the Linux/macOS jobs in the same matrix run.

## Investigation

Compared step-level timings and raw logs from two real runs on GitHub-hosted runners ([30388105917](https://github.com/Radexito/DjManager/actions/runs/30388105917) and [30389212534](https://github.com/Radexito/DjManager/actions/runs/30389212534)):

- The `npm ci` timing swing observed in #411 (175s vs 13s) turned out to be a red herring — both runs hit a genuine cold npm dependency cache because the exact `package-lock.json` hash had just changed (a wave of dependency-bump PRs landed right before). Not a caching bug, no action needed there.
- The real, consistent cost is in the **`Build Electron app`** step: on Windows, `electron-builder` downloads NSIS installer tooling (`nsis-3.0.4.1.7z` + `nsis-resources-3.4.1.7z`) from scratch on *every single run* — confirmed identical downloads in both sampled runs, taking **~36-43s** combined. Linux/macOS download their own equivalent tool bundles (7zip/AppImage, dmgbuild/icons) too, but those are tiny and near-instant, so they aren't the bottleneck there.
- None of this is currently cached across CI runs. `electron-builder` has its own well-defined per-platform tool-cache directory (confirmed by reading `getCacheDirectory()` in `node_modules/app-builder-lib/out/util/electronGet.js`):
  - Linux: `~/.cache/electron-builder`
  - macOS: `~/Library/Caches/electron-builder`
  - Windows: `%LOCALAPPDATA%\electron-builder\Cache`

## Fix

Add an `actions/cache` step in the `build` job (matrix-scoped, so each OS gets its own cache) that persists electron-builder's tool-cache directory across runs, keyed on `runner.os` + a hash of `package-lock.json` (so the cache naturally invalidates whenever `electron-builder`/`electron` versions bump), with an OS-scoped `restore-keys` fallback.

This should eliminate the repeat NSIS download+extract on Windows after the first run following each dependency change, and gives a smaller equivalent win on Linux/macOS.

## Test plan

- YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- This is CI-config-only; real validation is the next `Build & Release` run actually hitting the cache (first run after merge will still be a cold miss and populate the cache; the *following* run on the same lockfile hash is the one that proves the fix).
- No app code changed.
