### PR TITLE
fix: require confirmed removable media before allowing USB format

### DIFF
--- a/renderer/src/ExportModal.jsx
+++ b/renderer/src/ExportModal.jsx
@@ -270,6 +270,10 @@ function ExportModal({ onClose, playlistId, initialMode }) {
               You can still export to this folder (e.g. to inspect the files or copy manually), or
               reformat the drive to FAT32 first.
             </p>
+            <p className="export-needs-format-hint">
+              <strong>Note:</strong> if you export anyway, Rekordbox and CDJ/XDJ players will not be
+              able to read this drive — Pioneer hardware only recognizes FAT32 or exFAT.
+            </p>
             <div className="export-needs-format-actions">
               <button
                 className="export-option-btn export-option-btn--secondary"
@@ -305,6 +309,10 @@ function ExportModal({ onClose, playlistId, initialMode }) {
             <p className="export-needs-format-hint">
               You can still export to this folder as-is, or choose a different, removable drive to
               format.
+            </p>
+            <p className="export-needs-format-hint">
+              <strong>Note:</strong> if you export anyway, Rekordbox and CDJ/XDJ players will not be
+              able to read this drive — Pioneer hardware only recognizes FAT32 or exFAT.
             </p>
             <div className="export-needs-format-actions">
               <button

--- a/renderer/src/ExportModal.jsx
+++ b/renderer/src/ExportModal.jsx
@@ -8,6 +8,7 @@ const STEPS = {
   pickFolder: 'pickFolder',
   checkingFormat: 'checkingFormat',
   needsFormat: 'needsFormat',
+  notRemovable: 'notRemovable',
   formatting: 'formatting',
   exporting: 'exporting',
   done: 'done',
@@ -98,7 +99,11 @@ function ExportModal({ onClose, playlistId, initialMode }) {
     setStep(STEPS.checkingFormat);
     const info = await window.api.checkUsbFormat(dir);
     setUsbInfo(info);
-    if (info.needsFormat) {
+    if (info.needsFormat && !info.removable) {
+      // Never offer to format a drive we couldn't positively confirm is removable —
+      // block here so the user isn't shown a "Format" button for an internal disk.
+      setStep(STEPS.notRemovable);
+    } else if (info.needsFormat) {
       setStep(STEPS.needsFormat);
     } else {
       startExport(exportMode, dir);
@@ -277,6 +282,36 @@ function ExportModal({ onClose, playlistId, initialMode }) {
                 onClick={() => setStep('confirmFormat')}
               >
                 Format to FAT32 &amp; Export
+              </button>
+              <button className="export-cancel-btn" onClick={() => setStep(STEPS.idle)}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === STEPS.notRemovable && usbInfo && (
+          <div className="export-modal-body">
+            <p className="export-needs-format-title">⚠️ Cannot format this drive</p>
+            <p className="export-needs-format-desc">
+              This drive is formatted as <strong>{usbInfo.fsLabel}</strong>, but it could not be
+              confirmed as removable media. To prevent accidentally erasing an internal disk,
+              formatting is only allowed on drives positively identified as removable/external.
+            </p>
+            <p className="export-needs-format-sub">
+              <span className="export-info-label">Device:</span> {usbInfo.device ?? 'unknown'} ·{' '}
+              <span className="export-info-label">Mount:</span> {usbRoot}
+            </p>
+            <p className="export-needs-format-hint">
+              You can still export to this folder as-is, or choose a different, removable drive to
+              format.
+            </p>
+            <div className="export-needs-format-actions">
+              <button
+                className="export-option-btn export-option-btn--secondary"
+                onClick={() => startExport(mode, usbRoot)}
+              >
+                Export Anyway
               </button>
               <button className="export-cancel-btn" onClick={() => setStep(STEPS.idle)}>
                 Cancel

--- a/renderer/src/__tests__/ExportModal.test.jsx
+++ b/renderer/src/__tests__/ExportModal.test.jsx
@@ -131,6 +131,7 @@ describe('ExportModal', () => {
     window.api.openDirDialog.mockResolvedValueOnce('/tmp/usb');
     window.api.checkUsbFormat.mockResolvedValueOnce({
       needsFormat: true,
+      removable: true,
       fs: 'btrfs',
       fsLabel: 'btrfs',
       device: '/dev/sdb1',
@@ -149,6 +150,7 @@ describe('ExportModal', () => {
     window.api.openDirDialog.mockResolvedValueOnce('/tmp/usb');
     window.api.checkUsbFormat.mockResolvedValueOnce({
       needsFormat: true,
+      removable: true,
       fs: 'btrfs',
       fsLabel: 'btrfs',
       device: '/dev/sdb1',
@@ -168,6 +170,7 @@ describe('ExportModal', () => {
     window.api.openDirDialog.mockResolvedValueOnce('/tmp/usb');
     window.api.checkUsbFormat.mockResolvedValueOnce({
       needsFormat: true,
+      removable: true,
       fs: 'btrfs',
       fsLabel: 'btrfs',
       device: '/dev/sdb1',
@@ -194,6 +197,7 @@ describe('ExportModal', () => {
     window.api.openDirDialog.mockResolvedValueOnce('/tmp/usb');
     window.api.checkUsbFormat.mockResolvedValueOnce({
       needsFormat: true,
+      removable: true,
       fs: 'btrfs',
       fsLabel: 'btrfs',
       device: '/dev/sdb1',

--- a/src/__tests__/usbUtils.test.js
+++ b/src/__tests__/usbUtils.test.js
@@ -15,7 +15,7 @@ vi.mock('child_process', () => {
 });
 
 // Import after mocks
-import { detectFilesystem, describeFilesystem } from '../usb/usbUtils.js';
+import { detectFilesystem, describeFilesystem, formatDrive } from '../usb/usbUtils.js';
 
 // ── Platform stub — force Linux branch regardless of host OS ─────────────────
 // usbUtils reads process.platform at call time, so stubbing the global works.
@@ -146,6 +146,116 @@ describe('detectFilesystem — Linux', () => {
 
     expect(result.needsFormat).toBe(false);
     expect(result.fs).toBe('unknown');
+  });
+});
+
+// ── detectFilesystem — removable-media detection ──────────────────────────────
+
+describe('detectFilesystem — removable detection (Linux)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('flags a device with rm:true as removable', async () => {
+    mockExecOutput(
+      makeLsblkJson([{ name: 'sdb1', fstype: 'fat32', mountpoint: '/mnt/usb', rm: true }])
+    );
+
+    const result = await detectFilesystem('/mnt/usb');
+
+    expect(result.removable).toBe(true);
+  });
+
+  it('flags a device with tran:"usb" as removable even if rm is unset', async () => {
+    mockExecOutput(
+      makeLsblkJson([{ name: 'sdb1', fstype: 'fat32', mountpoint: '/mnt/usb', tran: 'usb' }])
+    );
+
+    const result = await detectFilesystem('/mnt/usb');
+
+    expect(result.removable).toBe(true);
+  });
+
+  it('does NOT flag a fixed internal drive (rm:false, tran:"nvme") as removable', async () => {
+    mockExecOutput(
+      makeLsblkJson([
+        { name: 'nvme0n1p1', fstype: 'ext4', mountpoint: '/', rm: false, tran: 'nvme' },
+      ])
+    );
+
+    const result = await detectFilesystem('/');
+
+    expect(result.removable).toBe(false);
+  });
+
+  it('does NOT flag as removable when rm/tran are absent', async () => {
+    mockExecOutput(makeLsblkJson([{ name: 'sda1', fstype: 'ext4', mountpoint: '/mnt/data' }]));
+
+    const result = await detectFilesystem('/mnt/data');
+
+    expect(result.removable).toBe(false);
+  });
+
+  it('inherits parent rm/tran onto a matched child partition', async () => {
+    const json = makeLsblkJson([
+      {
+        name: 'sdb',
+        fstype: null,
+        mountpoint: null,
+        rm: true,
+        tran: 'usb',
+        children: [{ name: 'sdb1', fstype: 'fat32', mountpoint: '/mnt/usb' }],
+      },
+    ]);
+    mockExecOutput(json);
+
+    const result = await detectFilesystem('/mnt/usb');
+
+    expect(result.removable).toBe(true);
+  });
+
+  it('defaults to removable: false when detection fails entirely', async () => {
+    mockExecError(new Error('lsblk not found'));
+
+    const result = await detectFilesystem('/mnt/usb');
+
+    expect(result.removable).toBe(false);
+  });
+});
+
+// ── formatDrive — refuses to format non-removable media ────────────────────────
+
+describe('formatDrive — removable-media safety gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws and never runs the format command when the target is not removable', async () => {
+    // detectFilesystem() re-check inside formatDrive resolves via this lsblk call
+    mockExecOutput(
+      makeLsblkJson([{ name: 'sda1', fstype: 'ext4', mountpoint: '/', rm: false, tran: 'sata' }])
+    );
+
+    const onProgress = vi.fn();
+    await expect(formatDrive('/dev/sda1', '/', onProgress)).rejects.toThrow(/removable/i);
+
+    // Only the removable-check lsblk call should have happened — no mkfs/format call.
+    expect(mockExecAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('proceeds to format when the target is confirmed removable', async () => {
+    mockExecOutput(
+      makeLsblkJson([{ name: 'sdb1', fstype: 'fat32', mountpoint: '/mnt/usb', rm: true }])
+    );
+    // umount call inside formatLinux
+    mockExecOutput('');
+    // mkfs.fat call (pkexec attempt succeeds)
+    mockExecOutput('');
+
+    const onProgress = vi.fn();
+    await expect(formatDrive('/dev/sdb1', '/mnt/usb', onProgress)).resolves.toBeUndefined();
+
+    expect(onProgress).toHaveBeenCalledWith('Format complete.');
   });
 });
 

--- a/src/usb/usbUtils.js
+++ b/src/usb/usbUtils.js
@@ -31,12 +31,24 @@ export async function detectFilesystem(mountPath) {
 async function detectFilesystemWindows(mountPath) {
   // mountPath is like "E:\" or "E:"
   const drive = mountPath.replace(/[/\\]/g, '').replace(/:$/, '');
-  const { stdout } = await execAsync(`fsutil fsinfo volumeinfo ${drive}: 2>&1`, {
-    windowsHide: true,
-  });
-  console.log(`[diag] fsutil volumeinfo ${drive}: stdout:\n${stdout.trim()}`);
-  const fsMatch = stdout.match(/File System Name\s*:\s*(\S+)/i);
-  const fsName = fsMatch ? fsMatch[1].toLowerCase() : 'unknown';
+
+  // Querying the system/boot volume's volumeinfo requires elevation and throws
+  // "Access is denied" for non-admin users. Catch that locally (like the diskfree
+  // and drivetype calls below) instead of letting it propagate to the outer catch
+  // in detectFilesystem() — that outer catch forces needsFormat:false, which would
+  // silently skip the format-safety UI entirely. Falling back to fsName 'unknown'
+  // here still correctly triggers needsFormat below, so the removable check still runs.
+  let fsName = 'unknown';
+  try {
+    const { stdout } = await execAsync(`fsutil fsinfo volumeinfo ${drive}: 2>&1`, {
+      windowsHide: true,
+    });
+    console.log(`[diag] fsutil volumeinfo ${drive}: stdout:\n${stdout.trim()}`);
+    const fsMatch = stdout.match(/File System Name\s*:\s*(\S+)/i);
+    fsName = fsMatch ? fsMatch[1].toLowerCase() : 'unknown';
+  } catch (e) {
+    console.log(`[diag] volumeinfo check failed: ${e.message}`);
+  }
 
   // Log drive size so we can tell if FAT32 format will be rejected (> 32 GB limit)
   try {

--- a/src/usb/usbUtils.js
+++ b/src/usb/usbUtils.js
@@ -24,7 +24,13 @@ export async function detectFilesystem(mountPath) {
   } catch {
     // If detection fails, we cannot confirm the device is removable — default to
     // "not removable" so a failed detection can never accidentally permit formatting.
-    return { fs: 'unknown', device: null, mountPoint: mountPath, needsFormat: false, removable: false };
+    return {
+      fs: 'unknown',
+      device: null,
+      mountPoint: mountPath,
+      needsFormat: false,
+      removable: false,
+    };
   }
 }
 
@@ -155,7 +161,13 @@ async function detectFilesystemLinux(mountPath) {
     };
   }
 
-  return { fs: 'unknown', device: null, mountPoint: mountPath, needsFormat: false, removable: false };
+  return {
+    fs: 'unknown',
+    device: null,
+    mountPoint: mountPath,
+    needsFormat: false,
+    removable: false,
+  };
 }
 
 function findLinuxDevice(devices, mountPath, parentInfo = {}) {

--- a/src/usb/usbUtils.js
+++ b/src/usb/usbUtils.js
@@ -22,8 +22,9 @@ export async function detectFilesystem(mountPath) {
       return await detectFilesystemLinux(mountPath);
     }
   } catch {
-    // If detection fails, assume we can't check — let user proceed with warning
-    return { fs: 'unknown', device: null, mountPoint: mountPath, needsFormat: false };
+    // If detection fails, we cannot confirm the device is removable — default to
+    // "not removable" so a failed detection can never accidentally permit formatting.
+    return { fs: 'unknown', device: null, mountPoint: mountPath, needsFormat: false, removable: false };
   }
 }
 
@@ -55,11 +56,25 @@ async function detectFilesystemWindows(mountPath) {
     console.log(`[diag] drive size check failed: ${e.message}`);
   }
 
+  // Only a drive fsutil positively reports as "Removable Drive" is treated as removable —
+  // internal/fixed drives (including the system drive) must never be formattable.
+  let removable = false;
+  try {
+    const { stdout: driveTypeOut } = await execAsync(`fsutil fsinfo drivetype ${drive}: 2>&1`, {
+      windowsHide: true,
+    });
+    console.log(`[diag] fsutil drivetype ${drive}: ${driveTypeOut.trim()}`);
+    removable = /removable drive/i.test(driveTypeOut);
+  } catch (e) {
+    console.log(`[diag] drivetype check failed: ${e.message}`);
+  }
+
   return {
     fs: fsName,
     device: `${drive}:`,
     mountPoint: mountPath,
     needsFormat: !FAT_FILESYSTEMS.has(fsName),
+    removable,
   };
 }
 
@@ -70,59 +85,97 @@ async function detectFilesystemMac(mountPath) {
   const deviceMatch = stdout.match(/Device Node\s*:\s*(\S+)/i);
   const fsName = fsMatch ? fsMatch[1].toLowerCase().replace('msdos', 'fat32') : 'unknown';
   const device = deviceMatch ? deviceMatch[1] : null;
+
+  // Require positive confirmation of external/removable media. "Device Location: External"
+  // and/or "Removable Media: Removable" are how diskutil reports USB/external drives;
+  // an internal disk (the boot drive included) must never be treated as removable.
+  const locationMatch = stdout.match(/Device Location\s*:\s*(\S+)/i);
+  const removableMatch = stdout.match(/Removable Media\s*:\s*(\S+)/i);
+  const removable =
+    (!!locationMatch && /external/i.test(locationMatch[1])) ||
+    (!!removableMatch && /removable/i.test(removableMatch[1]));
+
   return {
     fs: fsName,
     device,
     mountPoint: mountPath,
     needsFormat: !FAT_FILESYSTEMS.has(fsName),
+    removable,
   };
 }
 
 async function detectFilesystemLinux(mountPath) {
-  // Try lsblk first
+  // Try lsblk first — RM (removable flag) and TRAN (transport, e.g. "usb") let us
+  // positively confirm the device is removable media before it's ever eligible to format.
   try {
-    const { stdout: lsblkOut } = await execAsync(`lsblk -o MOUNTPOINT,FSTYPE,NAME -J 2>/dev/null`);
+    const { stdout: lsblkOut } = await execAsync(
+      `lsblk -o MOUNTPOINT,FSTYPE,NAME,RM,TRAN -J 2>/dev/null`
+    );
     const data = JSON.parse(lsblkOut);
     const device = findLinuxDevice(data.blockdevices, mountPath);
     if (device) {
       const fsName = (device.fstype || 'unknown').toLowerCase();
+      const removable = isRemovableLinuxDevice(device);
       return {
         fs: fsName,
         device: `/dev/${device.name}`,
         mountPoint: mountPath,
         needsFormat: !FAT_FILESYSTEMS.has(fsName),
+        removable,
       };
     }
   } catch {}
 
-  // Fallback: df -T
+  // Fallback: df -T, then check /sys/block/<disk>/removable for the resolved device.
   const { stdout } = await execAsync(`df -T "${mountPath}" 2>&1`);
   const lines = stdout.trim().split('\n');
   if (lines.length >= 2) {
     const parts = lines[1].trim().split(/\s+/);
     const fsName = (parts[1] || 'unknown').toLowerCase();
     const device = parts[0] || null;
+    const removable = await isRemovableLinuxDeviceNode(device);
     return {
       fs: fsName,
       device,
       mountPoint: mountPath,
       needsFormat: !FAT_FILESYSTEMS.has(fsName),
+      removable,
     };
   }
 
-  return { fs: 'unknown', device: null, mountPoint: mountPath, needsFormat: false };
+  return { fs: 'unknown', device: null, mountPoint: mountPath, needsFormat: false, removable: false };
 }
 
-function findLinuxDevice(devices, mountPath, prefix = '') {
+function findLinuxDevice(devices, mountPath, parentInfo = {}) {
   for (const d of devices || []) {
-    const fullName = prefix ? `${prefix}${d.name}` : d.name;
-    if (d.mountpoint === mountPath) return { ...d, name: fullName };
+    const info = { rm: d.rm ?? parentInfo.rm, tran: d.tran ?? parentInfo.tran };
+    if (d.mountpoint === mountPath) return { ...d, ...info };
     if (d.children) {
-      const found = findLinuxDevice(d.children, mountPath, '');
+      const found = findLinuxDevice(d.children, mountPath, info);
       if (found) return found;
     }
   }
   return null;
+}
+
+function isRemovableLinuxDevice(device) {
+  const rm = device.rm;
+  const isRemovableFlag = rm === true || rm === 1 || rm === '1';
+  const isUsbTransport = typeof device.tran === 'string' && device.tran.toLowerCase() === 'usb';
+  return isRemovableFlag || isUsbTransport;
+}
+
+async function isRemovableLinuxDeviceNode(devicePath) {
+  if (!devicePath) return false;
+  // e.g. /dev/sdb1 -> sdb
+  const base = devicePath.replace(/^\/dev\//, '').replace(/[0-9]+$/, '');
+  if (!base) return false;
+  try {
+    const val = fs.readFileSync(`/sys/block/${base}/removable`, 'utf8').trim();
+    return val === '1';
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -131,6 +184,18 @@ function findLinuxDevice(devices, mountPath, prefix = '') {
  */
 export async function formatDrive(device, mountPoint, onProgress) {
   const platform = process.platform;
+
+  // Re-verify removability right before the destructive command runs. This is the
+  // single choke point every format call goes through, so it can't be bypassed by
+  // a stale or forged renderer-supplied device/mountPoint pair.
+  const info = await detectFilesystem(mountPoint);
+  if (!info.removable) {
+    throw new Error(
+      `Refusing to format ${device}: it was not confirmed to be removable media. ` +
+        `Internal/fixed drives cannot be formatted.`
+    );
+  }
+
   onProgress('Starting format…');
 
   if (platform === 'win32') {


### PR DESCRIPTION
## What

`detectFilesystem()` in `src/usb/usbUtils.js` now positively identifies removable/external media per platform and returns a `removable: boolean` field:

- **Windows** — `fsutil fsinfo drivetype <drive>:` must report "Removable Drive".
- **macOS** — `diskutil info` must report `Device Location: External` and/or `Removable Media: Removable`.
- **Linux** — `lsblk -o ...,RM,TRAN` must report `RM=1` or `TRAN=usb` (inherited from the parent disk if the matched partition doesn't carry the flag itself), with a `/sys/block/<disk>/removable` fallback when `lsblk` isn't available.
- Any detection failure defaults to `removable: false` — a failed check can never accidentally permit formatting.

`formatDrive()` re-runs `detectFilesystem(mountPoint)` and throws immediately if `removable` is not `true`, **before** doing anything platform-specific. This is the single choke point every format call passes through, so the check can't be bypassed by a stale or forged `device`/`mountPoint` pair from the renderer.

`renderer/src/ExportModal.jsx` also gets a new `notRemovable` UI state: if a drive needs formatting but isn't confirmed removable, the "Format to FAT32 & Export" button is never shown — only "Export Anyway" (non-destructive) or "Cancel".

## Why

Previously there was no removable-media check anywhere in the format pipeline — `ExportModal.jsx`'s folder picker → `check-usb-format` → `format-usb` chain would format whatever device backed the selected path, including an internal system drive. See #429 for the full trace.

## Testing

- Added 8 new unit tests in `src/__tests__/usbUtils.test.js` covering: `rm`/`tran`-based removable detection, parent→child flag inheritance, detection-failure defaults, and a `formatDrive` test asserting it throws (and never issues the format command) for a non-removable target.
- Full suite: `npx vitest run` → 419/419 passing.
- `npm run lint` clean.

## Still recommended

Per the original issue, real-VM testing across Windows/Linux guests (attempting to format an internal HD should be blocked; a genuine external/removable USB drive should still format successfully) is recommended before release to validate this against real hardware/driver quirks that unit tests can't cover.

Closes #429