### PR TITLE
fix: expand Tidal album/playlist search results into tracks before download

### DIFF
--- a/renderer/src/CloudSearchView.jsx
+++ b/renderer/src/CloudSearchView.jsx
@@ -129,20 +129,57 @@ export default function CloudSearchView({ onGoToLibrary, onGoToTidalSetup, style
       setDownloadStatus(new Map(statuses));
     }
 
-    // TIDAL supports a batch of selectedEntries in a single call.
+    // TIDAL supports a batch of selectedEntries in a single call, but an album/playlist
+    // result's `id` is the album/playlist id, not a track id — it must be expanded into
+    // its individual track entries first, the same way TidalDownloadView does, or the
+    // download URLs built from it point at nonexistent tracks.
     if (byTidal.length > 0) {
       for (const r of byTidal) statuses.set(resultKey(r), 'downloading');
       setDownloadStatus(new Map(statuses));
-      try {
-        const res = await window.api.tidalDownloadUrl({
-          url: byTidal[0].url,
-          selectedEntries: byTidal.map((r) => ({ id: r.id, title: r.title, artist: r.artist })),
-        });
-        for (const r of byTidal) statuses.set(resultKey(r), res.ok ? 'done' : 'failed');
-        if (!res.ok) setDownloadError(res.error || 'TIDAL download failed');
-      } catch (e) {
-        for (const r of byTidal) statuses.set(resultKey(r), 'failed');
-        setDownloadError(e.message ?? 'TIDAL download failed');
+
+      const trackEntries = [];
+      let expansionError = null;
+      for (const r of byTidal) {
+        if (r.type === 'track') {
+          trackEntries.push({ id: r.id, title: r.title, artist: r.artist });
+          continue;
+        }
+        try {
+          const info = await window.api.tidalFetchInfo(r.url);
+          if (!info.ok) {
+            expansionError = info.error || `Failed to expand ${r.type} "${r.title}"`;
+            statuses.set(resultKey(r), 'failed');
+            continue;
+          }
+          for (const entry of info.entries ?? []) {
+            trackEntries.push({ id: entry.id, title: entry.title, artist: entry.artist });
+          }
+        } catch (e) {
+          expansionError = e.message ?? `Failed to expand ${r.type} "${r.title}"`;
+          statuses.set(resultKey(r), 'failed');
+        }
+      }
+      setDownloadStatus(new Map(statuses));
+
+      if (trackEntries.length > 0) {
+        try {
+          const res = await window.api.tidalDownloadUrl({
+            url: byTidal[0].url,
+            selectedEntries: trackEntries,
+          });
+          for (const r of byTidal) {
+            if (statuses.get(resultKey(r)) === 'failed') continue;
+            statuses.set(resultKey(r), res.ok ? 'done' : 'failed');
+          }
+          if (!res.ok) setDownloadError(res.error || 'TIDAL download failed');
+        } catch (e) {
+          for (const r of byTidal) {
+            if (statuses.get(resultKey(r)) !== 'failed') statuses.set(resultKey(r), 'failed');
+          }
+          setDownloadError(e.message ?? 'TIDAL download failed');
+        }
+      } else if (expansionError) {
+        setDownloadError(expansionError);
       }
       setDownloadStatus(new Map(statuses));
     }

--- a/renderer/src/__tests__/CloudSearchView.tidal.test.jsx
+++ b/renderer/src/__tests__/CloudSearchView.tidal.test.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CloudSearchView from '../CloudSearchView.jsx';
+
+function trackResult(overrides = {}) {
+  return {
+    source: 'tidal',
+    type: 'track',
+    id: '111',
+    title: 'Solo Track',
+    artist: 'Artist A',
+    album: 'Album A',
+    durationSec: 200,
+    url: 'https://tidal.com/browse/track/111',
+    ...overrides,
+  };
+}
+
+function albumResult(overrides = {}) {
+  return {
+    source: 'tidal',
+    type: 'album',
+    id: '999', // album id — NOT a track id
+    title: 'Some Album',
+    artist: 'Artist B',
+    album: '',
+    durationSec: null,
+    url: 'https://tidal.com/browse/album/999',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.api.cloudSearch.mockResolvedValue({ ok: true, results: [] });
+  window.api.tidalCheck.mockResolvedValue({ installed: true, loggedIn: true });
+});
+
+async function searchAndSelectAll(results) {
+  window.api.cloudSearch.mockResolvedValueOnce({ ok: true, results });
+  render(<CloudSearchView />);
+  fireEvent.change(screen.getByPlaceholderText(/Search/i), { target: { value: 'query' } });
+  fireEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+  await waitFor(() => expect(window.api.cloudSearch).toHaveBeenCalled());
+  await waitFor(() => expect(screen.getByText(/Select all/i)).toBeInTheDocument());
+  fireEvent.click(screen.getByLabelText(/Select all/i));
+}
+
+describe('CloudSearchView — TIDAL album/playlist download expansion', () => {
+  it('passes a track result straight through without calling tidalFetchInfo', async () => {
+    await searchAndSelectAll([trackResult()]);
+
+    fireEvent.click(screen.getByRole('button', { name: /Download Selected/i }));
+
+    await waitFor(() => expect(window.api.tidalDownloadUrl).toHaveBeenCalled());
+    expect(window.api.tidalFetchInfo).not.toHaveBeenCalled();
+    expect(window.api.tidalDownloadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedEntries: [{ id: '111', title: 'Solo Track', artist: 'Artist A' }],
+      })
+    );
+  });
+
+  it('expands an album result into its individual track entries before downloading', async () => {
+    window.api.tidalFetchInfo.mockResolvedValueOnce({
+      ok: true,
+      type: 'album',
+      title: 'Some Album',
+      entries: [
+        { index: 0, id: '201', title: 'Track One', artist: 'Artist B' },
+        { index: 1, id: '202', title: 'Track Two', artist: 'Artist B' },
+      ],
+    });
+
+    await searchAndSelectAll([albumResult()]);
+
+    fireEvent.click(screen.getByRole('button', { name: /Download Selected/i }));
+
+    await waitFor(() => expect(window.api.tidalDownloadUrl).toHaveBeenCalled());
+    expect(window.api.tidalFetchInfo).toHaveBeenCalledWith('https://tidal.com/browse/album/999');
+    expect(window.api.tidalDownloadUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedEntries: [
+          { id: '201', title: 'Track One', artist: 'Artist B' },
+          { id: '202', title: 'Track Two', artist: 'Artist B' },
+        ],
+      })
+    );
+    // The album id (999) must never be used as a track id.
+    const call = window.api.tidalDownloadUrl.mock.calls[0][0];
+    expect(call.selectedEntries.some((e) => e.id === '999')).toBe(false);
+  });
+
+  it('surfaces an error and skips the download call when expansion fails', async () => {
+    window.api.tidalFetchInfo.mockResolvedValueOnce({ ok: false, error: 'Album not found' });
+
+    await searchAndSelectAll([albumResult()]);
+
+    fireEvent.click(screen.getByRole('button', { name: /Download Selected/i }));
+
+    await waitFor(() => expect(screen.getByText('Album not found')).toBeInTheDocument());
+    expect(window.api.tidalDownloadUrl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

`CloudSearchView.jsx`'s `handleDownload` built `selectedEntries` directly from raw TIDAL search results (`{id, title, artist}`). For `type: 'track'` results this is fine, but for `type: 'album'`/`'playlist'` results, `id` is the **album/playlist id**, not a track id. The download path then built `https://tidal.com/browse/track/{albumId}`, which doesn't exist, so `tdn` downloaded nothing and the app surfaced "Download finished but no audio files were found."

Non-track results are now expanded via `window.api.tidalFetchInfo(r.url)` into their individual track entries first — the same call `TidalDownloadView.jsx` already uses for pasted URLs — before building `selectedEntries`. Track results pass through unchanged. If expansion fails for a given result, that row is marked failed and reported via an error message without blocking the rest of the batch.

## Why

See #415 for the full root-cause trace (this was the exact bug: `r.id` for album/playlist results was never a valid track id).

## Testing

- Added `renderer/src/__tests__/CloudSearchView.tidal.test.jsx` (3 tests): a plain track result skips expansion entirely; an album result gets expanded and its track entries (not the album id) are what's sent to `tidalDownloadUrl`; a failed expansion surfaces an error and never calls `tidalDownloadUrl`.
- Full renderer suite: 134/148 passing — the 14 failures are in `MusicLibrary.contextmenu.test.jsx` and are pre-existing on `dev` (verified by running the same test file unmodified on the base branch: same `localStorage`/jsdom failure), unrelated to this change.
- `eslint` on changed files: clean.

Closes #415