### PR TITLE
Fix missing AppImage icon on Linux/Wayland (Arch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.23",
   "description": "DJ-focused music library manager",
   "main": "src/main.js",
+  "desktopName": "dj_manager.desktop",
   "scripts": {
     "react": "cd renderer && npm run dev",
     "electron": "wait-on file:.dev-url && electron .",
@@ -53,7 +54,8 @@
       ],
       "category": "Audio",
       "extraResources": [],
-      "artifactName": "${productName}-${version}-Linux.${ext}"
+      "artifactName": "${productName}-${version}-Linux.${ext}",
+      "syncDesktopName": true
     },
     "mac": {
       "target": [

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,11 @@ import { app, BrowserWindow, ipcMain, dialog, Menu, MenuItem, shell } from 'elec
 app.name = 'Dj Manager';
 
 if (process.platform === 'linux') {
+  // Must match `desktopName` in package.json / the packaged .desktop file's basename —
+  // this is what Wayland/X11 use to associate the running window with its .desktop
+  // entry (and therefore its icon). Without it, desktop environments show a generic
+  // icon since they can't resolve the app_id/WM_CLASS Electron picks by default.
+  app.setDesktopName('dj_manager.desktop');
   app.disableHardwareAcceleration();
   if (process.env.WAYLAND_DISPLAY) {
     app.commandLine.appendSwitch('ozone-platform', 'wayland');


### PR DESCRIPTION
## Summary
- Closes #417

## Root cause
Electron determines its Wayland app_id / X11 `WM_CLASS` from the `desktopName` field in `package.json` at runtime (`app.setDesktopName()` / [electron.d.ts:1706-1718](https://github.com/electron/electron)). We never set this field, so Electron falls back to inferring a name that doesn't match the `.desktop` file electron-builder generates for the AppImage (`StartupWMClass` defaults to `productName`, "DJ Manager"). Desktop environments — especially under Wayland, which resolves icons via app-id matching rather than raw X11 `WM_CLASS` — can't associate the running window with the installed `.desktop` entry, so they fall back to a generic icon.

This exact failure mode and its fix are called out directly in the installed `electron-builder` version's source (`LinuxTargetHelper.js`) and in Electron's own type declarations for `setDesktopName`.

## Fix
- `package.json`: added `"desktopName": "dj_manager.desktop"` and `"build.linux.syncDesktopName": true`, so electron-builder's generated `StartupWMClass` in the AppImage's `.desktop` file matches.
- `src/main.js`: added an explicit `app.setDesktopName('dj_manager.desktop')` call (Linux only, before `ready`) so dev/unpacked Electron runs are also consistent, not just packaged AppImages.

## Test plan
- [x] `npm run lint` — clean.
- [x] `npx vitest run` — 411/411 pass, no regressions.
- [x] `npx prettier --check package.json src/main.js` — clean.
- [ ] Not verified on an actual Arch + Wayland session (no VM available in this environment) — the config change matches electron-builder's own documented root cause/fix for this exact symptom, but real-world confirmation on GNOME/KDE Wayland would be good before closing.