### PR TITLE
Search bar: fix input alignment, add live highlighting, chip editing, and keyboard nav

### DIFF
--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -813,8 +813,12 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   // Keyboard shortcuts
   useEffect(() => {
     const onKeyDown = async (e) => {
-      // Ctrl+A — select all tracks including unloaded ones
+      // Ctrl+A — select all tracks including unloaded ones (but let native
+      // select-all-text win when the user is typing in an input/textarea,
+      // e.g. the search box)
       if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
+        const target = e.target;
+        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
         e.preventDefault();
         const { filters, remaining } = parseQuery(search);
         const structuredFilters = filters.filter((f) => f.field !== '_text');

--- a/renderer/src/SearchBar.css
+++ b/renderer/src/SearchBar.css
@@ -5,13 +5,6 @@
 
 /* ── chips ─────────────────────────────────────────────────────────────────── */
 
-.search-bar__chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  margin-bottom: 6px;
-}
-
 .search-chip {
   display: inline-flex;
   align-items: center;
@@ -22,6 +15,7 @@
   padding: 2px 6px;
   font-size: 12px;
   line-height: 1.6;
+  white-space: nowrap;
 }
 
 .search-chip__field {
@@ -59,6 +53,27 @@
   color: #cf9e5e;
 }
 
+/* plain free-text terms (unstructured, mid-query) */
+.search-chip--text {
+  border-color: #444;
+  background: #1a1a1a;
+}
+.search-chip--text .search-chip__value {
+  color: #ccc;
+}
+
+/* Applied alongside .search-chip / .search-chip--{field} so an editing chip
+   keeps the same box (border, background, padding) as its static form —
+   this only resets the input-specific bits the chip classes don't cover. */
+.search-chip__edit-input {
+  outline: none;
+  color: #fff;
+  font-family: inherit;
+  margin: 0;
+  min-width: 20px;
+  field-sizing: content;
+}
+
 .search-chip__remove {
   background: none;
   border: none;
@@ -78,24 +93,101 @@
 .search-bar__input-row {
   position: relative;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-}
-
-.search-bar__input {
-  width: 100%;
-  padding: 8px 30px 8px 8px;
+  gap: 6px;
+  padding: 6px 30px 6px 8px;
   border: 1px solid #333;
   border-radius: 4px;
   background-color: #222;
+}
+
+.search-bar__input-row:focus-within {
+  border-color: #4a7a4a;
+}
+
+/* Live-wrap fills the row (so the placeholder has room and the row stays
+   click-to-focus) until the user types a character, at which point it
+   becomes a real bordered box that grows/shrinks with the typed text —
+   the same visual language as a committed .search-chip. */
+.search-bar__live-wrap {
+  position: relative;
+  display: inline-grid;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 80px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+
+.search-bar__live-wrap--active {
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 2px 6px;
+  border-color: #3a5a3a;
+  background: #1e2e1e;
+}
+
+.search-bar__live-wrap--active.search-bar__live-wrap--bpm {
+  border-color: #5a3a1a;
+  background: #2e1e0e;
+}
+
+.search-bar__live-wrap--active.search-bar__live-wrap--key {
+  border-color: #5a4a7a;
+  background: #1e1a2e;
+}
+
+.search-bar__highlight {
+  grid-area: 1 / 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 18px;
+  white-space: pre;
+  pointer-events: none;
+}
+
+.search-bar__hl-field {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.search-bar__hl-op {
+  color: #7ab;
+  font-style: italic;
+}
+
+.search-bar__hl-value,
+.search-bar__hl-plain,
+.search-bar__hl-ws {
   color: #fff;
+}
+
+.search-bar__input {
+  grid-area: 1 / 1;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: transparent;
+  caret-color: #fff;
   outline: none;
   font-size: 13px;
   font-family: inherit;
-  box-sizing: border-box;
+  line-height: 18px;
 }
 
-.search-bar__input:focus {
-  border-color: #4a7a4a;
+/* Once the box is active, the input shrinks/grows to fit exactly what's
+   been typed instead of stretching to fill the row. */
+.search-bar__live-wrap--active .search-bar__input {
+  field-sizing: content;
+  width: auto;
 }
 
 .search-bar__clear {

--- a/renderer/src/SearchBar.jsx
+++ b/renderer/src/SearchBar.jsx
@@ -1,6 +1,16 @@
-import { useState, useRef } from 'react';
-import { parseQuery, getSuggestions, removeFilter, FIELDS, CAMELOT_KEYS } from './searchParser.js';
+import { useState, useRef, useEffect } from 'react';
+import {
+  parseClause,
+  getSuggestions,
+  getOpsForField,
+  isCompleteClause,
+  FIELDS,
+} from './searchParser.js';
 import './SearchBar.css';
+
+// Field accent colors, matched to the .search-chip--{field} rules in SearchBar.css
+const FIELD_ACCENT = { bpm: '#cf9e5e', key: '#b07ecf' };
+const DEFAULT_FIELD_ACCENT = '#7ecf7e';
 
 const OP_LABELS = {
   is: 'is',
@@ -16,6 +26,84 @@ const OP_LABELS = {
   matches: 'matches',
 };
 
+// Splits the query on " AND " while keeping the delimiter, so every character
+// of `value` is accounted for. Everything before the last delimiter is a
+// "confirmed" clause rendered as a removable chip; the last clause is always
+// the live, plain-text portion that stays in the real input — even once it
+// happens to parse into a valid filter — so a clause only locks into a chip
+// once the user deliberately moves on to a new one (types "AND").
+const AND_RE = /(\s+AND\s+)/i;
+
+function splitLastClause(value) {
+  if (!value) return { priorClauses: [], lastClauseRaw: '' };
+  const parts = value.split(AND_RE);
+  const lastClauseRaw = parts[parts.length - 1] ?? '';
+  const priorClauses = [];
+  for (let i = 0; i < parts.length - 1; i += 2) {
+    if (parts[i] !== '') priorClauses.push(parts[i]);
+  }
+  return { priorClauses, lastClauseRaw };
+}
+
+// Tokenizes the clause currently being typed into colorable segments, so the
+// live input can be highlighted the same way a committed chip would be —
+// without waiting for " AND " to lock it in. Segment text is never trimmed or
+// reordered: concatenating every segment's `text` reproduces `raw` exactly,
+// which keeps the invisible input's characters aligned with the highlight
+// overlay drawn behind it.
+function tokenizeLiveClause(raw) {
+  if (!raw) return { fieldKey: null, segments: [] };
+  const upper = raw.toUpperCase();
+
+  for (const [fieldKey, fieldDef] of Object.entries(FIELDS)) {
+    const label = fieldDef.label;
+    if (!upper.startsWith(label)) continue;
+    const afterField = raw.slice(label.length);
+    // require whitespace after label so "ARTIST" doesn't match "ART"
+    if (afterField.length > 0 && !/^\s/.test(afterField)) continue;
+
+    const fieldText = raw.slice(0, label.length);
+    const accent = FIELD_ACCENT[fieldKey] ?? DEFAULT_FIELD_ACCENT;
+    const wsAfterField = afterField.match(/^\s*/)[0];
+    const afterWs = afterField.slice(wsAfterField.length);
+    const afterWsUpper = afterWs.toUpperCase();
+
+    const ops = getOpsForField(fieldKey);
+    for (const op of ops) {
+      const opUpper = op.toUpperCase();
+      if (!afterWsUpper.startsWith(opUpper)) continue;
+      const afterOp = afterWs.slice(op.length);
+      if (afterOp.length > 0 && !/^\s/.test(afterOp)) continue;
+
+      const opText = afterWs.slice(0, op.length);
+      const wsAfterOp = afterOp.match(/^\s*/)[0];
+      const valueText = afterOp.slice(wsAfterOp.length);
+
+      return {
+        fieldKey,
+        segments: [
+          { text: fieldText, cls: 'field', color: accent },
+          { text: wsAfterField, cls: 'ws' },
+          { text: opText, cls: 'op' },
+          { text: wsAfterOp, cls: 'ws' },
+          { text: valueText, cls: 'value' },
+        ].filter((s) => s.text.length > 0),
+      };
+    }
+
+    // Field matched but no complete operator yet — color the field, leave the rest plain.
+    return {
+      fieldKey,
+      segments: [
+        { text: fieldText, cls: 'field', color: accent },
+        { text: afterField, cls: 'plain' },
+      ].filter((s) => s.text.length > 0),
+    };
+  }
+
+  return { fieldKey: null, segments: [{ text: raw, cls: 'plain' }] };
+}
+
 function ChipValue({ filter }) {
   if (filter.op === 'range')
     return (
@@ -29,21 +117,62 @@ function ChipValue({ filter }) {
 export default function SearchBar({ value, onChange }) {
   const [showDropdown, setShowDropdown] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [editingIndex, setEditingIndex] = useState(null);
   const inputRef = useRef(null);
+  const editInputRef = useRef(null);
+  const cancelEditRef = useRef(false);
+  const skipNextBlurRef = useRef(false);
+  // 'select' | 'start' | 'end' | 'live-start' — where the caret should land
+  // the next time editingIndex changes, consumed once by the effect below.
+  const editCaretRef = useRef('select');
 
-  const { filters } = parseQuery(value);
-  const structuredFilters = filters.filter((f) => f.field !== '_text');
+  const { priorClauses, lastClauseRaw } = splitLastClause(value);
+  const chips = priorClauses.map((raw) => {
+    const filter = parseClause(raw);
+    return filter && filter.field !== '_text'
+      ? { kind: 'field', filter, raw }
+      : { kind: 'text', raw };
+  });
 
   // Suggestions are keyed to the full current input value
   const suggestions = showDropdown ? getSuggestions(value) : [];
+  const { fieldKey: draftField, segments: liveSegments } = tokenizeLiveClause(lastClauseRaw);
+
+  // Places focus/caret whenever editingIndex changes — covers double-click
+  // entry as well as arrow-key navigation between chips (and back out into
+  // the live input), which move editingIndex programmatically.
+  useEffect(() => {
+    if (editingIndex === null) {
+      if (editCaretRef.current === 'live-start') {
+        editCaretRef.current = 'select';
+        inputRef.current?.focus();
+        inputRef.current?.setSelectionRange(0, 0);
+      }
+      return;
+    }
+    const el = editInputRef.current;
+    if (!el) return;
+    el.focus();
+    if (editCaretRef.current === 'start') {
+      el.setSelectionRange(0, 0);
+    } else if (editCaretRef.current === 'end') {
+      const len = el.value.length;
+      el.setSelectionRange(len, len);
+    } else {
+      el.select();
+    }
+    editCaretRef.current = 'select';
+  }, [editingIndex]);
 
   // ── event handlers ──────────────────────────────────────────────────────────
 
   const handleChange = (e) => {
-    onChange(e.target.value);
+    const prefix = value.slice(0, value.length - lastClauseRaw.length);
+    onChange(prefix + e.target.value);
     setActiveIndex(0);
     setShowDropdown(true);
   };
+
   const applySuggestion = (s) => {
     onChange(s.insertText);
     setActiveIndex(0);
@@ -51,26 +180,102 @@ export default function SearchBar({ value, onChange }) {
     inputRef.current?.focus();
   };
 
-  const handleKeyDown = (e) => {
-    if (!showDropdown || suggestions.length === 0) return;
-
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setActiveIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === 'Tab' || (e.key === 'Enter' && suggestions[activeIndex])) {
-      e.preventDefault();
-      applySuggestion(suggestions[activeIndex]);
-    } else if (e.key === 'Escape') {
-      setShowDropdown(false);
-    }
+  const handleRemoveChip = (index) => {
+    const remaining = priorClauses.filter((_, i) => i !== index);
+    const prefix = remaining.length ? remaining.join(' AND ') + ' AND ' : '';
+    onChange(prefix + lastClauseRaw);
+    inputRef.current?.focus();
   };
 
-  const handleRemove = (index) => {
-    onChange(removeFilter(value, index));
-    inputRef.current?.focus();
+  // Double-clicking a committed chip re-opens it as editable text. Committing
+  // (blur, Enter, or Tab) rewrites just that clause in place; clearing it out
+  // entirely removes the chip, same as the × button. Split from commitEdit so
+  // arrow-key navigation can save the current chip and move editingIndex to
+  // an adjacent one in the same gesture, without the "close to null" step.
+  const saveEdit = (index, rawText) => {
+    const trimmed = rawText.trim();
+    const updated = [...priorClauses];
+    if (trimmed) {
+      updated[index] = trimmed;
+    } else {
+      updated.splice(index, 1);
+    }
+    const prefix = updated.length ? updated.join(' AND ') + ' AND ' : '';
+    onChange(prefix + lastClauseRaw);
+  };
+
+  const commitEdit = (index, rawText) => {
+    saveEdit(index, rawText);
+    setEditingIndex(null);
+  };
+
+  // Locks the current live clause in as its own block, same as if the user
+  // had typed " AND " — a fresh empty clause starts right after.
+  const commitClause = () => {
+    onChange(value + ' AND ');
+    setActiveIndex(0);
+    setShowDropdown(true);
+  };
+
+  const handleKeyDown = (e) => {
+    // Backspace on an empty live clause deletes the last confirmed chip.
+    if (e.key === 'Backspace' && lastClauseRaw === '' && chips.length > 0) {
+      e.preventDefault();
+      handleRemoveChip(chips.length - 1);
+      return;
+    }
+
+    // ArrowLeft at the very start of the live input steps back into the
+    // last committed chip, opening it for editing with the caret at its end.
+    if (
+      e.key === 'ArrowLeft' &&
+      chips.length > 0 &&
+      e.currentTarget.selectionStart === 0 &&
+      e.currentTarget.selectionEnd === 0
+    ) {
+      e.preventDefault();
+      editCaretRef.current = 'end';
+      setEditingIndex(chips.length - 1);
+      return;
+    }
+
+    // Space auto-commits the clause once it's unambiguous (a complete
+    // number, range, or Camelot key) — text values can contain spaces
+    // mid-typing, so those only commit via " AND " or Tab.
+    if (e.key === ' ' && isCompleteClause(lastClauseRaw)) {
+      e.preventDefault();
+      commitClause();
+      return;
+    }
+
+    if (showDropdown && suggestions.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === 'Tab' || (e.key === 'Enter' && suggestions[activeIndex])) {
+        e.preventDefault();
+        applySuggestion(suggestions[activeIndex]);
+        return;
+      }
+      if (e.key === 'Escape') {
+        setShowDropdown(false);
+        return;
+      }
+    }
+
+    // Tab with nothing left to autocomplete commits whatever's typed as its
+    // own block — a structured filter chip, or a free-text chip.
+    if (e.key === 'Tab' && lastClauseRaw.trim() !== '') {
+      e.preventDefault();
+      commitClause();
+    }
   };
 
   const handleClear = () => {
@@ -83,46 +288,144 @@ export default function SearchBar({ value, onChange }) {
 
   return (
     <div className="search-bar">
-      {/* ── parsed filter chips ── */}
-      {structuredFilters.length > 0 && (
-        <div className="search-bar__chips">
-          {structuredFilters.map((filter, i) => (
-            <span key={i} className={`search-chip search-chip--${filter.field}`}>
-              <span className="search-chip__field">
-                {FIELDS[filter.field]?.label ?? filter.field.toUpperCase()}
-              </span>
-              <span className="search-chip__op">{OP_LABELS[filter.op] ?? filter.op}</span>
-              <span className="search-chip__value">
-                <ChipValue filter={filter} />
-              </span>
+      {/* ── text input row ── */}
+      <div
+        className="search-bar__input-row"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) inputRef.current?.focus();
+        }}
+      >
+        {chips.map((chip, i) =>
+          i === editingIndex ? (
+            <input
+              key={i}
+              ref={editInputRef}
+              className={
+                (chip.kind === 'field'
+                  ? `search-chip search-chip--${chip.filter.field}`
+                  : 'search-chip search-chip--text') + ' search-chip__edit-input'
+              }
+              defaultValue={chip.raw.trim()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === 'Tab') {
+                  e.preventDefault();
+                  e.currentTarget.blur();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelEditRef.current = true;
+                  e.currentTarget.blur();
+                } else if (
+                  e.key === 'ArrowLeft' &&
+                  i > 0 &&
+                  e.currentTarget.selectionStart === 0 &&
+                  e.currentTarget.selectionEnd === 0
+                ) {
+                  e.preventDefault();
+                  skipNextBlurRef.current = true;
+                  saveEdit(i, e.currentTarget.value);
+                  editCaretRef.current = 'end';
+                  setEditingIndex(i - 1);
+                } else if (
+                  e.key === 'ArrowRight' &&
+                  e.currentTarget.selectionStart === e.currentTarget.value.length &&
+                  e.currentTarget.selectionEnd === e.currentTarget.value.length
+                ) {
+                  e.preventDefault();
+                  skipNextBlurRef.current = true;
+                  saveEdit(i, e.currentTarget.value);
+                  if (i < chips.length - 1) {
+                    editCaretRef.current = 'start';
+                    setEditingIndex(i + 1);
+                  } else {
+                    editCaretRef.current = 'live-start';
+                    setEditingIndex(null);
+                  }
+                }
+              }}
+              onBlur={(e) => {
+                if (skipNextBlurRef.current) {
+                  skipNextBlurRef.current = false;
+                  return;
+                }
+                if (cancelEditRef.current) {
+                  cancelEditRef.current = false;
+                  setEditingIndex(null);
+                  return;
+                }
+                commitEdit(i, e.target.value);
+              }}
+            />
+          ) : (
+            <span
+              key={i}
+              className={
+                chip.kind === 'field'
+                  ? `search-chip search-chip--${chip.filter.field}`
+                  : 'search-chip search-chip--text'
+              }
+              onDoubleClick={() => setEditingIndex(i)}
+            >
+              {chip.kind === 'field' ? (
+                <>
+                  <span className="search-chip__field">
+                    {FIELDS[chip.filter.field]?.label ?? chip.filter.field.toUpperCase()}
+                  </span>
+                  <span className="search-chip__op">
+                    {OP_LABELS[chip.filter.op] ?? chip.filter.op}
+                  </span>
+                  <span className="search-chip__value">
+                    <ChipValue filter={chip.filter} />
+                  </span>
+                </>
+              ) : (
+                <span className="search-chip__value">{chip.raw.trim()}</span>
+              )}
               <button
                 className="search-chip__remove"
-                onClick={() => handleRemove(i)}
+                onClick={() => handleRemoveChip(i)}
                 aria-label="Remove filter"
               >
                 ×
               </button>
             </span>
-          ))}
-        </div>
-      )}
+          )
+        )}
 
-      {/* ── text input row ── */}
-      <div className="search-bar__input-row">
-        <input
-          ref={inputRef}
-          className="search-bar__input search-input"
-          placeholder="Search… or try: GENRE is Techno AND BPM in range 130-140 AND KEY adjacent 8A"
-          value={value}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          onFocus={() => {
-            if (value) setShowDropdown(true);
-          }}
-          onBlur={() => setTimeout(() => setShowDropdown(false), 150)}
-          spellCheck={false}
-          autoComplete="off"
-        />
+        <span
+          className={[
+            'search-bar__live-wrap',
+            lastClauseRaw ? 'search-bar__live-wrap--active' : '',
+            lastClauseRaw && draftField ? `search-bar__live-wrap--${draftField}` : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          <span className="search-bar__highlight" aria-hidden="true">
+            {liveSegments.map((seg, i) => (
+              <span
+                key={i}
+                className={`search-bar__hl-${seg.cls}`}
+                style={seg.color ? { color: seg.color } : undefined}
+              >
+                {seg.text}
+              </span>
+            ))}
+          </span>
+          <input
+            ref={inputRef}
+            className="search-bar__input search-input"
+            placeholder="Search… or try: GENRE is Techno AND BPM in range 130-140 AND KEY adjacent 8A"
+            value={lastClauseRaw}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onFocus={() => {
+              if (value) setShowDropdown(true);
+            }}
+            onBlur={() => setTimeout(() => setShowDropdown(false), 150)}
+            spellCheck={false}
+            autoComplete="off"
+          />
+        </span>
         {value && (
           <button className="search-bar__clear" onClick={handleClear} aria-label="Clear search">
             ×

--- a/renderer/src/TopBar.css
+++ b/renderer/src/TopBar.css
@@ -1,5 +1,5 @@
 .top-bar {
-  height: 68px;
+  min-height: 68px;
   flex-shrink: 0;
   background: #111;
   border-bottom: 1px solid #2a2a2a;

--- a/renderer/src/searchParser.js
+++ b/renderer/src/searchParser.js
@@ -78,7 +78,7 @@ export function camelotMatches(key) {
  * Returns null when the clause is empty or doesn't start with a known field.
  * Returns { field: '_text', ... } for unstructured text.
  */
-function parseClause(clause) {
+export function parseClause(clause) {
   const c = clause.trim();
   if (!c) return null;
 
@@ -112,6 +112,28 @@ function parseClause(clause) {
 
   // No structured match — free-text fallback
   return { field: '_text', op: 'contains', value: c };
+}
+
+/**
+ * Whether `raw` is already an unambiguous, complete filter clause (a full
+ * number, range, or Camelot key). Used to auto-commit a clause into a chip
+ * as soon as it's finished, without waiting for " AND ". Text-field values
+ * are deliberately excluded since they can legitimately contain spaces
+ * mid-typing (e.g. "GENRE is Deep House").
+ */
+export function isCompleteClause(raw) {
+  const filter = parseClause(raw);
+  if (!filter || filter.field === '_text') return false;
+  const fieldDef = FIELDS[filter.field];
+  if (!fieldDef || fieldDef.type === 'text') return false;
+
+  if (fieldDef.type === 'key') {
+    return CAMELOT_KEYS.includes(String(filter.value).trim().toLowerCase());
+  }
+
+  // number field
+  if (filter.op === 'range') return true; // parseClause already validated the full pattern
+  return /^-?\d+\.?\d*$/.test(String(filter.value).trim());
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -254,6 +276,9 @@ function getValueHints(fieldKey, op, base, partialValue = '') {
     // Don't flood with all 24 keys — wait until the user starts typing
     if (!partialValue) return [];
     const partial = partialValue.toLowerCase();
+    // Already a complete, valid key — nothing left to suggest, and offering
+    // one would let Enter/Tab silently overwrite what was just typed.
+    if (CAMELOT_KEYS.includes(partial)) return [];
     const desc = {
       is: 'exact — e.g. 8A',
       adjacent: 'energy shift — e.g. 8A',
@@ -266,6 +291,18 @@ function getValueHints(fieldKey, op, base, partialValue = '') {
       insertText: base + k.toUpperCase(),
       description: desc[op],
     }));
+  }
+
+  // Once the user has typed a syntactically complete value, stop suggesting
+  // the generic example — accepting it via Enter/Tab would silently replace
+  // what they actually typed with the placeholder hint.
+  if (partialValue) {
+    const trimmed = partialValue.trim();
+    const isComplete =
+      op === 'in range'
+        ? /^-?\d+\.?\d*\s*[-–]\s*-?\d+\.?\d*$/.test(trimmed)
+        : /^-?\d+\.?\d*$/.test(trimmed);
+    if (isComplete) return [];
   }
 
   const hints = {


### PR DESCRIPTION
Closes #418

## What
Started as the search-input misalignment fix (`.top-bar` `height` → `min-height`) and grew to cover the search bar's filter-chip UX end to end:

- **Live syntax highlighting**: the clause currently being typed is now colorized the same way a committed chip is (field/op/value), via a transparent-input-over-colored-overlay technique, and grows into a bordered "chip-like" box as you type (`field-sizing: content` + CSS Grid stacking).
- **Auto-commit on space/tab**: once a clause is unambiguous and complete (a full number, range, or Camelot key), pressing Space or Tab locks it into its own chip immediately instead of waiting for `AND`. Text-field values are excluded since they can legitimately contain spaces mid-typing.
- **Caret-misalignment fix**: the overlay input's caret was drifting one character early on longer values, root-caused to missing `margin/padding/border: 0` resets letting the UA default input padding desync it from the overlay text.
- **Edit a committed chip**: double-click a chip to edit its raw text inline; Enter/Tab/blur saves, Escape cancels, clearing it out removes the chip.
- **Arrow-key navigation**: ArrowLeft from the start of the live input steps back into editing the last chip; ArrowLeft/ArrowRight inside a chip's edit box move to the previous/next chip (or back out into the live input past the last one).
- **Ctrl+A fix** (`MusicLibrary.jsx`): Ctrl+A was always intercepted as "select all tracks," even while typing in the search box — now it only fires when focus isn't in an input/textarea, so native text selection works in the search bar.

## Why
The original misalignment bug and the deeper UX gaps (no visual feedback while typing a clause, no way to fix a typo in a committed chip, keyboard navigation dead-ending at the live input) all live in the same component and were reported together during manual testing.

## How
See commit-by-commit diffs in `renderer/src/TopBar.css`, `renderer/src/SearchBar.jsx`, `renderer/src/SearchBar.css`, `renderer/src/searchParser.js`, and `renderer/src/MusicLibrary.jsx`.

## Test Plan
- [x] `npx eslint src/SearchBar.jsx src/SearchBar.css src/searchParser.js src/MusicLibrary.jsx` — clean
- [x] `npx vitest run` (renderer) — 145/145 passing
- [x] `npx prettier --check` on all touched files — clean
- [ ] Manual/visual verification in the dev build — this renderer has no browser fallback (`window.api` only exists under Electron), so the chip highlighting, growing-box behavior, and arrow-key navigation need a human pass in `npm run dev`.
