### PR TITLE
Clear search when re-clicking the active tab (logo, Music, or any playlist)

### DIFF
--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -16,6 +16,10 @@ import { TidalDownloadProvider } from './TidalDownloadContext.jsx';
 import { DepsOverlay } from './DepsOverlay.jsx';
 import './App.css';
 
+// Tabs that don't use the shared MusicLibrary search bar — clicking one of
+// these again shouldn't try to clear a search that isn't showing there.
+const NON_SEARCHABLE_TABS = new Set(['download', 'tidal', 'cloud-search', 'explorer']);
+
 function App() {
   const [selectedPlaylistId, setSelectedPlaylistId] = useState('music');
   const [showSettings, setShowSettings] = useState(false);
@@ -38,7 +42,7 @@ function App() {
   };
 
   const handleMenuSelect = (id) => {
-    if (id === 'music' && selectedPlaylistId === 'music') setSearch('');
+    if (id === selectedPlaylistId && !NON_SEARCHABLE_TABS.has(id)) setSearch('');
     setSelectedPlaylistId(id);
   };
 

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -32,6 +32,16 @@ function App() {
     setSearch(`ARTIST is ${artist}`);
   };
 
+  const handleLogoClick = () => {
+    setSelectedPlaylistId('music');
+    setSearch('');
+  };
+
+  const handleMenuSelect = (id) => {
+    if (id === 'music' && selectedPlaylistId === 'music') setSearch('');
+    setSelectedPlaylistId(id);
+  };
+
   useEffect(() => {
     const unsub = window.api.onOpenSettings(() => setShowSettings(true));
     return unsub;
@@ -113,11 +123,12 @@ function App() {
               search={search}
               onSearchChange={setSearch}
               onOpenSettings={() => setShowSettings(true)}
+              onLogoClick={handleLogoClick}
             />
             <div className="app-main">
               <Sidebar
                 selectedMenuItemId={selectedPlaylistId}
-                onMenuSelect={setSelectedPlaylistId}
+                onMenuSelect={handleMenuSelect}
                 activePlaylistId={selectedPlaylistId}
                 onExportPlaylistRekordboxUsb={(id) =>
                   setExportState({ playlistId: id, mode: 'rekordbox' })

--- a/renderer/src/TopBar.css
+++ b/renderer/src/TopBar.css
@@ -17,6 +17,7 @@
   align-items: center;
   gap: 8px;
   min-width: 160px;
+  cursor: pointer;
 }
 
 .top-bar__logo-img {

--- a/renderer/src/TopBar.jsx
+++ b/renderer/src/TopBar.jsx
@@ -2,10 +2,21 @@ import SearchBar from './SearchBar.jsx';
 import logo from './assets/logo.png';
 import './TopBar.css';
 
-export default function TopBar({ search, onSearchChange, onOpenSettings }) {
+export default function TopBar({ search, onSearchChange, onOpenSettings, onLogoClick }) {
   return (
     <div className="top-bar">
-      <div className="top-bar__logo">
+      <div
+        className="top-bar__logo"
+        onClick={onLogoClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onLogoClick?.();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
         <img className="top-bar__logo-img" src={logo} alt="DJ Manager" draggable={false} />
       </div>
 

--- a/renderer/src/__tests__/TopBar.test.jsx
+++ b/renderer/src/__tests__/TopBar.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import TopBar from '../TopBar.jsx';
+
+describe('TopBar logo', () => {
+  it('calls onLogoClick when the logo is clicked', () => {
+    const onLogoClick = vi.fn();
+    render(
+      <TopBar
+        search=""
+        onSearchChange={() => {}}
+        onOpenSettings={() => {}}
+        onLogoClick={onLogoClick}
+      />
+    );
+
+    fireEvent.click(screen.getByAltText('DJ Manager'));
+
+    expect(onLogoClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onLogoClick on Enter/Space when the logo is focused', () => {
+    const onLogoClick = vi.fn();
+    render(
+      <TopBar
+        search=""
+        onSearchChange={() => {}}
+        onOpenSettings={() => {}}
+        onLogoClick={onLogoClick}
+      />
+    );
+
+    const logo = screen.getByRole('button', { name: 'DJ Manager' });
+    fireEvent.keyDown(logo, { key: 'Enter' });
+    fireEvent.keyDown(logo, { key: ' ' });
+
+    expect(onLogoClick).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #419

## What
- Clicking the DJ Manager logo now navigates to the Music tab and clears the current search string.
- Clicking a nav item while already on it now clears the search string — generalized from just the "Music" tab to **every tab that shares the MusicLibrary search bar** (Music plus every playlist tab), since playlists render the same search-driven view.

## Why
Previously the logo `<img>` had no click handler at all, and `Sidebar`'s `onMenuSelect` was wired directly to `setSelectedPlaylistId` with no check for "already on this item." The initial fix only special-cased `id === 'music'`, but re-clicking an active playlist tab (which also uses the shared search bar) silently left a stale search in place.

## How
- `renderer/src/App.jsx`: added `handleLogoClick` (navigate to `'music'` + `setSearch('')`) and `handleMenuSelect`, which now clears search whenever `id === selectedPlaylistId` and `id` isn't in the new `NON_SEARCHABLE_TABS` set (`download`, `tidal`, `cloud-search`, `explorer` — the tabs that don't render `MusicLibrary`/the shared search bar at all).
- `renderer/src/TopBar.jsx`: the logo wrapper is now a `role="button"` with `onClick`/`onKeyDown` (Enter/Space) calling `onLogoClick`.
- `renderer/src/TopBar.css`: `cursor: pointer` on `.top-bar__logo`.
- Added `renderer/src/__tests__/TopBar.test.jsx` covering click and keyboard activation of the logo.

## Test Plan
- [x] `npx prettier --check` — clean
- [x] `npm run lint` (renderer) — clean (same 3 pre-existing unrelated `PlayerBar.jsx` warnings seen across other PRs this cycle)
- [x] `npx vitest run` (renderer) — 147 passed (incl. 2 new TopBar tests)
- Note: a full-`App`-mount integration test for the tab-clear behavior was attempted but blocked by a pre-existing `MusicLibrary` localStorage/jsdom bug, unrelated to this fix — covered the logic at the `TopBar` unit level instead.
