### PR TITLE
Add title text to the Import button

### DIFF
--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -529,7 +529,11 @@ function Sidebar({
             Exporting {exportProgress.copied} / {exportProgress.total}… ({exportProgress.pct}%)
           </div>
         )}
-        <button className="import-button" onClick={handleImport}>
+        <button
+          className="import-button"
+          onClick={handleImport}
+          title="Copy audio files into the library"
+        >
           Import
         </button>
         <button

--- a/renderer/src/__tests__/Sidebar.test.jsx
+++ b/renderer/src/__tests__/Sidebar.test.jsx
@@ -59,6 +59,11 @@ describe('Sidebar', () => {
     expect(onMenuSelect).toHaveBeenCalledWith('music');
   });
 
+  it('gives the Import button a title, like the Link button', () => {
+    renderSidebar({ ...defaultProps });
+    expect(screen.getByText('Import')).toHaveAttribute('title');
+  });
+
   it('calls onMenuSelect with playlist id when playlist is clicked', async () => {
     const onMenuSelect = vi.fn();
     window.api.getPlaylists.mockResolvedValueOnce([


### PR DESCRIPTION
Closes #420

## What
Added a `title` attribute to the sidebar's "Import" button describing what it does, matching the adjacent "Link" button which already has one.

## How
`renderer/src/Sidebar.jsx`: `title="Copy audio files into the library"` on the import button (contrasts with Link's "Reference files without copying them into the library").

## Test Plan
- [x] `npx prettier --check` — clean
- [x] `npx vitest run src/__tests__/Sidebar.test.jsx` — 18 passed (added a regression test asserting the button has a `title` attribute)
- [x] Full renderer `npx vitest run` — 131 passed, 14 failed; the 14 failures are the pre-existing unrelated `MusicLibrary.contextmenu.test.jsx` localStorage/jsdom issue (same baseline confirmed in #431–#436), not caused by this change
- [x] `npm run lint` — clean (same 3 pre-existing unrelated `PlayerBar.jsx` warnings)