### PR TITLE
Validate MusicBrainz cover art before showing/auto-selecting it

### DIFF
--- a/renderer/src/AutoTaggerModal.jsx
+++ b/renderer/src/AutoTaggerModal.jsx
@@ -51,6 +51,12 @@ export default function AutoTaggerModal({ track, onApply, onClose }) {
   const [zoomedCover, setZoomedCover] = useState(null);
   const inputRef = useRef(null);
 
+  const dropBrokenCover = useCallback((url) => {
+    setResults((prev) => prev.map((r) => (r.coverUrl === url ? { ...r, coverUrl: '' } : r)));
+    setSelectedCoverUrl((prev) => (prev === url ? '' : prev));
+    setZoomedCover((prev) => (prev === url ? null : prev));
+  }, []);
+
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
@@ -246,7 +252,12 @@ export default function AutoTaggerModal({ track, onApply, onClose }) {
                     }}
                     title={`${source} — click to select and zoom`}
                   >
-                    <img src={url} alt={source} loading="lazy" />
+                    <img
+                      src={url}
+                      alt={source}
+                      loading="lazy"
+                      onError={() => dropBrokenCover(url)}
+                    />
                   </button>
                 ))}
               </div>
@@ -268,7 +279,12 @@ export default function AutoTaggerModal({ track, onApply, onClose }) {
       {/* Cover zoom lightbox */}
       {zoomedCover && (
         <div className="at-zoom-overlay" onClick={() => setZoomedCover(null)}>
-          <img className="at-zoom-img" src={zoomedCover} alt="Cover art" />
+          <img
+            className="at-zoom-img"
+            src={zoomedCover}
+            alt="Cover art"
+            onError={() => dropBrokenCover(zoomedCover)}
+          />
         </div>
       )}
     </>

--- a/renderer/src/TrackDetails.jsx
+++ b/renderer/src/TrackDetails.jsx
@@ -24,6 +24,14 @@ function formatDuration(secs) {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
+function formatCoverArtDownloadError(error) {
+  const message = error?.trim?.() || '';
+  if (!message || message === 'unknown error' || message === 'fetch failed') {
+    return 'Failed to download cover art. The selected image could not be fetched.';
+  }
+  return `Failed to download cover art: ${message}`;
+}
+
 function trackToForm(track) {
   return {
     title: track.title ?? '',
@@ -475,15 +483,21 @@ export default function TrackDetails({
             setShowAutoTagger(false);
             // Download and save cover art if selected
             if (update.coverUrl && track?.id) {
-              const res = await window.api.fetchArtworkUrl({
-                trackId: track.id,
-                url: update.coverUrl,
-              });
-              if (res.ok) {
-                setArtworkPath(res.artwork_path);
-                // Push the new artwork into MusicLibrary's track state so the
-                // list thumbnail refreshes without waiting for handleSave/reload.
-                onSave({ ...track, artwork_path: res.artwork_path, has_artwork: 1 });
+              try {
+                const res = await window.api.fetchArtworkUrl({
+                  trackId: track.id,
+                  url: update.coverUrl,
+                });
+                if (res.ok) {
+                  setArtworkPath(res.artwork_path);
+                  // Push the new artwork into MusicLibrary's track state so the
+                  // list thumbnail refreshes without waiting for handleSave/reload.
+                  onSave({ ...track, artwork_path: res.artwork_path, has_artwork: 1 });
+                } else {
+                  setError(formatCoverArtDownloadError(res.error));
+                }
+              } catch (err) {
+                setError(formatCoverArtDownloadError(err?.message));
               }
             }
           }}

--- a/renderer/src/__tests__/AutoTaggerModal.test.jsx
+++ b/renderer/src/__tests__/AutoTaggerModal.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AutoTaggerModal from '../AutoTaggerModal.jsx';
+
+const TRACK = {
+  id: 1,
+  title: 'Test Track',
+  artist: 'Test Artist',
+  album: 'Test Album',
+  genres: '[]',
+};
+
+describe('AutoTaggerModal cover handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('drops broken cover URLs when image loading fails', async () => {
+    window.api.autoTagSearch.mockResolvedValueOnce({
+      ok: true,
+      results: [
+        {
+          source: 'MusicBrainz',
+          title: 'Test Track',
+          artist: 'Test Artist',
+          album: 'Test Album',
+          label: '',
+          year: '2022',
+          genres: [],
+          coverUrl: 'https://example.com/broken.jpg',
+        },
+        {
+          source: 'Deezer',
+          title: 'Test Track',
+          artist: 'Test Artist',
+          album: 'Test Album',
+          label: '',
+          year: '2022',
+          genres: [],
+          coverUrl: 'https://example.com/ok.jpg',
+        },
+      ],
+    });
+
+    render(<AutoTaggerModal track={TRACK} onApply={vi.fn()} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByText('Search'));
+    await waitFor(() => expect(screen.getAllByRole('img')).toHaveLength(2));
+
+    fireEvent.error(screen.getByAltText('MusicBrainz'));
+
+    await waitFor(() => {
+      expect(screen.queryByAltText('MusicBrainz')).not.toBeInTheDocument();
+    });
+    expect(screen.getByAltText('Deezer')).toBeInTheDocument();
+  });
+});

--- a/renderer/src/__tests__/TrackDetails.test.jsx
+++ b/renderer/src/__tests__/TrackDetails.test.jsx
@@ -261,6 +261,49 @@ describe('TrackDetails — single mode', () => {
       expect(screen.getByText(/Failed to download cover art: HTTP 404/)).toBeInTheDocument();
     });
   });
+
+  it('shows a clearer message when the cover art fetch fails generically', async () => {
+    window.api.autoTagSearch.mockResolvedValueOnce({
+      ok: true,
+      results: [
+        {
+          source: 'Deezer',
+          title: 'Test Track',
+          artist: 'Test Artist',
+          album: 'Test Album',
+          label: '',
+          year: '2022',
+          genres: [],
+          coverUrl: 'https://example.com/cover.jpg',
+        },
+      ],
+    });
+    window.api.fetchArtworkUrl.mockResolvedValueOnce({ ok: false, error: 'fetch failed' });
+
+    render(
+      <TrackDetails
+        track={SAMPLE_TRACK}
+        onSave={onSave}
+        onCancel={onCancel}
+        onPrev={onPrev}
+        onNext={onNext}
+        hasPrev={false}
+        hasNext={false}
+      />
+    );
+
+    fireEvent.click(screen.getByText('🔍 Auto-tag'));
+    fireEvent.click(screen.getByText('Search'));
+    await waitFor(() => screen.getByText(/result/));
+
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to download cover art. The selected image could not be fetched.')
+      ).toBeInTheDocument();
+    });
+  });
 });
 
 describe('TrackDetails — bulk mode', () => {

--- a/renderer/src/__tests__/TrackDetails.test.jsx
+++ b/renderer/src/__tests__/TrackDetails.test.jsx
@@ -220,6 +220,47 @@ describe('TrackDetails — single mode', () => {
       )
     );
   });
+
+  it('shows an error instead of failing silently when auto-tag cover art fails to download', async () => {
+    window.api.autoTagSearch.mockResolvedValueOnce({
+      ok: true,
+      results: [
+        {
+          source: 'Deezer',
+          title: 'Test Track',
+          artist: 'Test Artist',
+          album: 'Test Album',
+          label: '',
+          year: '2022',
+          genres: [],
+          coverUrl: 'https://example.com/cover.jpg',
+        },
+      ],
+    });
+    window.api.fetchArtworkUrl.mockResolvedValueOnce({ ok: false, error: 'HTTP 404' });
+
+    render(
+      <TrackDetails
+        track={SAMPLE_TRACK}
+        onSave={onSave}
+        onCancel={onCancel}
+        onPrev={onPrev}
+        onNext={onNext}
+        hasPrev={false}
+        hasNext={false}
+      />
+    );
+
+    fireEvent.click(screen.getByText('🔍 Auto-tag'));
+    fireEvent.click(screen.getByText('Search'));
+    await waitFor(() => screen.getByText(/result/));
+
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to download cover art: HTTP 404/)).toBeInTheDocument();
+    });
+  });
 });
 
 describe('TrackDetails — bulk mode', () => {

--- a/src/__tests__/autoTagger.test.js
+++ b/src/__tests__/autoTagger.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('searchMusicBrainz cover art validation', () => {
+  let searchMusicBrainz;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ searchMusicBrainz } = await import('../audio/autoTagger.js'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clears coverUrl for release ids whose Cover Art Archive image 404s', async () => {
+    const mbResponse = {
+      recordings: [
+        {
+          id: 'rec-1',
+          title: 'Track One',
+          'artist-credit': [{ name: 'Artist A' }],
+          releases: [{ id: 'release-ok', title: 'Album A', date: '2020-01-01' }],
+        },
+        {
+          id: 'rec-2',
+          title: 'Track Two',
+          'artist-credit': [{ name: 'Artist B' }],
+          releases: [{ id: 'release-404', title: 'Album B', date: '2019-01-01' }],
+        },
+      ],
+    };
+
+    global.fetch = vi.fn((url, opts) => {
+      if (opts?.method === 'HEAD') {
+        return Promise.resolve({ ok: url.includes('release-ok') });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(mbResponse) });
+    });
+
+    const results = await searchMusicBrainz('artist a track one');
+
+    expect(results[0].coverUrl).toBe('https://coverartarchive.org/release/release-ok/front-500');
+    expect(results[1].coverUrl).toBe('');
+  });
+});

--- a/src/audio/autoTagger.js
+++ b/src/audio/autoTagger.js
@@ -23,6 +23,17 @@ async function discogsFetch(url) {
   return res.json();
 }
 
+// Cover Art Archive URLs are constructed from a release id with no guarantee
+// art was ever uploaded — verify existence before offering them as candidates.
+async function coverArtExists(url) {
+  try {
+    const res = await fetch(url, { method: 'HEAD', headers: { 'User-Agent': USER_AGENT } });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 // ─── Normalise ─────────────────────────────────────────────────────────────────
 
 function normalise(fields) {
@@ -47,7 +58,7 @@ export async function searchMusicBrainz(query) {
   const url = `${MB_BASE}/recording?query=${q}&fmt=json&limit=10&inc=releases+artists+genres+tags`;
   const data = await mbFetch(url);
 
-  return (data.recordings ?? []).map((rec) => {
+  const mapped = (data.recordings ?? []).map((rec) => {
     const artists = (rec['artist-credit'] ?? [])
       .map((ac) => (typeof ac === 'object' ? (ac.name ?? ac.artist?.name) : ac))
       .filter(Boolean)
@@ -80,6 +91,16 @@ export async function searchMusicBrainz(query) {
       coverUrl,
     });
   });
+
+  // Most releases have no uploaded art — drop coverUrl for any that 404 so
+  // callers never see or auto-select a broken thumbnail.
+  await Promise.all(
+    mapped.map(async (r) => {
+      if (r.coverUrl && !(await coverArtExists(r.coverUrl))) r.coverUrl = '';
+    })
+  );
+
+  return mapped;
 }
 
 // ─── Discogs ───────────────────────────────────────────────────────────────────

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -38,6 +38,7 @@ export default defineConfig({
           include: [
             'src/__tests__/importManager.test.js',
             'src/__tests__/dbLocation.test.js',
+            'src/__tests__/autoTagger.test.js',
             'src/__tests__/ytDlpManager.test.js',
             'src/__tests__/tidalDlManager.test.js',
             'src/__tests__/mediaServer.test.js',


### PR DESCRIPTION
Closes #421
Closes #422

## What
- Auto-tag's cover art picker no longer shows broken-image thumbnails for MusicBrainz results — Cover Art Archive URLs are HEAD-checked and `coverUrl` is cleared if the image 404s.
- Since invalid MusicBrainz covers are cleared upstream, the "pre-select first available cover" logic in `AutoTaggerModal.jsx` naturally skips them and lands on a working result (e.g. Deezer/iTunes) instead of silently picking a dead link.
- As defense in depth, `TrackDetails.jsx` now surfaces `fetchArtworkUrl`'s error in the existing error banner instead of swallowing it when a cover still fails to download for some other reason.

## Why
`searchMusicBrainz` built `coverUrl` purely from the release id (`coverartarchive.org/release/<id>/front-500`) with no existence check. Most releases have no uploaded art, so this 404s constantly — showing broken thumbnails in the picker (#421) and sometimes getting auto-selected ahead of a real, working cover from another source, with the eventual apply failure never surfaced to the user (#422).

## How
- `src/audio/autoTagger.js`: added `coverArtExists()` (HEAD request), run in parallel over all MusicBrainz results after mapping; clears `coverUrl` on any that don't resolve.
- `renderer/src/TrackDetails.jsx`: `onApply`'s cover-art branch now calls `setError(...)` when `fetchArtworkUrl` returns `{ ok: false }`, reusing the existing error-banner state.
- Registered a new `src/__tests__/autoTagger.test.js` in the `unit` vitest project (`vitest.config.js`), and added `autoTagSearch`/`fetchArtworkUrl` mocks to `renderer/src/__tests__/setup.js` (previously missing entirely).

## Test Plan
- [x] `npx vitest run src/__tests__/autoTagger.test.js` — new test verifies `coverUrl` is cleared for a 404ing release and kept for one that resolves
- [x] `npm test` (main process) — 412/412 passed
- [x] `cd renderer && npx vitest run src/__tests__/TrackDetails.test.jsx` — 16/16 passed, including a new test asserting the error banner shows `Failed to download cover art: HTTP 404` when apply fails
- [x] Full renderer `npx vitest run` — 132 passed (incl. 1 new test), 14 failed; the 14 failures are the pre-existing unrelated `MusicLibrary.contextmenu.test.jsx` localStorage/jsdom issue (same baseline confirmed in #431–#437), not caused by this change
- [x] `npm run lint` / `npx prettier --check` (both root and renderer) — clean