### PR TITLE
Refresh track list thumbnail after auto-tag applies a new cover

### DIFF
--- a/renderer/src/TrackDetails.jsx
+++ b/renderer/src/TrackDetails.jsx
@@ -333,7 +333,12 @@ export default function TrackDetails({
                 trackId: track.id,
                 url: update.coverUrl,
               });
-              if (res.ok) setArtworkPath(res.artwork_path);
+              if (res.ok) {
+                setArtworkPath(res.artwork_path);
+                // Push the new artwork into MusicLibrary's track state so the
+                // list thumbnail refreshes without waiting for handleSave/reload.
+                onSave({ ...track, artwork_path: res.artwork_path, has_artwork: 1 });
+              }
             }
           }}
         />

--- a/renderer/src/__tests__/TrackDetails.test.jsx
+++ b/renderer/src/__tests__/TrackDetails.test.jsx
@@ -174,6 +174,52 @@ describe('TrackDetails — single mode', () => {
     );
     expect(onSave).toHaveBeenCalledTimes(1);
   });
+
+  it('refreshes the track list thumbnail after auto-tag applies a cover', async () => {
+    window.api.autoTagSearch.mockResolvedValueOnce({
+      ok: true,
+      results: [
+        {
+          source: 'Deezer',
+          title: 'Test Track',
+          artist: 'Test Artist',
+          album: 'Test Album',
+          label: '',
+          year: '2022',
+          genres: [],
+          coverUrl: 'https://example.com/cover.jpg',
+        },
+      ],
+    });
+    window.api.fetchArtworkUrl.mockResolvedValueOnce({
+      ok: true,
+      artwork_path: '/tmp/new-cover.jpg',
+    });
+
+    render(
+      <TrackDetails
+        track={SAMPLE_TRACK}
+        onSave={onSave}
+        onCancel={onCancel}
+        onPrev={onPrev}
+        onNext={onNext}
+        hasPrev={false}
+        hasNext={false}
+      />
+    );
+
+    fireEvent.click(screen.getByText('🔍 Auto-tag'));
+    fireEvent.click(screen.getByText('Search'));
+    await waitFor(() => screen.getByText(/result/));
+
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1, artwork_path: '/tmp/new-cover.jpg', has_artwork: 1 })
+      )
+    );
+  });
 });
 
 describe('TrackDetails — bulk mode', () => {

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -115,6 +115,8 @@ window.api = {
   onExportRekordboxProgress: vi.fn().mockImplementation(noop),
   onExportAllProgress: vi.fn().mockImplementation(noop),
   onFormatUsbProgress: vi.fn().mockImplementation(noop),
+  autoTagSearch: vi.fn().mockResolvedValue({ ok: true, results: [] }),
+  fetchArtworkUrl: vi.fn().mockResolvedValue({ ok: true, artwork_path: '/tmp/artwork.jpg' }),
 };
 
 // jsdom does not implement Web Audio API — stub the minimum PlayerContext needs


### PR DESCRIPTION
## Summary
Closes #423

`TrackDetails.jsx`'s auto-tag cover-art apply flow called `window.api.fetchArtworkUrl` directly instead of going through the existing `onSave(...)` callback, so `MusicLibrary.jsx`'s in-memory `tracks` state never learned about the new `artwork_path`/`has_artwork` values. The track list thumbnail stayed stale until an unrelated reload even though the DB was already updated correctly.

Fix: after a successful `fetchArtworkUrl` call, also call `onSave({ ...track, artwork_path, has_artwork: 1 })`, mirroring the exact pattern already used by `handleSave` elsewhere in the file. `MusicLibrary.jsx`'s `handleDetailsSave` merges this into its local `tracks` state immediately, matching the field names (`has_artwork`, `artwork_path`) it already uses to gate thumbnail rendering.

## Test plan
- [x] New test in `TrackDetails.test.jsx`: applying an auto-tag result with a cover calls `onSave` with the updated `artwork_path`/`has_artwork` — passes
- [x] `npx vitest run src/__tests__/TrackDetails.test.jsx` → 16/16 passed
- [x] Full renderer suite → 132 passed / 14 failed (same known pre-existing baseline, unrelated `localStorage`/jsdom issue in `MusicLibrary.jsx`)
- [x] `eslint` + `prettier --check` clean on changed files