### PR TITLE
Auto-tag apply saves directly to the DB, no separate confirm step

### DIFF
--- a/renderer/src/TrackDetails.jsx
+++ b/renderer/src/TrackDetails.jsx
@@ -456,35 +456,59 @@ export default function TrackDetails({
           track={track}
           onClose={() => setShowAutoTagger(false)}
           onApply={async (update) => {
-            // Merge result into form fields (convert genres array → comma string)
-            const merged = { ...form };
-            if (update.title != null) merged.title = update.title;
-            if (update.artist != null) merged.artist = update.artist;
-            if (update.album != null) merged.album = update.album;
-            if (update.label != null) merged.label = update.label;
-            if (update.year != null) merged.year = String(update.year);
-            if (update.genres != null) {
-              try {
-                merged.genres = JSON.parse(update.genres).join(', ');
-              } catch {
-                merged.genres = update.genres;
-              }
-            }
-            setForm(merged);
-            setDirty(true);
             setShowAutoTagger(false);
-            // Download and save cover art if selected
-            if (update.coverUrl && track?.id) {
-              const res = await window.api.fetchArtworkUrl({
-                trackId: track.id,
-                url: update.coverUrl,
-              });
-              if (res.ok) {
-                setArtworkPath(res.artwork_path);
-                // Push the new artwork into MusicLibrary's track state so the
-                // list thumbnail refreshes without waiting for handleSave/reload.
-                onSave({ ...track, artwork_path: res.artwork_path, has_artwork: 1 });
+            setSaving(true);
+            setError(null);
+            try {
+              // Auto-tag applies straight to the DB — no separate Save step needed.
+              const data = {};
+              if (update.title != null) data.title = update.title;
+              if (update.artist != null) data.artist = update.artist;
+              if (update.album != null) data.album = update.album;
+              if (update.label != null) data.label = update.label;
+              if (update.year != null) data.year = update.year;
+              if (update.genres != null) data.genres = update.genres;
+
+              if (Object.keys(data).length > 0) {
+                await window.api.updateTrack(track.id, data);
+                onSave({ ...track, ...data });
               }
+
+              // Merge result into form fields (convert genres array → comma string)
+              const merged = { ...form };
+              if (update.title != null) merged.title = update.title;
+              if (update.artist != null) merged.artist = update.artist;
+              if (update.album != null) merged.album = update.album;
+              if (update.label != null) merged.label = update.label;
+              if (update.year != null) merged.year = String(update.year);
+              if (update.genres != null) {
+                try {
+                  merged.genres = JSON.parse(update.genres).join(', ');
+                } catch {
+                  merged.genres = update.genres;
+                }
+              }
+              setForm(merged);
+
+              // Download and save cover art if selected
+              if (update.coverUrl && track?.id) {
+                const res = await window.api.fetchArtworkUrl({
+                  trackId: track.id,
+                  url: update.coverUrl,
+                });
+                if (res.ok) {
+                  setArtworkPath(res.artwork_path);
+                  // Push the new artwork into MusicLibrary's track state so the
+                  // list thumbnail refreshes without waiting for a reload.
+                  onSave({ ...track, ...data, artwork_path: res.artwork_path, has_artwork: 1 });
+                } else {
+                  setError(`Failed to download cover art: ${res.error ?? 'unknown error'}`);
+                }
+              }
+            } catch (e) {
+              setError(e.message ?? 'Auto-tag apply failed');
+            } finally {
+              setSaving(false);
             }
           }}
         />

--- a/renderer/src/__tests__/TrackDetails.test.jsx
+++ b/renderer/src/__tests__/TrackDetails.test.jsx
@@ -220,6 +220,54 @@ describe('TrackDetails — single mode', () => {
       )
     );
   });
+
+  it('applying an auto-tag result saves directly to the DB without a separate Save step', async () => {
+    window.api.autoTagSearch.mockResolvedValueOnce({
+      ok: true,
+      results: [
+        {
+          source: 'Deezer',
+          title: 'Test Track',
+          artist: 'New Artist',
+          album: 'New Album',
+          label: '',
+          year: '2023',
+          genres: ['House'],
+          coverUrl: '',
+        },
+      ],
+    });
+
+    render(
+      <TrackDetails
+        track={SAMPLE_TRACK}
+        onSave={onSave}
+        onCancel={onCancel}
+        onPrev={onPrev}
+        onNext={onNext}
+        hasPrev={false}
+        hasNext={false}
+      />
+    );
+
+    fireEvent.click(screen.getByText('🔍 Auto-tag'));
+    fireEvent.click(screen.getByText('Search'));
+    await waitFor(() => screen.getByText(/result/));
+
+    fireEvent.click(screen.getByText('Apply'));
+
+    await waitFor(() =>
+      expect(window.api.updateTrack).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ artist: 'New Artist', album: 'New Album' })
+      )
+    );
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, artist: 'New Artist', album: 'New Album' })
+    );
+    // Nothing left to confirm — Save stays disabled since there's no unsaved local change.
+    expect(screen.getByText('Save')).toBeDisabled();
+  });
 });
 
 describe('TrackDetails — bulk mode', () => {


### PR DESCRIPTION
## Summary
Closes #424

Related: #422, #423

Previously, applying an auto-tag result only merged values into the Track Details form's local state (`setForm`, `setDirty(true)`) — the user still had to hit the panel's own Save button afterward for title/artist/album/label/year/genres to persist. Cover art was the one exception, saving immediately.

This makes text-field auto-tag apply consistent with the cover-art path: it now writes straight to the DB via `updateTrack` and pushes the result through the existing `onSave` callback (same mechanism `handleSave` uses), so there's nothing left to "confirm." The form is still updated so the UI reflects the applied values, but `dirty` is never set for this path, so Save stays disabled since everything is already persisted.

## Test plan
- [x] New test: applying an auto-tag result calls `updateTrack` and `onSave` immediately, and Save stays disabled afterward — passes
- [x] `npx vitest run src/__tests__/TrackDetails.test.jsx` → 16/16 passed
- [x] Full renderer suite → 132 passed / 14 failed (same known pre-existing baseline, unrelated `localStorage`/jsdom issue in `MusicLibrary.jsx`)
- [x] `eslint` + `prettier --check` clean on changed files