### PR TITLE
Enlarge Prepare Track (Beat Grid Editor) modal

### DIFF
--- a/renderer/src/BeatGridEditor.css
+++ b/renderer/src/BeatGridEditor.css
@@ -14,8 +14,8 @@
   background: #1a1a1a;
   border: 1px solid #333;
   border-radius: 8px;
-  width: min(860px, 96vw);
-  max-height: min(96vh, 900px);
+  width: min(1400px, 96vw);
+  max-height: min(96vh, 1200px);
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## Summary
Closes #425

`.bge-modal` (`renderer/src/BeatGridEditor.css:13-18`) was capped at `width: min(860px, 96vw); max-height: min(96vh, 900px);` regardless of display size, leaving little room for the waveform/detail view on larger screens. Raised the caps to `1400px`/`1200px` (still clamped to `96vw`/`96vh` on smaller viewports).

Note: the reporter's secondary complaint about the per-cue "change type" popup filling the whole page was already fixed in a prior commit (`72f401e`) — no action needed there, confirmed via the issue's own description.

## Test plan
- [x] `prettier --check` clean on changed file
- [x] Pure CSS change — not meaningfully unit-testable under jsdom (same as the #418 CSS fix); verified visually not possible in this environment, but the change is a straightforward numeric cap increase with no logic risk