### PR TITLE
Recenter beatgrid waveform view immediately on seek while paused

### DIFF
--- a/renderer/src/BeatGridEditor.jsx
+++ b/renderer/src/BeatGridEditor.jsx
@@ -341,6 +341,13 @@ export default function BeatGridEditor({ track, onClose, onApply }) {
   useEffect(() => {
     currentTimeSecRef.current = currentTime;
     lastTimeUpdateRef.current = performance.now();
+    // While paused the RAF loop's recenter branch never runs (it only tracks
+    // the playhead while playing), so an explicit seek (e.g. clicking a cue's
+    // timestamp) would leave the view stuck on the old window until play was
+    // toggled. Recenter immediately here for the paused case.
+    if (isThisTrackRef.current && !isPlayingRef.current && !userScrollingRef.current) {
+      viewCenterRef.current = currentTime * 1000;
+    }
   }, [currentTime]);
 
   // Reset the wall-clock reference the moment playback starts so the elapsed


### PR DESCRIPTION
## Summary
Closes #426

`BeatGridEditor.jsx`'s RAF loop only recentered the view (`viewCenterRef`) while `isPlayingRef.current` was true. Clicking a cue point's timestamp in `CuePointsEditor.jsx` seeks via the global player without starting playback, so the playhead position updated correctly but the waveform view stayed on the old window until the user toggled play/pause (which flips `isPlayingRef` and unblocks the recenter branch).

Fix: the existing `useEffect` that syncs `currentTimeSecRef` on `currentTime` changes now also recenters `viewCenterRef` directly whenever the position changes while paused and the user isn't manually scrolling — covering explicit seeks (cue-timestamp clicks, scrub-release, etc.) without waiting for playback to start.

## Test plan
- [x] `eslint` + `prettier --check` clean on changed file
- [x] Full renderer suite → 131 passed / 14 failed (same known pre-existing baseline, unrelated `localStorage`/jsdom issue in `MusicLibrary.jsx`)
- [x] No existing test coverage for `BeatGridEditor.jsx` (canvas/RAF-heavy, not previously covered) — verified the fix by code trace matching the issue's own confirmed root cause; not meaningfully unit-testable under jsdom without significant new canvas/RAF mocking infrastructure, which is out of scope for this fix