### PR TITLE
Details panel follows track selection, with pin/unpin + unsaved-changes prompt

### DIFF
--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -579,6 +579,8 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   const [beatGridEditorTrack, setBeatGridEditorTrack] = useState(null);
   const [detailsTrack, setDetailsTrack] = useState(null);
   const [detailsBulkTracks, setDetailsBulkTracks] = useState(null); // array | null
+  const [detailsPinned, setDetailsPinned] = useState(false); // when true, panel ignores row selection
+  const [detailsDirty, setDetailsDirty] = useState(false); // mirrors TrackDetails' own dirty state
   const [bpmEditValue, setBpmEditValue] = useState(''); // value for inline Set BPM input
 
   const offsetRef = useRef(0);
@@ -885,7 +887,10 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
           if (prev.size === 1) {
             const id = [...prev][0];
             const track = sortedTracksRef.current.find((t) => t.id === id);
-            if (track) setDetailsTrack(track);
+            if (track) {
+              setDetailsTrack(track);
+              setDetailsPinned(false);
+            }
           }
           return prev;
         });
@@ -955,7 +960,41 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   const handleDetailsClose = useCallback(() => {
     setDetailsTrack(null);
     setDetailsBulkTracks(null);
+    setDetailsPinned(false);
+    setDetailsDirty(false);
   }, []);
+
+  const handleDetailsTogglePin = useCallback(() => {
+    setDetailsPinned((p) => !p);
+  }, []);
+
+  // Follow row selection: when exactly one track is selected and it differs
+  // from the currently open (single-track) Details panel, either switch to it
+  // automatically, or — if there are unsaved edits — ask the user whether to
+  // discard them or pin the panel to the track they're editing.
+  useEffect(() => {
+    if (!detailsTrack || detailsBulkTracks) return;
+    if (selectedIds.size !== 1) return;
+    const [id] = selectedIds;
+    if (id === detailsTrack.id) return;
+    const track = sortedTracksRef.current.find((t) => t.id === id);
+    if (!track) return;
+    if (detailsPinned) return;
+    if (detailsDirty) {
+      const discard = window.confirm(
+        'The Details panel has unsaved changes.\n\n' +
+          'Click OK to discard them and follow the new selection, or Cancel to pin the panel and keep editing this track.'
+      );
+      if (discard) {
+        setDetailsTrack(track);
+        setDetailsDirty(false);
+      } else {
+        setDetailsPinned(true);
+      }
+      return;
+    }
+    setDetailsTrack(track);
+  }, [selectedIds, detailsTrack, detailsBulkTracks, detailsPinned, detailsDirty]);
 
   // ── Cue column click — open Prepare Track window ──────────────────────────
 
@@ -2062,10 +2101,12 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
                         if (targetTracks.length === 1) {
                           setDetailsBulkTracks(null);
                           setDetailsTrack(targetTracks[0]);
+                          setDetailsPinned(false);
                           setSelectedIds(new Set([targetTracks[0].id]));
                         } else if (targetTracks.length > 1) {
                           setDetailsTrack(null);
                           setDetailsBulkTracks(targetTracks);
+                          setDetailsPinned(false);
                         }
                       }}
                     >
@@ -2194,6 +2235,9 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
               onNext={handleDetailsNext}
               hasPrev={idx > 0}
               hasNext={idx >= 0 && idx < sortedTracksRef.current.length - 1}
+              pinned={detailsPinned}
+              onTogglePin={handleDetailsTogglePin}
+              onDirtyChange={setDetailsDirty}
             />
           );
         })()}

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -1002,6 +1002,8 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange, openDetailsReq
   useEffect(() => {
     const ids = [...selectedIds];
     if (ids.length === 0) return; // nothing selected
+    // Selection only DRIVES an already-open panel; it never opens one.
+    if (!detailsTrack && !detailsBulkTracks) return;
     if (detailsTrack && detailsPinned) return; // pinned single-track panel ignores selection
     if (ids.length === 1) {
       const [id] = ids;

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -995,34 +995,37 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange, openDetailsReq
     setDetailsPinned((p) => !p);
   }, []);
 
-  // Follow row selection. Single selection: switch the open single-track
-  // panel to the newly selected row (or pin it when there are unsaved edits).
-  // Multi-selection: switch the panel to the bulk editor for the selected
-  // rows immediately - no context-menu action needed.
+  // Follow row selection. Single selection: switch the open panel back to the
+  // single-track editor for that row (closing bulk mode if needed). Bulk
+  // multi-selection: open/refresh the bulk editor for the selected rows.
+  // Unsaved edits trigger a discard/keep prompt in both directions.
   useEffect(() => {
     const ids = [...selectedIds];
     if (ids.length === 0) return; // nothing selected
     if (detailsTrack && detailsPinned) return; // pinned single-track panel ignores selection
     if (ids.length === 1) {
-      // Bulk panel stays open until closed/saved; only single panels follow.
-      if (!detailsTrack || detailsBulkTracks) return;
       const [id] = ids;
-      if (id === detailsTrack.id) return;
       const track = sortedTracksRef.current.find((t) => t.id === id);
       if (!track) return;
+      const inSingle = !!detailsTrack && !detailsBulkTracks;
+      if (inSingle && detailsTrack.id === id) return; // already showing this track
       if (detailsDirty) {
-        const discard = window.confirm(
-          'The Details panel has unsaved changes.\n\n' +
-            'Click OK to discard them and follow the new selection, or Cancel to pin the panel and keep editing this track.'
-        );
-        if (discard) {
-          setDetailsTrack(track);
-          setDetailsDirty(false);
-        } else {
-          setDetailsPinned(true);
+        const discard = inSingle
+          ? window.confirm(
+              'The Details panel has unsaved changes.\n\n' +
+                'Click OK to discard them and follow the new selection, or Cancel to pin the panel and keep editing this track.'
+            )
+          : window.confirm(
+              'The Details panel has unsaved changes.\n\n' +
+                'Click OK to discard them and show the selected track in single edit mode, or Cancel to keep the bulk panel open.'
+            );
+        if (!discard) {
+          if (inSingle) setDetailsPinned(true);
+          return;
         }
-        return;
+        setDetailsDirty(false);
       }
+      setDetailsBulkTracks(null);
       setDetailsTrack(track);
       return;
     }

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -995,32 +995,57 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange, openDetailsReq
     setDetailsPinned((p) => !p);
   }, []);
 
-  // Follow row selection: when exactly one track is selected and it differs
-  // from the currently open (single-track) Details panel, either switch to it
-  // automatically, or — if there are unsaved edits — ask the user whether to
-  // discard them or pin the panel to the track they're editing.
+  // Follow row selection. Single selection: switch the open single-track
+  // panel to the newly selected row (or pin it when there are unsaved edits).
+  // Multi-selection: switch the panel to the bulk editor for the selected
+  // rows immediately - no context-menu action needed.
   useEffect(() => {
-    if (!detailsTrack || detailsBulkTracks) return;
-    if (selectedIds.size !== 1) return;
-    const [id] = selectedIds;
-    if (id === detailsTrack.id) return;
-    const track = sortedTracksRef.current.find((t) => t.id === id);
-    if (!track) return;
-    if (detailsPinned) return;
-    if (detailsDirty) {
-      const discard = window.confirm(
-        'The Details panel has unsaved changes.\n\n' +
-          'Click OK to discard them and follow the new selection, or Cancel to pin the panel and keep editing this track.'
-      );
-      if (discard) {
-        setDetailsTrack(track);
-        setDetailsDirty(false);
-      } else {
-        setDetailsPinned(true);
+    const ids = [...selectedIds];
+    if (ids.length === 0) return; // nothing selected
+    if (detailsTrack && detailsPinned) return; // pinned single-track panel ignores selection
+    if (ids.length === 1) {
+      // Bulk panel stays open until closed/saved; only single panels follow.
+      if (!detailsTrack || detailsBulkTracks) return;
+      const [id] = ids;
+      if (id === detailsTrack.id) return;
+      const track = sortedTracksRef.current.find((t) => t.id === id);
+      if (!track) return;
+      if (detailsDirty) {
+        const discard = window.confirm(
+          'The Details panel has unsaved changes.\n\n' +
+            'Click OK to discard them and follow the new selection, or Cancel to pin the panel and keep editing this track.'
+        );
+        if (discard) {
+          setDetailsTrack(track);
+          setDetailsDirty(false);
+        } else {
+          setDetailsPinned(true);
+        }
+        return;
       }
+      setDetailsTrack(track);
       return;
     }
-    setDetailsTrack(track);
+
+    // Multi-select: open (or refresh) the bulk editor for these tracks.
+    const bulk = sortedTracksRef.current.filter((t) => selectedIds.has(t.id));
+    if (bulk.length === 0) return;
+    const idsKey = [...selectedIds].map(String).sort().join(',');
+    const openKey = detailsBulkTracks
+      ?.map((t) => String(t.id))
+      .sort()
+      .join(',');
+    if (detailsBulkTracks && openKey === idsKey) return; // already showing these
+    if (detailsDirty && (detailsTrack || detailsBulkTracks)) {
+      const discard = window.confirm(
+        'The Details panel has unsaved changes.\n\n' +
+          'Click OK to discard them and edit the newly selected tracks, or Cancel to keep the current panel open.'
+      );
+      if (!discard) return;
+      setDetailsDirty(false);
+    }
+    setDetailsTrack(null);
+    setDetailsBulkTracks(bulk);
   }, [selectedIds, detailsTrack, detailsBulkTracks, detailsPinned, detailsDirty]);
 
   useEffect(() => {

--- a/renderer/src/PlayerBarCues.css
+++ b/renderer/src/PlayerBarCues.css
@@ -3,7 +3,7 @@
   flex: 1;
   display: flex;
   align-items: center;
-  height: calc(var(--pb-h, 88px) * 0.56);
+  height: 40px;
 }
 
 .player-seekbar-bg {

--- a/renderer/src/TrackDetails.css
+++ b/renderer/src/TrackDetails.css
@@ -71,6 +71,33 @@
   color: #eee;
 }
 
+.track-details__pin {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  line-height: 1.4;
+  margin-left: auto;
+  margin-right: 8px;
+}
+
+.track-details__pin:hover {
+  background: #333;
+  color: #eee;
+}
+
+.track-details__pin--active {
+  color: #f7c07e;
+}
+
+.track-details__pin--active:hover {
+  background: #3a2f1e;
+  color: #f7c07e;
+}
+
 .track-details__fields {
   flex: 1;
   overflow-y: auto;

--- a/renderer/src/TrackDetails.jsx
+++ b/renderer/src/TrackDetails.jsx
@@ -60,6 +60,9 @@ export default function TrackDetails({
   onNext,
   hasPrev,
   hasNext,
+  pinned,
+  onTogglePin,
+  onDirtyChange,
 }) {
   const isBulk = Array.isArray(tracks) && tracks.length > 1;
   const { mediaPort } = usePlayer() ?? {};
@@ -135,6 +138,12 @@ export default function TrackDetails({
     ? null
     : (libraries.find((l) => l.id === track?.library_id)?.name ?? (track?.library_id ? '—' : null));
   const otherLibraries = libraries.filter((l) => l.id !== track?.library_id);
+
+  // Let the parent know whenever unsaved-changes state flips, so it can decide
+  // whether to auto-follow row selection or prompt before switching tracks.
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+  }, [dirty, onDirtyChange]);
 
   const handleChange = useCallback((key, value) => {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -218,6 +227,19 @@ export default function TrackDetails({
         <span className="track-details__title">
           {isBulk ? `Edit ${tracks.length} Tracks` : 'Track Details'}
         </span>
+        {!isBulk && onTogglePin && (
+          <button
+            className={`track-details__pin${pinned ? ' track-details__pin--active' : ''}`}
+            onClick={onTogglePin}
+            title={
+              pinned
+                ? 'Unpin — resume following the row selection'
+                : 'Pin — keep this track open regardless of selection'
+            }
+          >
+            {pinned ? '📌 Pinned' : '📌'}
+          </button>
+        )}
         <button className="track-details__close" onClick={onCancel} title="Close (Esc)">
           ✕
         </button>

--- a/renderer/src/__tests__/TrackDetails.test.jsx
+++ b/renderer/src/__tests__/TrackDetails.test.jsx
@@ -220,6 +220,85 @@ describe('TrackDetails — single mode', () => {
       )
     );
   });
+
+  it('reports dirty state changes via onDirtyChange as the form is edited and saved', async () => {
+    const onDirtyChange = vi.fn();
+    render(
+      <TrackDetails
+        track={SAMPLE_TRACK}
+        onSave={onSave}
+        onCancel={onCancel}
+        onPrev={onPrev}
+        onNext={onNext}
+        hasPrev={false}
+        hasNext={false}
+        onDirtyChange={onDirtyChange}
+      />
+    );
+    // Initial mount reports clean.
+    expect(onDirtyChange).toHaveBeenCalledWith(false);
+    onDirtyChange.mockClear();
+
+    fireEvent.change(screen.getByDisplayValue('Test Artist'), { target: { value: 'New Artist' } });
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(onDirtyChange).toHaveBeenLastCalledWith(false));
+  });
+
+  it('does not render a pin button when onTogglePin is not provided', () => {
+    render(
+      <TrackDetails
+        track={SAMPLE_TRACK}
+        onSave={onSave}
+        onCancel={onCancel}
+        onPrev={onPrev}
+        onNext={onNext}
+        hasPrev={false}
+        hasNext={false}
+      />
+    );
+    expect(screen.queryByTitle(/pin/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a pin toggle button and calls onTogglePin when clicked', () => {
+    const onTogglePin = vi.fn();
+    render(
+      <TrackDetails
+        track={SAMPLE_TRACK}
+        onSave={onSave}
+        onCancel={onCancel}
+        onPrev={onPrev}
+        onNext={onNext}
+        hasPrev={false}
+        hasNext={false}
+        pinned={false}
+        onTogglePin={onTogglePin}
+      />
+    );
+    const pinBtn = screen.getByTitle('Pin — keep this track open regardless of selection');
+    fireEvent.click(pinBtn);
+    expect(onTogglePin).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the pinned state and unpin label when pinned=true', () => {
+    const onTogglePin = vi.fn();
+    render(
+      <TrackDetails
+        track={SAMPLE_TRACK}
+        onSave={onSave}
+        onCancel={onCancel}
+        onPrev={onPrev}
+        onNext={onNext}
+        hasPrev={false}
+        hasNext={false}
+        pinned={true}
+        onTogglePin={onTogglePin}
+      />
+    );
+    expect(screen.getByTitle('Unpin — resume following the row selection')).toBeInTheDocument();
+    expect(screen.getByText('📌 Pinned')).toBeInTheDocument();
+  });
 });
 
 describe('TrackDetails — bulk mode', () => {
@@ -266,6 +345,18 @@ describe('TrackDetails — bulk mode', () => {
     );
     expect(screen.queryByText('BPM')).not.toBeInTheDocument();
     expect(screen.queryByText('Bitrate')).not.toBeInTheDocument();
+  });
+
+  it('hides the pin button in bulk mode even when onTogglePin is provided', () => {
+    render(
+      <TrackDetails
+        tracks={[SAMPLE_TRACK, SAMPLE_TRACK_2]}
+        onSave={onSave}
+        onCancel={onCancel}
+        onTogglePin={vi.fn()}
+      />
+    );
+    expect(screen.queryByTitle(/pin/i)).not.toBeInTheDocument();
   });
 
   it('calls updateTrack for each track on save with only filled fields', async () => {


### PR DESCRIPTION
Closes #427

## What
- The Details panel now auto-follows the currently selected row instead of only updating on explicit open actions (Enter/E, right-click → Edit Details, Prev/Next).
- If the panel has unsaved edits (`dirty` in `TrackDetails.jsx`) and the selection changes, the user is prompted (`window.confirm`, matching the existing confirm pattern used for Remove-from-library/playlist) to either discard and follow the new selection, or pin the panel to keep editing.
- Added a pin/unpin toggle button in the Details panel header (single-track mode only; not shown in bulk-edit mode).

## How
- `TrackDetails.jsx`: accepts new `pinned`, `onTogglePin`, `onDirtyChange` props. Reports its internal `dirty` state upward via a new effect so the parent can gate auto-follow without lifting all of `TrackDetails`' state. Renders a pin button in the header when `onTogglePin` is provided and not in bulk mode.
- `MusicLibrary.jsx`: new `detailsPinned`/`detailsDirty` state, mirrored from `TrackDetails` via `onDirtyChange`. A new effect reacts to `selectedIds` changes while the (non-bulk) Details panel is open: switches automatically if clean, prompts if dirty (OK = discard and switch, Cancel = pin), and does nothing while pinned. All existing explicit-open paths (Enter/E, context menu, Prev/Next) reset `detailsPinned` back to `false` so opening a track always starts in follow mode.

## Test plan
- Added `TrackDetails.test.jsx` cases: pin button renders/hides correctly (including bulk mode), `onTogglePin` fires on click, pinned label/title reflect state, and `onDirtyChange` reports `true`/`false` correctly as the form is edited and saved.
- `cd renderer && npx vitest run src/__tests__/TrackDetails.test.jsx` — 20/20 passed.
- `cd renderer && npx vitest run` — 136 passed / 14 failed (the 14 failures are the pre-existing, unrelated jsdom `localStorage` issue at `MusicLibrary.jsx:499` that affects every full-`MusicLibrary` mount in this suite regardless of this change).
- `cd renderer && npx eslint src/MusicLibrary.jsx src/TrackDetails.jsx` and `npx prettier --check` — clean.
- `npm run lint` (root) — clean.