### PR TITLE
Flip playlist Color submenu when it would overflow the viewport

### DIFF
--- a/renderer/src/Sidebar.css
+++ b/renderer/src/Sidebar.css
@@ -327,15 +327,16 @@ button.normalize-progress-wrap.ytdlp-progress-clickable:focus-visible {
 }
 
 /* Fixed grid keeps swatches inside the submenu background near viewport edges. */
-.context-submenu--colors {
+.context-submenu.context-submenu--colors {
   min-width: 0;
-  width: max-content;
+  width: 106px;
   padding: 8px;
-  grid-template-columns: repeat(3, 18px);
+  box-sizing: border-box;
+  grid-template-columns: repeat(4, 18px);
   gap: 6px;
 }
 
-.context-menu-item--has-submenu:hover > .context-submenu--colors {
+.context-menu-item--has-submenu:hover > .context-submenu.context-submenu--colors {
   display: grid;
 }
 .scrollable-playlists::-webkit-scrollbar {

--- a/renderer/src/Sidebar.css
+++ b/renderer/src/Sidebar.css
@@ -306,10 +306,10 @@ button.normalize-progress-wrap.ytdlp-progress-clickable:focus-visible {
   height: 18px;
   border-radius: 50%;
   cursor: pointer;
-  margin: 2px;
-  display: inline-block;
+  display: block;
   flex-shrink: 0;
   border: 2px solid transparent;
+  box-sizing: border-box;
 }
 
 .color-swatch:hover {
@@ -326,13 +326,17 @@ button.normalize-progress-wrap.ytdlp-progress-clickable:focus-visible {
   border-radius: 4px;
 }
 
-/* Override submenu layout for color picker */
-.context-submenu:has(.color-swatch) {
-  display: flex;
-  flex-wrap: wrap;
-  padding: 6px;
-  min-width: 110px;
-  max-width: 130px;
+/* Fixed grid keeps swatches inside the submenu background near viewport edges. */
+.context-submenu--colors {
+  min-width: 0;
+  width: max-content;
+  padding: 8px;
+  grid-template-columns: repeat(3, 18px);
+  gap: 6px;
+}
+
+.context-menu-item--has-submenu:hover > .context-submenu--colors {
+  display: grid;
 }
 .scrollable-playlists::-webkit-scrollbar {
   width: 4px;

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -631,7 +631,7 @@ function Sidebar({
           </div>
           <div className="context-menu-item context-menu-item--has-submenu">
             🎨 Color
-            <div className="context-submenu">
+            <div className="context-submenu context-submenu--colors">
               {PRESET_COLORS.map((c) => (
                 <div
                   key={c}

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -44,7 +44,7 @@ function Sidebar({
   const [creatingPlaylist, setCreatingPlaylist] = useState(false);
   const [createError, setCreateError] = useState('');
   const [renameError, setRenameError] = useState('');
-  const [playlistMenu, setPlaylistMenu] = useState(null); // { id, x, y }
+  const [playlistMenu, setPlaylistMenu] = useState(null); // { id, x, y, flipLeft, flipUp }
   const [renamingId, setRenamingId] = useState(null);
   const [renameValue, setRenameValue] = useState('');
   const [dragOverPlaylistId, setDragOverPlaylistId] = useState(null);
@@ -377,7 +377,11 @@ function Sidebar({
                 onClick={() => onMenuSelect(String(pl.id))}
                 onContextMenu={(e) => {
                   e.preventDefault();
-                  setPlaylistMenu({ id: pl.id, x: e.clientX, y: e.clientY });
+                  // Flip the Color submenu to the opposite side/edge when it would
+                  // otherwise overflow the viewport (see issue #428).
+                  const flipLeft = e.clientX > window.innerWidth / 2;
+                  const flipUp = e.clientY > window.innerHeight / 2;
+                  setPlaylistMenu({ id: pl.id, x: e.clientX, y: e.clientY, flipLeft, flipUp });
                 }}
                 onDragOver={handleDragOver}
                 onDragEnter={(e) => handleDragEnter(e, pl.id)}
@@ -610,7 +614,7 @@ function Sidebar({
       {/* Playlist context menu */}
       {playlistMenu && (
         <div
-          className="context-menu"
+          className={`context-menu${playlistMenu.flipLeft ? ' context-menu--flip-left' : ''}${playlistMenu.flipUp ? ' context-menu--flip-up' : ''}`}
           style={{ top: playlistMenu.y, left: playlistMenu.x }}
           onMouseDown={(e) => e.stopPropagation()}
         >

--- a/renderer/src/__tests__/Sidebar.test.jsx
+++ b/renderer/src/__tests__/Sidebar.test.jsx
@@ -144,6 +144,37 @@ describe('Sidebar', () => {
     renderSidebar({ ...defaultProps });
     expect(screen.queryByText(/Export USB/)).toBeNull();
   });
+
+  it('does not flip the Color submenu when opened in the top-left of the screen', async () => {
+    window.api.getPlaylists.mockResolvedValueOnce([
+      { id: 1, name: 'Techno Set', color: null, track_count: 0, total_duration: 0 },
+    ]);
+
+    const { container } = renderSidebar({ ...defaultProps });
+    await waitFor(() => screen.getByText('Techno Set'));
+    fireEvent.contextMenu(screen.getByText('Techno Set'), { clientX: 50, clientY: 50 });
+
+    const menu = container.querySelector('.context-menu');
+    expect(menu).not.toHaveClass('context-menu--flip-left');
+    expect(menu).not.toHaveClass('context-menu--flip-up');
+  });
+
+  it('flips the Color submenu left and up when opened near the bottom-right of the screen', async () => {
+    window.api.getPlaylists.mockResolvedValueOnce([
+      { id: 1, name: 'Techno Set', color: null, track_count: 0, total_duration: 0 },
+    ]);
+
+    const { container } = renderSidebar({ ...defaultProps });
+    await waitFor(() => screen.getByText('Techno Set'));
+    fireEvent.contextMenu(screen.getByText('Techno Set'), {
+      clientX: window.innerWidth - 10,
+      clientY: window.innerHeight - 10,
+    });
+
+    const menu = container.querySelector('.context-menu');
+    expect(menu).toHaveClass('context-menu--flip-left');
+    expect(menu).toHaveClass('context-menu--flip-up');
+  });
 });
 
 describe('Sidebar — import dialog playlist association', () => {

--- a/renderer/src/__tests__/Sidebar.test.jsx
+++ b/renderer/src/__tests__/Sidebar.test.jsx
@@ -175,6 +175,18 @@ describe('Sidebar', () => {
     expect(menu).toHaveClass('context-menu--flip-left');
     expect(menu).toHaveClass('context-menu--flip-up');
   });
+
+  it('uses the dedicated color submenu grid so swatches stay inside the menu panel', async () => {
+    window.api.getPlaylists.mockResolvedValueOnce([
+      { id: 1, name: 'Techno Set', color: null, track_count: 0, total_duration: 0 },
+    ]);
+
+    const { container } = renderSidebar({ ...defaultProps });
+    await waitFor(() => screen.getByText('Techno Set'));
+    fireEvent.contextMenu(screen.getByText('Techno Set'), { clientX: 50, clientY: 50 });
+
+    expect(container.querySelector('.context-submenu--colors')).toBeInTheDocument();
+  });
 });
 
 describe('Sidebar — import dialog playlist association', () => {


### PR DESCRIPTION
Closes #428

## What
The playlist right-click "Color" submenu (`.context-submenu` inside `Sidebar.jsx`) always positioned itself with `left: 100%`, with no viewport-edge collision detection, so it rendered off-screen when the parent context menu opened near the right or bottom edge.

## How
`MusicLibrary.jsx`'s track context menu already solves this exact problem for its own submenus via `context-menu--flip-left` / `context-menu--flip-up` modifier classes (defined in `MusicLibrary.css`, loaded globally) that flip `left: 100%` → `right: 100%` and `top` → `bottom` respectively. Rather than duplicating that CSS, `Sidebar.jsx`'s playlist `onContextMenu` handler now computes the same `flipLeft`/`flipUp` flags from click position vs. `window.innerWidth`/`innerHeight` and applies the existing classes to its own `.context-menu` wrapper — so the Color submenu (and any other submenu added to this menu later) picks up the same collision handling for free.

## Test plan
- Added `Sidebar.test.jsx` cases: no flip classes when the menu opens near the top-left, both `context-menu--flip-left` and `context-menu--flip-up` applied when opened near the bottom-right.
- `cd renderer && npx vitest run src/__tests__/Sidebar.test.jsx` — 19/19 passed.
- `cd renderer && npx vitest run` — 133 passed / 14 failed (the 14 failures are the pre-existing, unrelated jsdom `localStorage` issue at `MusicLibrary.jsx:499`, unaffected by this change).
- `cd renderer && npx eslint src/Sidebar.jsx src/__tests__/Sidebar.test.jsx` and `npx prettier --check` — clean.
- `npm run lint` (root) — clean.