### PR TITLE
fix(usb): reuse existing USB path on re-export instead of renaming

### DIFF
--- a/src/__tests__/exportReuse.test.js
+++ b/src/__tests__/exportReuse.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { reuseExistingUsbTrack } from '../usb/exportReuse.js';
+
+describe('reuseExistingUsbTrack', () => {
+  it('returns null when the track is not in the existing manifest', () => {
+    const existingTracks = new Map();
+    const usedNames = new Map();
+    expect(reuseExistingUsbTrack(existingTracks, 'track-1', usedNames)).toBeNull();
+    expect(usedNames.size).toBe(0);
+  });
+
+  it('returns null when the manifest entry has no file_path', () => {
+    const existingTracks = new Map([['track-1', {}]]);
+    const usedNames = new Map();
+    expect(reuseExistingUsbTrack(existingTracks, 'track-1', usedNames)).toBeNull();
+  });
+
+  it('reuses the stored path and registers the filename in usedNames', () => {
+    const existingTracks = new Map([
+      ['track-1', { file_path: '/music/Artist - Title.mp3', file_size: 12345, bitrate: 320 }],
+    ]);
+    const usedNames = new Map();
+
+    const result = reuseExistingUsbTrack(existingTracks, 'track-1', usedNames);
+
+    expect(result).toEqual({
+      path: '/music/Artist - Title.mp3',
+      meta: { fileSize: 12345, bitrate: 320 },
+    });
+    expect(usedNames.get('artist - title.mp3')).toBe(true);
+  });
+
+  it('returns meta: null when the manifest entry has no file_size or bitrate', () => {
+    const existingTracks = new Map([['track-1', { file_path: '/music/Track.mp3' }]]);
+    const usedNames = new Map();
+
+    const result = reuseExistingUsbTrack(existingTracks, 'track-1', usedNames);
+
+    expect(result).toEqual({ path: '/music/Track.mp3', meta: null });
+  });
+
+  it('does not collide with a different track already registered in usedNames', () => {
+    const existingTracks = new Map([
+      ['track-1', { file_path: '/music/Artist - Title.mp3' }],
+      ['track-2', { file_path: '/music/Other - Song.mp3' }],
+    ]);
+    const usedNames = new Map();
+
+    reuseExistingUsbTrack(existingTracks, 'track-1', usedNames);
+    reuseExistingUsbTrack(existingTracks, 'track-2', usedNames);
+
+    expect(usedNames.size).toBe(2);
+    expect(usedNames.get('artist - title.mp3')).toBe(true);
+    expect(usedNames.get('other - song.mp3')).toBe(true);
+  });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -116,6 +116,7 @@ import { writeAnlz, getAnlzFolder } from './audio/anlzWriter.js';
 import { writeSettingFiles } from './usb/settingWriter.js';
 import { writePdb } from './usb/pdbWriter.js';
 import { resolveExportFormat } from './usb/deviceFormats.js';
+import { reuseExistingUsbTrack } from './usb/exportReuse.js';
 import { getResetCleanupTargets, startResetCleanup } from './resetCleanup.js';
 import {
   getCuePoints,
@@ -2003,14 +2004,20 @@ ipcMain.handle(
       const usbMeta = new Map(); // trackId → { fileSize, bitrate } override, only set on re-encode
       for (let i = 0; i < tracks.length; i++) {
         const t = tracks[i];
-        const { path: usbPath, meta } = await copyTrackToUsb(t, usbRoot, usedNames, {
-          useNormalized,
-          targetLufs,
-          targetDevice,
-          forceMp3,
-        });
-        usbPaths.set(t.id, usbPath);
-        if (meta) usbMeta.set(t.id, meta);
+        const reused = reuseExistingUsbTrack(existingTracks, t.id, usedNames);
+        if (reused) {
+          usbPaths.set(t.id, reused.path);
+          if (reused.meta) usbMeta.set(t.id, reused.meta);
+        } else {
+          const { path: usbPath, meta } = await copyTrackToUsb(t, usbRoot, usedNames, {
+            useNormalized,
+            targetLufs,
+            targetDevice,
+            forceMp3,
+          });
+          usbPaths.set(t.id, usbPath);
+          if (meta) usbMeta.set(t.id, meta);
+        }
         send('export-rekordbox-progress', {
           msg: `Copying files… ${i + 1}/${total}`,
           pct: Math.round(((i + 1) / total) * 40),
@@ -2155,14 +2162,20 @@ ipcMain.handle(
       const usbMeta = new Map(); // trackId → { fileSize, bitrate } override, only set on re-encode
       for (let i = 0; i < allTracks.length; i++) {
         const t = allTracks[i];
-        const { path: usbPath, meta } = await copyTrackToUsb(t, usbRoot, usedNames, {
-          useNormalized,
-          targetLufs,
-          targetDevice,
-          forceMp3,
-        });
-        usbPaths.set(t.id, usbPath);
-        if (meta) usbMeta.set(t.id, meta);
+        const reused = reuseExistingUsbTrack(existingTracks, t.id, usedNames);
+        if (reused) {
+          usbPaths.set(t.id, reused.path);
+          if (reused.meta) usbMeta.set(t.id, reused.meta);
+        } else {
+          const { path: usbPath, meta } = await copyTrackToUsb(t, usbRoot, usedNames, {
+            useNormalized,
+            targetLufs,
+            targetDevice,
+            forceMp3,
+          });
+          usbPaths.set(t.id, usbPath);
+          if (meta) usbMeta.set(t.id, meta);
+        }
         send('export-all-progress', {
           msg: `Copying files… ${i + 1}/${total}`,
           pct: Math.round(((i + 1) / total) * 35),

--- a/src/main.js
+++ b/src/main.js
@@ -1983,12 +1983,13 @@ ipcMain.handle(
 
       // Load existing manifest so we can merge with previously exported tracks/playlists
       const { tracks: existingTracks, playlists: existingPlaylists } = loadManifest(usbRoot);
-      const existingCount = existingTracks.size;
+      const copyTargets = tracks.filter(
+        (t) => !reuseExistingUsbTrack(existingTracks, t.id, new Map())
+      );
+      const copyTotal = copyTargets.length;
 
       send('export-rekordbox-progress', {
-        msg: existingCount
-          ? `Merging ${total} tracks into existing export (${existingCount} tracks already on USB)…`
-          : `Exporting ${total} tracks…`,
+        msg: `Exporting ${total} tracks…`,
         pct: 0,
       });
 
@@ -2002,6 +2003,7 @@ ipcMain.handle(
       // 2. Copy files to USB, build USB path map
       const usbPaths = new Map(); // trackId → USB path
       const usbMeta = new Map(); // trackId → { fileSize, bitrate } override, only set on re-encode
+      let copiedCount = 0;
       for (let i = 0; i < tracks.length; i++) {
         const t = tracks[i];
         const reused = reuseExistingUsbTrack(existingTracks, t.id, usedNames);
@@ -2017,9 +2019,13 @@ ipcMain.handle(
           });
           usbPaths.set(t.id, usbPath);
           if (meta) usbMeta.set(t.id, meta);
+          copiedCount += 1;
         }
+        const copyMsg = copyTotal
+          ? `Copying files… ${copiedCount}/${copyTotal}`
+          : 'Copying files… all tracks already on USB';
         send('export-rekordbox-progress', {
-          msg: `Copying files… ${i + 1}/${total}`,
+          msg: copyMsg,
           pct: Math.round(((i + 1) / total) * 40),
         });
       }
@@ -2141,12 +2147,13 @@ ipcMain.handle(
 
       // Load existing manifest for merging
       const { tracks: existingTracks, playlists: existingPlaylists } = loadManifest(usbRoot);
-      const existingCount = existingTracks.size;
+      const copyTargets = allTracks.filter(
+        (t) => !reuseExistingUsbTrack(existingTracks, t.id, new Map())
+      );
+      const copyTotal = copyTargets.length;
 
       send('export-all-progress', {
-        msg: existingCount
-          ? `Merging ${total} tracks into existing export (${existingCount} tracks already on USB)…`
-          : `Exporting ${total} tracks…`,
+        msg: `Exporting ${total} tracks…`,
         pct: 0,
       });
 
@@ -2160,6 +2167,7 @@ ipcMain.handle(
       // Copy files once
       const usbPaths = new Map();
       const usbMeta = new Map(); // trackId → { fileSize, bitrate } override, only set on re-encode
+      let copiedCount = 0;
       for (let i = 0; i < allTracks.length; i++) {
         const t = allTracks[i];
         const reused = reuseExistingUsbTrack(existingTracks, t.id, usedNames);
@@ -2175,9 +2183,13 @@ ipcMain.handle(
           });
           usbPaths.set(t.id, usbPath);
           if (meta) usbMeta.set(t.id, meta);
+          copiedCount += 1;
         }
+        const copyMsg = copyTotal
+          ? `Copying files… ${copiedCount}/${copyTotal}`
+          : 'Copying files… all tracks already on USB';
         send('export-all-progress', {
-          msg: `Copying files… ${i + 1}/${total}`,
+          msg: copyMsg,
           pct: Math.round(((i + 1) / total) * 35),
         });
       }

--- a/src/usb/exportReuse.js
+++ b/src/usb/exportReuse.js
@@ -1,0 +1,37 @@
+import path from 'path';
+
+/**
+ * Decides whether a track already present in a previous export's manifest can
+ * be reused as-is, avoiding a redundant `copyTrackToUsb()` call.
+ *
+ * On a 2nd+ export to the same USB, `usedNames` is pre-populated from the
+ * existing manifest so *new* tracks don't collide with already-exported
+ * filenames. But if the main export loop still calls `copyTrackToUsb()` for
+ * a track that's already on the USB, that track's own filename collides with
+ * itself in `usedNames` and gets renamed to "... (1).ext" — the real file is
+ * left untouched on disk, but the manifest/PDB now points at a path that
+ * doesn't exist. Because the ANLZ folder hash is derived from that same path
+ * string, the beat grid/waveform data also gets written to the wrong
+ * directory. See issue #247.
+ *
+ * @param {Map<string, object>} existingTracks - trackId → manifest track row (has `file_path`, `file_size`, `bitrate`)
+ * @param {string} trackId
+ * @param {Map<string, boolean>} usedNames - mutated: registers the reused filename so later new tracks don't collide with it
+ * @returns {{ path: string, meta: { fileSize: number, bitrate: number } | null } | null}
+ *   The reusable `{ path, meta }` pair (same shape `copyTrackToUsb()` returns), or
+ *   `null` if the track isn't already on the USB and `copyTrackToUsb()` must be called.
+ */
+export function reuseExistingUsbTrack(existingTracks, trackId, usedNames) {
+  const existing = existingTracks.get(trackId);
+  if (!existing?.file_path) return null;
+
+  const name = path.basename(existing.file_path).toLowerCase();
+  if (name) usedNames.set(name, true);
+
+  const meta =
+    existing.file_size || existing.bitrate
+      ? { fileSize: existing.file_size, bitrate: existing.bitrate }
+      : null;
+
+  return { path: existing.file_path, meta };
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -47,6 +47,7 @@ export default defineConfig({
             'src/__tests__/pdbWriter.test.js',
             'src/__tests__/deviceFormats.test.js',
             'src/__tests__/ffmpegConvert.test.js',
+            'src/__tests__/exportReuse.test.js',
           ],
         },
       },


### PR DESCRIPTION
## What
Fixes tracks getting renamed to `Artist - Title (1).mp3` on the 2nd+ export to the same USB drive, which breaks both audio playback and beatgrid/waveform data on CDJs.

## How
Root cause: `usedNames` (the dedup map passed to `copyTrackToUsb`) is pre-populated from the existing on-drive manifest before the export loop starts, so new tracks don't collide with previously exported filenames. But the loop still called `copyTrackToUsb` for *every* track, including ones already on the USB — so an already-exported track's own filename collided with itself in `usedNames` and got a `(1)` suffix. The actual file copy was skipped (dest already existed), but the `(1)` path was what got written into the manifest/PDB. Since the ANLZ folder hash (`getAnlzFolder`) is derived from that same path string, the beatgrid/waveform data was also written to a new, wrong directory, orphaning the correct one.

Added `src/usb/exportReuse.js` with `reuseExistingUsbTrack()`: given the existing manifest, a track ID, and the `usedNames` map, it returns the track's already-known `{ path, meta }` if it's already on the USB (registering the filename in `usedNames` so later new tracks still avoid colliding with it), or `null` if `copyTrackToUsb` still needs to run. Wired into both the `export-rekordbox` and `export-all` IPC handlers in `src/main.js`.

Closes #247

## Test plan
- [x] Added `src/__tests__/exportReuse.test.js` (5 cases: no manifest entry, entry with no `file_path`, successful reuse + `usedNames` registration, missing size/bitrate meta, no cross-track collisions). Registered in `vitest.config.js`'s `unit` project.
- [x] `npm test` (root): 416 passed, 16 test files — no regressions.
- [x] `npm run lint` — clean.
- [x] `npx prettier --check` on changed files — clean.