### PR TITLE
fix: sync file_path to renderer after library move / storage-format conversion

### DIFF
--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -740,6 +740,10 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
 
       setTracks((prev) => prev.map((t) => (t.id === trackId ? { ...t, ...merged } : t)));
 
+      // Keep an already-open Edit Details panel in sync (e.g. file_path
+      // changes after a library move or storage-format conversion)
+      setDetailsTrack((prev) => (prev && prev.id === trackId ? { ...prev, ...merged } : prev));
+
       // Keep PlayerContext's currentTrack in sync
       patchCurrentTrack(trackId, merged);
     });

--- a/src/audio/importManager.js
+++ b/src/audio/importManager.js
@@ -173,6 +173,15 @@ export function convertStorageFormat(libraryId, newFormat) {
       if (newPath !== oldPath) {
         moveFileSafe(oldPath, newPath);
         updateTrack(track.id, { file_path: newPath });
+        // Keep the track list and any open Edit Details panel in sync —
+        // pass through the existing `analyzed` flag so this doesn't
+        // masquerade as a completed analysis for not-yet-analyzed tracks.
+        if (global.mainWindow) {
+          global.mainWindow.webContents.send('track-updated', {
+            trackId: track.id,
+            analysis: { file_path: newPath, analyzed: track.analyzed },
+          });
+        }
       }
     }
     moved++;

--- a/src/main.js
+++ b/src/main.js
@@ -466,8 +466,16 @@ ipcMain.handle('move-library', async (event, newDir, libraryId) => {
     moved++;
 
     const pct = Math.round((moved / total) * 100);
-    if (global.mainWindow)
+    if (global.mainWindow) {
       global.mainWindow.webContents.send('move-library-progress', { moved, total, pct });
+      // Keep the track list and any open Edit Details panel in sync — pass
+      // through the existing `analyzed` flag so this doesn't masquerade as
+      // a completed analysis for not-yet-analyzed tracks.
+      global.mainWindow.webContents.send('track-updated', {
+        trackId: track.id,
+        analysis: { file_path: newPath, analyzed: track.analyzed },
+      });
+    }
   }
 
   // Remove old empty shard dirs (best-effort)


### PR DESCRIPTION
## What
After moving a library's folder or converting its storage format (hashed <-> readable), the DB's `file_path` was updated but the renderer never learned about it.

## Why
The track list and any already-open Edit Details panel kept showing the stale path until a manual app reload, since `move-library` and `convertStorageFormat` never emitted `track-updated`.

## How
- `src/audio/importManager.js`: `convertStorageFormat()` now sends `track-updated` per moved track.
- `src/main.js`: `move-library` handler now sends `track-updated` per moved track.
- Both pass through the track's existing `analyzed` flag so this does not falsely mark not-yet-analyzed tracks as analyzed.
- `renderer/src/MusicLibrary.jsx`: the `onTrackUpdated` handler now also patches `detailsTrack` (the open Edit Details panel state), not just the track list and PlayerContext.

## Test plan
- [x] `npx vitest run src/__tests__/importManager.test.js` (31/31 pass)
- [x] `npm run lint` / `npm run format:check` clean
- [ ] Manual: move a library's folder or convert its storage format while Edit Details is open on one of its tracks — path updates live
