### PR TITLE
Settings: show DB/library sizes, clarify DB is metadata-only

### DIFF
--- a/renderer/src/SettingsModal.css
+++ b/renderer/src/SettingsModal.css
@@ -295,6 +295,14 @@
   white-space: nowrap;
   padding: 4px 0;
 }
+.settings-size-display {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-family: monospace;
+  color: #a6adc8;
+  white-space: nowrap;
+  padding: 4px 8px;
+}
 .move-progress {
   margin-top: 0.5rem;
 }

--- a/renderer/src/SettingsModal.css
+++ b/renderer/src/SettingsModal.css
@@ -468,6 +468,7 @@
 }
 .library-card--new {
   border-style: dashed;
+  margin-top: 10px;
 }
 .library-card-header {
   display: flex;
@@ -492,6 +493,35 @@
   border-radius: 4px;
   padding: 1px 6px;
   font-weight: 400;
+}
+.library-size-badge {
+  font-size: 10px;
+  letter-spacing: 0.03em;
+  color: #a6adc8;
+  border: 1px solid #45475a;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-weight: 400;
+  font-family: monospace;
+}
+.library-rename-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #888;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.library-rename-btn:hover {
+  background: #2a2a2a;
+  color: #ccc;
 }
 .library-card-actions {
   display: flex;

--- a/renderer/src/SettingsModal.jsx
+++ b/renderer/src/SettingsModal.jsx
@@ -399,22 +399,27 @@ function SettingsModal({ onClose }) {
                           />
                         ) : (
                           <span className="library-card-name">
+                            <button
+                              className="library-rename-btn"
+                              title="Rename"
+                              aria-label="Rename library"
+                              onClick={() => {
+                                setRenamingId(lib.id);
+                                setRenameInput(lib.name);
+                              }}
+                            >
+                              ✎
+                            </button>
                             {lib.name}
                             {lib.id === currentLibraryId && (
                               <span className="library-active-badge">current</span>
                             )}
+                            <span className="library-size-badge">
+                              {formatBytes(librarySizes[lib.id])}
+                            </span>
                           </span>
                         )}
                         <div className="library-card-actions">
-                          <button
-                            className="btn-secondary"
-                            onClick={() => {
-                              setRenamingId(lib.id);
-                              setRenameInput(lib.name);
-                            }}
-                          >
-                            Rename
-                          </button>
                           {lib.id !== currentLibraryId && (
                             <button
                               className="btn-secondary"
@@ -433,9 +438,6 @@ function SettingsModal({ onClose }) {
                         >
                           {lib.effective_root_path ?? lib.root_path}
                         </div>
-                        <span className="settings-size-display">
-                          {formatBytes(librarySizes[lib.id])}
-                        </span>
                         <button
                           className="btn-secondary"
                           onClick={() => handleBrowseLibrary(lib.id)}

--- a/renderer/src/SettingsModal.jsx
+++ b/renderer/src/SettingsModal.jsx
@@ -3,6 +3,20 @@ import './SettingsModal.css';
 
 const DEFAULT_TARGET = -9;
 
+// MB and up — sub-megabyte sizes just round down to "0.0 MB" rather than
+// switching to bytes/KB, since libraries are never meaningfully that small.
+const SIZE_UNITS = ['MB', 'GB', 'TB'];
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 MB';
+  const mb = bytes / 1024 ** 2;
+  const exp = Math.max(
+    0,
+    Math.min(Math.floor(Math.log(mb) / Math.log(1024)), SIZE_UNITS.length - 1)
+  );
+  const value = mb / 1024 ** exp;
+  return `${value.toFixed(1)} ${SIZE_UNITS[exp]}`;
+}
+
 const COOKIE_BROWSERS = [
   { value: '', label: 'None (not logged in)' },
   { value: 'chrome', label: 'Chrome' },
@@ -59,10 +73,20 @@ function SettingsModal({ onClose }) {
 
   // Database location — a single file shared by all libraries
   const [dbPath, setDbPath] = useState('');
+  const [dbSize, setDbSize] = useState(0);
   const [confirmMoveDb, setConfirmMoveDb] = useState(null); // pending new dir path
 
+  // Disk usage per library, keyed by library id — fetched alongside the
+  // library list itself since both change together (move/convert/create).
+  const [librarySizes, setLibrarySizes] = useState({});
+
   const refreshLibraries = useCallback(() => {
-    window.api.listLibraries().then(setLibraries);
+    window.api.listLibraries().then((libs) => {
+      setLibraries(libs);
+      Promise.all(
+        libs.map((l) => window.api.getLibrarySize(l.id).then((size) => [l.id, size]))
+      ).then((pairs) => setLibrarySizes(Object.fromEntries(pairs)));
+    });
     window.api.getCurrentLibraryId().then(setCurrentLibraryId);
   }, []);
 
@@ -96,6 +120,7 @@ function SettingsModal({ onClose }) {
     if (activeSection === 'library') {
       refreshLibraries();
       window.api.getDbPath().then(setDbPath);
+      window.api.getDbSize().then(setDbSize);
     }
     if (activeSection === 'updates') {
       window.api.getDepVersions().then(setDepVersions);
@@ -404,10 +429,13 @@ function SettingsModal({ onClose }) {
                       <div className="settings-row settings-row-action">
                         <div
                           className="settings-path-display"
-                          title={lib.root_path || '(default location)'}
+                          title={lib.effective_root_path ?? lib.root_path}
                         >
-                          {lib.root_path || '(default location)'}
+                          {lib.effective_root_path ?? lib.root_path}
                         </div>
+                        <span className="settings-size-display">
+                          {formatBytes(librarySizes[lib.id])}
+                        </span>
                         <button
                           className="btn-secondary"
                           onClick={() => handleBrowseLibrary(lib.id)}
@@ -544,13 +572,15 @@ function SettingsModal({ onClose }) {
               <div className="settings-group">
                 <div className="settings-group-title">Database Location</div>
                 <p className="settings-group-desc">
-                  Where the single shared database file lives (all libraries' tracks, playlists, and
-                  settings). Moving it closes and restarts the app.
+                  The metadata database — track info, playlists, cue points, and settings for every
+                  library. This is not where your audio files are stored; see each library's own
+                  folder above. Moving it closes and restarts the app.
                 </p>
                 <div className="settings-row settings-row-action">
                   <div className="settings-path-display" title={dbPath}>
                     {dbPath || '…'}
                   </div>
+                  <span className="settings-size-display">{formatBytes(dbSize)}</span>
                   <button className="btn-secondary" onClick={handleBrowseDatabase}>
                     Change…
                   </button>

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -6,7 +6,16 @@ const noop = () => () => {}; // returns unsubscribe fn
 window.api = {
   getTracks: vi.fn().mockResolvedValue([]),
   getTrackIds: vi.fn().mockResolvedValue([]),
-  listLibraries: vi.fn().mockResolvedValue([{ id: 1, name: 'Default', storage_format: 'hashed' }]),
+  listLibraries: vi.fn().mockResolvedValue([
+    {
+      id: 1,
+      name: 'Default',
+      storage_format: 'hashed',
+      root_path: null,
+      effective_root_path: '/tmp/userData/audio',
+    },
+  ]),
+  getLibrarySize: vi.fn().mockResolvedValue(0),
   getCurrentLibraryId: vi.fn().mockResolvedValue(1),
   setCurrentLibraryId: vi.fn().mockResolvedValue(undefined),
   createLibrary: vi
@@ -17,6 +26,7 @@ window.api = {
   convertStorageFormat: vi.fn().mockResolvedValue({ moved: 0, total: 0 }),
   onConvertStorageFormatProgress: vi.fn().mockImplementation(noop),
   getDbPath: vi.fn().mockResolvedValue('/tmp/library.db'),
+  getDbSize: vi.fn().mockResolvedValue(0),
   moveDatabase: vi.fn().mockResolvedValue(undefined),
   getUnavailableLinkedTracks: vi.fn().mockResolvedValue([]),
   getCuePoints: vi.fn().mockResolvedValue([]),

--- a/src/__tests__/importManager.test.js
+++ b/src/__tests__/importManager.test.js
@@ -98,6 +98,8 @@ vi.mock('fs', () => {
     copyFileSync: vi.fn(),
     mkdirSync: vi.fn(),
     createReadStream: vi.fn().mockImplementation(makeStream),
+    readdirSync: vi.fn().mockReturnValue([]),
+    statSync: vi.fn().mockReturnValue({ size: 0 }),
   };
   return { default: fsMock, ...fsMock };
 });
@@ -142,6 +144,7 @@ import {
   importAudioFile,
   moveTrackToLibrary,
   convertStorageFormat,
+  getLibraryDiskUsage,
 } from '../audio/importManager.js';
 import cryptoDefault from 'crypto';
 
@@ -651,5 +654,47 @@ describe('moveTrackToLibrary', () => {
       library_id: 1,
     });
     await expect(moveTrackToLibrary(5, 999)).rejects.toThrow('Target library not found');
+  });
+});
+
+describe('getLibraryDiskUsage', () => {
+  it('sums file sizes recursively across the library audio and artwork bases', () => {
+    // Library 1 is the default library (see mockGetDefaultLibraryId), so its
+    // audio/artwork bases resolve to the mocked userData dir unscoped.
+    const audioBase = path.join('/tmp/djman-test', 'audio');
+    const artworkBase = path.join('/tmp/djman-test', 'artwork');
+    fs.readdirSync.mockImplementation((dir) => {
+      if (dir === audioBase) {
+        return [
+          { name: 'de', isDirectory: () => true, isFile: () => false },
+          { name: 'top.mp3', isDirectory: () => false, isFile: () => true },
+        ];
+      }
+      if (dir === path.join(audioBase, 'de')) {
+        return [{ name: 'deadbeef.mp3', isDirectory: () => false, isFile: () => true }];
+      }
+      if (dir === artworkBase) {
+        return [{ name: 'cover.jpg', isDirectory: () => false, isFile: () => true }];
+      }
+      throw new Error(`unexpected readdirSync(${dir})`);
+    });
+    fs.statSync.mockImplementation((file) => {
+      const sizes = {
+        [path.join(audioBase, 'top.mp3')]: 100,
+        [path.join(audioBase, 'de', 'deadbeef.mp3')]: 200,
+        [path.join(artworkBase, 'cover.jpg')]: 50,
+      };
+      return { size: sizes[file] ?? 0 };
+    });
+
+    expect(getLibraryDiskUsage(1)).toBe(350);
+  });
+
+  it('returns 0 when a base directory does not exist yet', () => {
+    fs.readdirSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(getLibraryDiskUsage(1)).toBe(0);
   });
 });

--- a/src/audio/importManager.js
+++ b/src/audio/importManager.js
@@ -101,6 +101,34 @@ export function getArtworkBase(libraryId) {
   return defaultArtworkBase(libraryId);
 }
 
+function getDirSize(dir) {
+  let total = 0;
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0; // not created yet (e.g. brand-new library with no imports)
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      total += getDirSize(full);
+    } else if (entry.isFile()) {
+      try {
+        total += fs.statSync(full).size;
+      } catch {
+        /* file removed mid-scan */
+      }
+    }
+  }
+  return total;
+}
+
+/** Total bytes a library's audio + artwork files occupy on disk. */
+export function getLibraryDiskUsage(libraryId) {
+  return getDirSize(getLibraryBase(libraryId)) + getDirSize(getArtworkBase(libraryId));
+}
+
 export function getStorageFormat(libraryId) {
   return getLibrary(libraryId)?.storage_format === 'readable' ? 'readable' : 'hashed';
 }

--- a/src/main.js
+++ b/src/main.js
@@ -79,6 +79,7 @@ import {
   getStorageFormat,
   convertStorageFormat,
   moveTrackToLibrary,
+  getLibraryDiskUsage,
 } from './audio/importManager.js';
 import {
   listLibraries,
@@ -501,7 +502,14 @@ ipcMain.handle('move-library', async (event, newDir, libraryId) => {
 // active/visible at the same time — no restart to "switch" between them.
 // "Current library" only affects where new imports land.
 
-ipcMain.handle('list-libraries', () => listLibraries());
+ipcMain.handle('list-libraries', () =>
+  // root_path is null for a library on its (unscoped-by-user) default path —
+  // resolve it so the renderer always has a real path to display.
+  listLibraries().map((lib) => ({ ...lib, effective_root_path: getLibraryBase(lib.id) }))
+);
+ipcMain.handle('get-library-size', (_, libraryId) =>
+  getLibraryDiskUsage(libraryId ?? getCurrentLibraryId())
+);
 ipcMain.handle('get-current-library-id', () => getCurrentLibraryId());
 ipcMain.handle('set-current-library-id', (_, id) => setCurrentLibraryId(id));
 ipcMain.handle('create-library', (_, opts) => {
@@ -527,6 +535,13 @@ ipcMain.handle('convert-storage-format', (_, libraryId, newFormat) =>
 // the database file itself can't be relocated while better-sqlite3 has it
 // open — close it, move it, record the new location, then restart.
 ipcMain.handle('get-db-path', () => getDbPath(app.getPath('userData')));
+ipcMain.handle('get-db-size', () => {
+  try {
+    return fs.statSync(getDbPath(app.getPath('userData'))).size;
+  } catch {
+    return 0;
+  }
+});
 ipcMain.handle('move-database', async (_, newDir) => {
   const oldPath = getDbPath(app.getPath('userData'));
   const newPath = path.join(newDir, path.basename(oldPath));

--- a/src/preload.js
+++ b/src/preload.js
@@ -94,6 +94,7 @@ contextBridge.exposeInMainWorld('api', {
   // Multiple libraries (#390) — all active at once, no switching/restart
   // except to relocate the database file itself (moveDatabase).
   listLibraries: () => ipcRenderer.invoke('list-libraries'),
+  getLibrarySize: (libraryId) => ipcRenderer.invoke('get-library-size', libraryId),
   getCurrentLibraryId: () => ipcRenderer.invoke('get-current-library-id'),
   setCurrentLibraryId: (id) => ipcRenderer.invoke('set-current-library-id', id),
   createLibrary: (opts) => ipcRenderer.invoke('create-library', opts),
@@ -107,6 +108,7 @@ contextBridge.exposeInMainWorld('api', {
     return () => ipcRenderer.removeAllListeners('convert-storage-format-progress');
   },
   getDbPath: () => ipcRenderer.invoke('get-db-path'),
+  getDbSize: () => ipcRenderer.invoke('get-db-size'),
   moveDatabase: (newDir) => ipcRenderer.invoke('move-database', newDir),
   normalizeLibrary: () => ipcRenderer.invoke('normalize-library'),
   getNormalizedCount: () => ipcRenderer.invoke('get-normalized-count'),


### PR DESCRIPTION
## What
- Reword the Database Location description in Settings to make clear the shared file is a **metadata** database (track info, playlists, cue points, settings) — not where audio files live.
- Display the database file's size (MB/GB/TB) next to its path.
- Display each library's disk usage (audio + artwork combined, MB/GB/TB) next to its path.
- Fix the library path display: it previously showed a generic `(default location)` placeholder for libraries without an explicit `root_path`; it now shows the actual resolved path via a new `effective_root_path` field.
- UI polish: each library's size is now shown as a small badge next to its name (matching the "current" badge style) instead of plain text in the path row; the "Rename" text button was replaced with a compact ✎ icon button placed before the library name; added spacing between the library list and the "New Library" card so they're no longer flush against each other.

## Why
Users were confused into thinking the shared database file was where their audio lived, and had no visibility into how much disk space libraries or the DB were using. The placeholder text was also just unhelpful — the real path is always resolvable. The follow-up polish addresses layout/spacing feedback on the first pass of this UI.

## How
- `src/audio/importManager.js`: new `getDirSize()` helper (recursive, tolerant of missing dirs) and exported `getLibraryDiskUsage(libraryId)` = audio base + artwork base size.
- `src/main.js`: `list-libraries` now maps each library through `getLibraryBase()` to add `effective_root_path`; new `get-library-size` and `get-db-size` IPC handlers.
- `src/preload.js`: expose `getLibrarySize` / `getDbSize`.
- `renderer/src/SettingsModal.jsx`: new `formatBytes()` (MB and up only), fetch + display DB size and per-library sizes, use `effective_root_path` for the path display. Library size moved into the name row as a badge; rename button replaced with an icon button before the name.
- `renderer/src/SettingsModal.css`: `.settings-size-display` for the DB size; `.library-size-badge` for the per-library size badge; `.library-rename-btn` for the icon button; `margin-top` on `.library-card--new` to fix the missing gap before the "New Library" card.
- `renderer/src/__tests__/setup.js`: mock the new IPC methods and updated `listLibraries` shape.
- `src/__tests__/importManager.test.js`: added `readdirSync`/`statSync` stubs to the `fs` mock and two tests for `getLibraryDiskUsage` (recursive sum across nested dirs; returns 0 when a base dir doesn't exist).

## Test plan
- [x] `npx vitest run src/__tests__/importManager.test.js` — 33/33 passing (31 existing + 2 new)
- [x] `npx prettier --check` / `npx eslint` clean on all changed files (main + renderer)
- [ ] Manual: open Settings → Library tab, confirm each library shows a real path, a size badge next to its name, and the rename icon works; open Database tab, confirm size shows and description reads correctly
