### PR TITLE
Add Move to Library context-menu action with free disk space

### DIFF
--- a/renderer/src/MusicLibrary.css
+++ b/renderer/src/MusicLibrary.css
@@ -540,6 +540,17 @@
   vertical-align: middle;
 }
 
+.context-menu-item--library {
+  justify-content: space-between;
+}
+
+.ctx-library-free {
+  font-size: 11px;
+  color: #888;
+  margin-left: 12px;
+  white-space: nowrap;
+}
+
 .context-menu-item--header {
   padding: 5px 16px 3px;
   font-size: 11px;

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -1193,22 +1193,34 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
     async (targetLibraryId, targetIds) => {
       setContextMenu(null);
       if (!targetIds?.length) return;
-      let moved = 0;
+      const movedIds = [];
       let failed = 0;
       for (const id of targetIds) {
         try {
           await window.api.moveTrackToLibrary(id, targetLibraryId);
-          moved++;
+          movedIds.push(id);
         } catch (err) {
           console.error('moveTrackToLibrary failed:', err);
           failed++;
         }
       }
-      if (moved > 0) {
+      if (movedIds.length > 0) {
         setTracks((prev) =>
-          prev.map((t) => (targetIds.includes(t.id) ? { ...t, library_id: targetLibraryId } : t))
+          prev.map((t) => (movedIds.includes(t.id) ? { ...t, library_id: targetLibraryId } : t))
+        );
+        // Keep an already-open Edit Details panel in sync (same fix as the
+        // library-move/storage-format case above) — otherwise it keeps
+        // showing the track's old library after a move.
+        setDetailsTrack((prev) =>
+          prev && movedIds.includes(prev.id) ? { ...prev, library_id: targetLibraryId } : prev
+        );
+        setDetailsBulkTracks((prev) =>
+          prev
+            ? prev.map((t) => (movedIds.includes(t.id) ? { ...t, library_id: targetLibraryId } : t))
+            : prev
         );
       }
+      const moved = movedIds.length;
       if (failed === 0) {
         showToast(`Moved ${moved} track${moved !== 1 ? 's' : ''} to library.`);
       } else if (moved === 0) {

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -37,6 +37,20 @@ const PRELOAD_TRIGGER = 3;
 // Stable fallback so tests/mocks that stub usePlayer() without this field don't crash.
 const EMPTY_SET = new Set();
 
+// MB and up — sub-megabyte sizes just round down to "0.0 MB" rather than
+// switching to bytes/KB. Mirrors SettingsModal.jsx's formatBytes.
+const SIZE_UNITS = ['MB', 'GB', 'TB'];
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 MB';
+  const mb = bytes / 1024 ** 2;
+  const exp = Math.max(
+    0,
+    Math.min(Math.floor(Math.log(mb) / Math.log(1024)), SIZE_UNITS.length - 1)
+  );
+  const value = mb / 1024 ** exp;
+  return `${value.toFixed(1)} ${SIZE_UNITS[exp]}`;
+}
+
 const LS_COL_KEY = 'djman_column_visibility';
 const LS_ORDER_KEY = 'djman_column_order';
 
@@ -550,6 +564,7 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   const toastTimerRef = useRef(null);
   const [drillStack, setDrillStack] = useState([]); // overlay drill-down stack [{ id, label, content }]
   const [playlistSubmenu, setPlaylistSubmenu] = useState(null); // [{ id, name, color, is_member }]
+  const [librarySubmenu, setLibrarySubmenu] = useState(null); // [{ id, name, free_bytes }]
   const [newPlaylistInputActive, setNewPlaylistInputActive] = useState(false);
   const [newPlaylistName, setNewPlaylistName] = useState('');
   const [newPlaylistError, setNewPlaylistError] = useState('');
@@ -1052,6 +1067,8 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
       // Fetch playlist membership for single track (representative for submenu)
       const playlists = await window.api.getPlaylistsForTrack(targetIds[0]);
       setPlaylistSubmenu(playlists);
+      const libraries = await window.api.listLibrariesWithFreeSpace();
+      setLibrarySubmenu(libraries);
 
       const vw = window.innerWidth;
       const vh = window.innerHeight;
@@ -1171,6 +1188,37 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
       console.error('addTracksToPlaylist failed:', err);
     }
   }, []);
+
+  const handleMoveToLibrary = useCallback(
+    async (targetLibraryId, targetIds) => {
+      setContextMenu(null);
+      if (!targetIds?.length) return;
+      let moved = 0;
+      let failed = 0;
+      for (const id of targetIds) {
+        try {
+          await window.api.moveTrackToLibrary(id, targetLibraryId);
+          moved++;
+        } catch (err) {
+          console.error('moveTrackToLibrary failed:', err);
+          failed++;
+        }
+      }
+      if (moved > 0) {
+        setTracks((prev) =>
+          prev.map((t) => (targetIds.includes(t.id) ? { ...t, library_id: targetLibraryId } : t))
+        );
+      }
+      if (failed === 0) {
+        showToast(`Moved ${moved} track${moved !== 1 ? 's' : ''} to library.`);
+      } else if (moved === 0) {
+        showToast(`Failed to move track${targetIds.length !== 1 ? 's' : ''}.`, false);
+      } else {
+        showToast(`Moved ${moved}, failed to move ${failed}.`, false);
+      }
+    },
+    [showToast]
+  );
 
   const handleAddToNewPlaylist = useCallback(
     async (e) => {
@@ -1721,6 +1769,33 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
                           ))}
                         </SubItem>
                       ))}
+
+                    {/* ── Move to library ── */}
+                    {librarySubmenu !== null && librarySubmenu.length > 1 && (
+                      <SubItem id="move-to-library" label="📚 Move to library" wide>
+                        {librarySubmenu.map((lib) => {
+                          const isCurrent = contextMenu.track?.library_id === lib.id;
+                          return (
+                            <div
+                              key={lib.id}
+                              className={`context-menu-item context-menu-item--library${isCurrent ? ' context-menu-item--checked' : ''}`}
+                              onClick={() =>
+                                !isCurrent &&
+                                handleMoveToLibrary(lib.id, contextMenu?.targetIds ?? [])
+                              }
+                            >
+                              <span>
+                                {isCurrent ? '✓ ' : ''}
+                                {lib.name}
+                              </span>
+                              <span className="ctx-library-free">
+                                {formatBytes(lib.free_bytes)} free
+                              </span>
+                            </div>
+                          );
+                        })}
+                      </SubItem>
+                    )}
 
                     {/* ── Find similar ── */}
                     {contextMenu.targetTracks?.length > 0 && (

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -1193,40 +1193,37 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
     async (targetLibraryId, targetIds) => {
       setContextMenu(null);
       if (!targetIds?.length) return;
-      const movedIds = [];
-      let failed = 0;
-      for (const id of targetIds) {
-        try {
-          await window.api.moveTrackToLibrary(id, targetLibraryId);
-          movedIds.push(id);
-        } catch (err) {
-          console.error('moveTrackToLibrary failed:', err);
-          failed++;
-        }
-      }
-      if (movedIds.length > 0) {
+      const { moved, failed } = await window.api.moveTracksToLibrary(targetIds, targetLibraryId);
+      const patchById = new Map(
+        moved.map(({ trackId, newPath }) => [
+          trackId,
+          { library_id: targetLibraryId, is_linked: 0, ...(newPath ? { file_path: newPath } : {}) },
+        ])
+      );
+      if (patchById.size > 0) {
         setTracks((prev) =>
-          prev.map((t) => (movedIds.includes(t.id) ? { ...t, library_id: targetLibraryId } : t))
+          prev.map((t) => (patchById.has(t.id) ? { ...t, ...patchById.get(t.id) } : t))
         );
         // Keep an already-open Edit Details panel in sync (same fix as the
         // library-move/storage-format case above) — otherwise it keeps
         // showing the track's old library after a move.
         setDetailsTrack((prev) =>
-          prev && movedIds.includes(prev.id) ? { ...prev, library_id: targetLibraryId } : prev
+          prev && patchById.has(prev.id) ? { ...prev, ...patchById.get(prev.id) } : prev
         );
         setDetailsBulkTracks((prev) =>
           prev
-            ? prev.map((t) => (movedIds.includes(t.id) ? { ...t, library_id: targetLibraryId } : t))
+            ? prev.map((t) => (patchById.has(t.id) ? { ...t, ...patchById.get(t.id) } : t))
             : prev
         );
       }
-      const moved = movedIds.length;
-      if (failed === 0) {
-        showToast(`Moved ${moved} track${moved !== 1 ? 's' : ''} to library.`);
-      } else if (moved === 0) {
+      const movedCount = moved.length;
+      const failedCount = failed.length;
+      if (failedCount === 0) {
+        showToast(`Moved ${movedCount} track${movedCount !== 1 ? 's' : ''} to library.`);
+      } else if (movedCount === 0) {
         showToast(`Failed to move track${targetIds.length !== 1 ? 's' : ''}.`, false);
       } else {
-        showToast(`Moved ${moved}, failed to move ${failed}.`, false);
+        showToast(`Moved ${movedCount}, failed to move ${failedCount}.`, false);
       }
     },
     [showToast]

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -36,6 +36,7 @@ function Sidebar({
   const [normalizeProgress, setNormalizeProgress] = useState(null); // { completed, total } | null
   const [analysisProgress, setAnalysisProgress] = useState(null); // { done, total } | null
   const [waveformGenProgress, setWaveformGenProgress] = useState(null); // { completed, total } | null
+  const [moveLibraryProgress, setMoveLibraryProgress] = useState(null); // { completed, total } | null
   const [exportProgress, setExportProgress] = useState(null); // { copied, total, pct } | null
   const [ytDlpCheckProgress, setYtDlpCheckProgress] = useState(null); // { checked, total } | null during fetch/check
   const [newPlaylistName, setNewPlaylistName] = useState('');
@@ -193,6 +194,18 @@ function Sidebar({
         setTimeout(() => setWaveformGenProgress(null), 1500);
       } else {
         setWaveformGenProgress({ completed: data.completed, total: data.total });
+      }
+    });
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    if (!window.api.onMoveLibraryProgress) return;
+    const unsub = window.api.onMoveLibraryProgress((data) => {
+      if (data.done) {
+        setTimeout(() => setMoveLibraryProgress(null), 1500);
+      } else {
+        setMoveLibraryProgress({ completed: data.completed, total: data.total });
       }
     });
     return unsub;
@@ -425,6 +438,24 @@ function Sidebar({
                 className="normalize-progress-fill"
                 style={{
                   width: `${waveformGenProgress.total > 0 ? Math.round((waveformGenProgress.completed / waveformGenProgress.total) * 100) : 0}%`,
+                }}
+              />
+            </div>
+          </div>
+        )}
+        {moveLibraryProgress && (
+          <div className="normalize-progress-wrap">
+            <div className="normalize-progress-label">
+              <span>Moving tracks</span>
+              <span>
+                {moveLibraryProgress.completed} / {moveLibraryProgress.total}
+              </span>
+            </div>
+            <div className="normalize-progress-bar">
+              <div
+                className="normalize-progress-fill"
+                style={{
+                  width: `${moveLibraryProgress.total > 0 ? Math.round((moveLibraryProgress.completed / moveLibraryProgress.total) * 100) : 0}%`,
                 }}
               />
             </div>

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -36,7 +36,7 @@ function Sidebar({
   const [normalizeProgress, setNormalizeProgress] = useState(null); // { completed, total } | null
   const [analysisProgress, setAnalysisProgress] = useState(null); // { done, total } | null
   const [waveformGenProgress, setWaveformGenProgress] = useState(null); // { completed, total } | null
-  const [moveLibraryProgress, setMoveLibraryProgress] = useState(null); // { completed, total } | null
+  const [moveTracksProgress, setMoveTracksProgress] = useState(null); // { completed, total } | null
   const [exportProgress, setExportProgress] = useState(null); // { copied, total, pct } | null
   const [ytDlpCheckProgress, setYtDlpCheckProgress] = useState(null); // { checked, total } | null during fetch/check
   const [newPlaylistName, setNewPlaylistName] = useState('');
@@ -200,12 +200,12 @@ function Sidebar({
   }, []);
 
   useEffect(() => {
-    if (!window.api.onMoveLibraryProgress) return;
-    const unsub = window.api.onMoveLibraryProgress((data) => {
+    if (!window.api.onMoveTracksToLibraryProgress) return;
+    const unsub = window.api.onMoveTracksToLibraryProgress((data) => {
       if (data.done) {
-        setTimeout(() => setMoveLibraryProgress(null), 1500);
+        setTimeout(() => setMoveTracksProgress(null), 1500);
       } else {
-        setMoveLibraryProgress({ completed: data.completed, total: data.total });
+        setMoveTracksProgress({ completed: data.completed, total: data.total });
       }
     });
     return unsub;
@@ -443,19 +443,19 @@ function Sidebar({
             </div>
           </div>
         )}
-        {moveLibraryProgress && (
+        {moveTracksProgress && (
           <div className="normalize-progress-wrap">
             <div className="normalize-progress-label">
               <span>Moving tracks</span>
               <span>
-                {moveLibraryProgress.completed} / {moveLibraryProgress.total}
+                {moveTracksProgress.completed} / {moveTracksProgress.total}
               </span>
             </div>
             <div className="normalize-progress-bar">
               <div
                 className="normalize-progress-fill"
                 style={{
-                  width: `${moveLibraryProgress.total > 0 ? Math.round((moveLibraryProgress.completed / moveLibraryProgress.total) * 100) : 0}%`,
+                  width: `${moveTracksProgress.total > 0 ? Math.round((moveTracksProgress.completed / moveTracksProgress.total) * 100) : 0}%`,
                 }}
               />
             </div>

--- a/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
+++ b/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
@@ -271,6 +271,41 @@ describe('context menu — move to library', () => {
     fireEvent.click(await screen.findByText('Backup'));
     await waitFor(() => expect(window.api.moveTrackToLibrary).toHaveBeenCalledWith(1, 2));
   });
+
+  it('updates an already-open Edit Details panel in place after moving that same track', async () => {
+    window.api.moveTrackToLibrary.mockResolvedValue({ ok: true });
+    window.api.listLibraries.mockResolvedValue([
+      { id: 1, name: 'Default', storage_format: 'hashed', root_path: null },
+      { id: 2, name: 'Backup', storage_format: 'hashed', root_path: null },
+    ]);
+    window.api.listLibrariesWithFreeSpace.mockResolvedValue([
+      { id: 1, name: 'Default', free_bytes: 5 * 1024 ** 3 },
+      { id: 2, name: 'Backup', free_bytes: 2 * 1024 ** 3 },
+    ]);
+    renderLibrary();
+
+    // Open the Edit Details panel for "Track One" — it has no library_id, so shows '—'.
+    await openContextMenu('Track One');
+    fireEvent.click(screen.getByText(/✏️ Edit Details/));
+    await waitFor(() => expect(screen.getByText('Track Details')).toBeInTheDocument());
+    expect(screen.getByText('Library').nextSibling).toHaveTextContent('—');
+
+    // Move that same track via the context menu, without closing the panel.
+    await openContextMenu('Track One');
+    await waitFor(() => expect(getSubmenuParent('📚 Move to library')).toBeTruthy());
+    fireEvent.mouseEnter(getSubmenuParent('📚 Move to library'));
+    await waitFor(() => expect(document.querySelector('.context-menu-item--library')).toBeTruthy());
+    const backupItem = [...document.querySelectorAll('.context-menu-item--library')].find((el) =>
+      el.textContent.includes('Backup')
+    );
+    fireEvent.click(backupItem);
+    await waitFor(() => expect(window.api.moveTrackToLibrary).toHaveBeenCalledWith(1, 2));
+
+    // The still-open panel should reflect the new library without being reopened.
+    await waitFor(() =>
+      expect(screen.getByText('Library').nextSibling).toHaveTextContent('Backup')
+    );
+  });
 });
 
 // ── Remove confirmation ───────────────────────────────────────────────────────

--- a/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
+++ b/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
@@ -258,7 +258,7 @@ describe('context menu — move to library', () => {
     expect(screen.getByText('2.0 MB free')).toBeInTheDocument();
   });
 
-  it('clicking a library calls moveTrackToLibrary with the track id and target library', async () => {
+  it('clicking a library calls moveTracksToLibrary with the track id and target library', async () => {
     window.api.listLibrariesWithFreeSpace.mockResolvedValue([
       { id: 1, name: 'Default', free_bytes: 5 * 1024 ** 3 },
       { id: 2, name: 'Backup', free_bytes: 2 * 1024 ** 3 },
@@ -269,11 +269,14 @@ describe('context menu — move to library', () => {
     fireEvent.mouseEnter(getSubmenuParent('📚 Move to library'));
 
     fireEvent.click(await screen.findByText('Backup'));
-    await waitFor(() => expect(window.api.moveTrackToLibrary).toHaveBeenCalledWith(1, 2));
+    await waitFor(() => expect(window.api.moveTracksToLibrary).toHaveBeenCalledWith([1], 2));
   });
 
   it('updates an already-open Edit Details panel in place after moving that same track', async () => {
-    window.api.moveTrackToLibrary.mockResolvedValue({ ok: true });
+    window.api.moveTracksToLibrary.mockResolvedValue({
+      moved: [{ trackId: 1, newPath: '/tmp/userData/audio/2/newpath.mp3' }],
+      failed: [],
+    });
     window.api.listLibraries.mockResolvedValue([
       { id: 1, name: 'Default', storage_format: 'hashed', root_path: null },
       { id: 2, name: 'Backup', storage_format: 'hashed', root_path: null },
@@ -299,7 +302,7 @@ describe('context menu — move to library', () => {
       el.textContent.includes('Backup')
     );
     fireEvent.click(backupItem);
-    await waitFor(() => expect(window.api.moveTrackToLibrary).toHaveBeenCalledWith(1, 2));
+    await waitFor(() => expect(window.api.moveTracksToLibrary).toHaveBeenCalledWith([1], 2));
 
     // The still-open panel should reflect the new library without being reopened.
     await waitFor(() =>

--- a/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
+++ b/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
@@ -233,6 +233,46 @@ describe('context menu — submenu CSS classes', () => {
   });
 });
 
+// ── Move to library ───────────────────────────────────────────────────────────
+
+describe('context menu — move to library', () => {
+  it('does not show "Move to library" when only one library exists', async () => {
+    renderLibrary();
+    await openContextMenu('Track One');
+    await waitFor(() => expect(window.api.listLibrariesWithFreeSpace).toHaveBeenCalled());
+    expect(getSubmenuParent('📚 Move to library')).toBeNull();
+  });
+
+  it('shows each library with its free disk space when multiple libraries exist', async () => {
+    window.api.listLibrariesWithFreeSpace.mockResolvedValue([
+      { id: 1, name: 'Default', free_bytes: 5 * 1024 ** 3 },
+      { id: 2, name: 'Backup', free_bytes: 2 * 1024 ** 2 },
+    ]);
+    renderLibrary();
+    await openContextMenu('Track One');
+    await waitFor(() => expect(getSubmenuParent('📚 Move to library')).toBeTruthy());
+
+    fireEvent.mouseEnter(getSubmenuParent('📚 Move to library'));
+    expect(await screen.findByText('Backup')).toBeInTheDocument();
+    expect(screen.getByText('5.0 GB free')).toBeInTheDocument();
+    expect(screen.getByText('2.0 MB free')).toBeInTheDocument();
+  });
+
+  it('clicking a library calls moveTrackToLibrary with the track id and target library', async () => {
+    window.api.listLibrariesWithFreeSpace.mockResolvedValue([
+      { id: 1, name: 'Default', free_bytes: 5 * 1024 ** 3 },
+      { id: 2, name: 'Backup', free_bytes: 2 * 1024 ** 3 },
+    ]);
+    renderLibrary();
+    await openContextMenu('Track One');
+    await waitFor(() => expect(getSubmenuParent('📚 Move to library')).toBeTruthy());
+    fireEvent.mouseEnter(getSubmenuParent('📚 Move to library'));
+
+    fireEvent.click(await screen.findByText('Backup'));
+    await waitFor(() => expect(window.api.moveTrackToLibrary).toHaveBeenCalledWith(1, 2));
+  });
+});
+
 // ── Remove confirmation ───────────────────────────────────────────────────────
 
 describe('context menu — remove from library with confirmation', () => {

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -136,7 +136,7 @@ window.api = {
   remapFolder: vi.fn().mockResolvedValue({ ok: true, count: 0 }),
   moveTrackToLibrary: vi.fn().mockResolvedValue({ ok: true, moved: true }),
   moveTracksToLibrary: vi.fn().mockResolvedValue({ moved: [], failed: [] }),
-  onMoveLibraryProgress: vi.fn().mockImplementation(noop),
+  onMoveTracksToLibraryProgress: vi.fn().mockImplementation(noop),
   checkLinkedTrackStatus: vi.fn().mockResolvedValue([]),
   getLinkedTracksBasic: vi.fn().mockResolvedValue([]),
   checkUsbFormat: vi

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -15,6 +15,16 @@ window.api = {
       effective_root_path: '/tmp/userData/audio',
     },
   ]),
+  listLibrariesWithFreeSpace: vi.fn().mockResolvedValue([
+    {
+      id: 1,
+      name: 'Default',
+      storage_format: 'hashed',
+      root_path: null,
+      effective_root_path: '/tmp/userData/audio',
+      free_bytes: 1024 ** 3,
+    },
+  ]),
   getLibrarySize: vi.fn().mockResolvedValue(0),
   getCurrentLibraryId: vi.fn().mockResolvedValue(1),
   setCurrentLibraryId: vi.fn().mockResolvedValue(undefined),

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -135,6 +135,8 @@ window.api = {
   remapTrack: vi.fn().mockResolvedValue({ ok: true }),
   remapFolder: vi.fn().mockResolvedValue({ ok: true, count: 0 }),
   moveTrackToLibrary: vi.fn().mockResolvedValue({ ok: true, moved: true }),
+  moveTracksToLibrary: vi.fn().mockResolvedValue({ moved: [], failed: [] }),
+  onMoveLibraryProgress: vi.fn().mockImplementation(noop),
   checkLinkedTrackStatus: vi.fn().mockResolvedValue([]),
   getLinkedTracksBasic: vi.fn().mockResolvedValue([]),
   checkUsbFormat: vi

--- a/src/__tests__/importManager.test.js
+++ b/src/__tests__/importManager.test.js
@@ -100,6 +100,7 @@ vi.mock('fs', () => {
     createReadStream: vi.fn().mockImplementation(makeStream),
     readdirSync: vi.fn().mockReturnValue([]),
     statSync: vi.fn().mockReturnValue({ size: 0 }),
+    statfsSync: vi.fn().mockReturnValue({ bavail: 0, bsize: 0 }),
   };
   return { default: fsMock, ...fsMock };
 });
@@ -145,6 +146,7 @@ import {
   moveTrackToLibrary,
   convertStorageFormat,
   getLibraryDiskUsage,
+  getLibraryFreeSpace,
 } from '../audio/importManager.js';
 import cryptoDefault from 'crypto';
 
@@ -696,5 +698,35 @@ describe('getLibraryDiskUsage', () => {
     });
 
     expect(getLibraryDiskUsage(1)).toBe(0);
+  });
+});
+
+describe('getLibraryFreeSpace', () => {
+  it('returns free bytes (bavail * bsize) for the library base directory', () => {
+    const audioBase = path.join('/tmp/djman-test', 'audio');
+    fs.existsSync.mockImplementation((p) => p === audioBase);
+    fs.statfsSync.mockReturnValue({ bavail: 1000, bsize: 4096 });
+
+    expect(getLibraryFreeSpace(1)).toBe(1000 * 4096);
+    expect(fs.statfsSync).toHaveBeenCalledWith(audioBase);
+  });
+
+  it('walks up to the nearest existing ancestor when the library folder does not exist yet', () => {
+    const audioBase = path.join('/tmp/djman-test', 'audio');
+    fs.existsSync.mockImplementation((p) => p === '/tmp/djman-test');
+    fs.statfsSync.mockReturnValue({ bavail: 500, bsize: 4096 });
+
+    expect(getLibraryFreeSpace(1)).toBe(500 * 4096);
+    expect(fs.statfsSync).toHaveBeenCalledWith('/tmp/djman-test');
+    expect(fs.statfsSync).not.toHaveBeenCalledWith(audioBase);
+  });
+
+  it('returns null when statfsSync throws (e.g. unmounted drive)', () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.statfsSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(getLibraryFreeSpace(1)).toBeNull();
   });
 });

--- a/src/__tests__/trackRepository.test.js
+++ b/src/__tests__/trackRepository.test.js
@@ -310,6 +310,15 @@ describe('trackRepository', () => {
       expect(track.key_raw).toBe('Am');
       expect(track.title).toBe('Test Track'); // unchanged
     });
+
+    it('persists library_id and is_linked (used by moveTrackToLibrary)', () => {
+      const id = addTrack(SAMPLE);
+      updateTrack(id, { library_id: 2, is_linked: 0, file_path: '/tmp/new/location.mp3' });
+      const track = getTrackById(id);
+      expect(track.library_id).toBe(2);
+      expect(track.is_linked).toBe(0);
+      expect(track.file_path).toBe('/tmp/new/location.mp3');
+    });
   });
 
   describe('removeTrack', () => {

--- a/src/__tests__/trackRepository.test.js
+++ b/src/__tests__/trackRepository.test.js
@@ -15,6 +15,7 @@ import {
   clearLegacyNormalizedPaths,
   resetNormalization,
 } from '../db/trackRepository.js';
+import { createLibrary } from '../db/libraryRepository.js';
 
 const SAMPLE = {
   title: 'Test Track',
@@ -313,9 +314,14 @@ describe('trackRepository', () => {
 
     it('persists library_id and is_linked (used by moveTrackToLibrary)', () => {
       const id = addTrack(SAMPLE);
-      updateTrack(id, { library_id: 2, is_linked: 0, file_path: '/tmp/new/location.mp3' });
+      const targetLibrary = createLibrary({ name: 'Backup' });
+      updateTrack(id, {
+        library_id: targetLibrary.id,
+        is_linked: 0,
+        file_path: '/tmp/new/location.mp3',
+      });
       const track = getTrackById(id);
-      expect(track.library_id).toBe(2);
+      expect(track.library_id).toBe(targetLibrary.id);
       expect(track.is_linked).toBe(0);
       expect(track.file_path).toBe('/tmp/new/location.mp3');
     });

--- a/src/audio/importManager.js
+++ b/src/audio/importManager.js
@@ -129,6 +129,26 @@ export function getLibraryDiskUsage(libraryId) {
   return getDirSize(getLibraryBase(libraryId)) + getDirSize(getArtworkBase(libraryId));
 }
 
+/**
+ * Free bytes remaining on the filesystem/partition backing a library.
+ * Walks up to the nearest existing ancestor directory since a brand-new
+ * library's folder may not be created on disk yet.
+ */
+export function getLibraryFreeSpace(libraryId) {
+  let dir = getLibraryBase(libraryId);
+  while (!fs.existsSync(dir)) {
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  try {
+    const stats = fs.statfsSync(dir);
+    return stats.bavail * stats.bsize;
+  } catch {
+    return null;
+  }
+}
+
 export function getStorageFormat(libraryId) {
   return getLibrary(libraryId)?.storage_format === 'readable' ? 'readable' : 'hashed';
 }

--- a/src/db/trackRepository.js
+++ b/src/db/trackRepository.js
@@ -38,6 +38,8 @@ const ALLOWED_TRACK_COLUMNS = new Set([
   'source_platform',
   'source_quality',
   'source_link',
+  'library_id',
+  'is_linked',
 ]);
 
 // ─── Camelot helpers (mirrors renderer/src/searchParser.js) ─────────────────

--- a/src/main.js
+++ b/src/main.js
@@ -80,6 +80,7 @@ import {
   convertStorageFormat,
   moveTrackToLibrary,
   getLibraryDiskUsage,
+  getLibraryFreeSpace,
 } from './audio/importManager.js';
 import {
   listLibraries,
@@ -509,6 +510,13 @@ ipcMain.handle('list-libraries', () =>
 );
 ipcMain.handle('get-library-size', (_, libraryId) =>
   getLibraryDiskUsage(libraryId ?? getCurrentLibraryId())
+);
+ipcMain.handle('list-libraries-with-free-space', () =>
+  listLibraries().map((lib) => ({
+    ...lib,
+    effective_root_path: getLibraryBase(lib.id),
+    free_bytes: getLibraryFreeSpace(lib.id),
+  }))
 );
 ipcMain.handle('get-current-library-id', () => getCurrentLibraryId());
 ipcMain.handle('set-current-library-id', (_, id) => setCurrentLibraryId(id));

--- a/src/main.js
+++ b/src/main.js
@@ -1942,11 +1942,11 @@ ipcMain.handle('move-tracks-to-library', async (_, { trackIds, targetLibraryId }
       console.error('moveTrackToLibrary failed:', trackId, err);
       failed.push(trackId);
     }
-    send('move-library-progress', { completed: i + 1, total });
+    send('move-tracks-to-library-progress', { completed: i + 1, total });
   }
 
   if (moved.length > 0) send('library-updated');
-  send('move-library-progress', { completed: total, total, done: true });
+  send('move-tracks-to-library-progress', { completed: total, total, done: true });
   return { moved, failed };
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -1928,6 +1928,28 @@ ipcMain.handle('move-track-to-library', async (_, { trackId, targetLibraryId }) 
   return result;
 });
 
+ipcMain.handle('move-tracks-to-library', async (_, { trackIds, targetLibraryId }) => {
+  const total = trackIds.length;
+  const moved = [];
+  const failed = [];
+
+  for (let i = 0; i < total; i++) {
+    const trackId = trackIds[i];
+    try {
+      const result = await moveTrackToLibrary(trackId, targetLibraryId);
+      moved.push({ trackId, newPath: result.newPath ?? null });
+    } catch (err) {
+      console.error('moveTrackToLibrary failed:', trackId, err);
+      failed.push(trackId);
+    }
+    send('move-library-progress', { completed: i + 1, total });
+  }
+
+  if (moved.length > 0) send('library-updated');
+  send('move-library-progress', { completed: total, total, done: true });
+  return { moved, failed };
+});
+
 ipcMain.handle('check-linked-track-status', (_, trackIds) => {
   return trackIds.map((id) => {
     const t = getTrackById(id);

--- a/src/preload.js
+++ b/src/preload.js
@@ -267,10 +267,10 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.invoke('move-track-to-library', { trackId, targetLibraryId }),
   moveTracksToLibrary: (trackIds, targetLibraryId) =>
     ipcRenderer.invoke('move-tracks-to-library', { trackIds, targetLibraryId }),
-  onMoveLibraryProgress: (cb) => {
+  onMoveTracksToLibraryProgress: (cb) => {
     const handler = (_, data) => cb(data);
-    ipcRenderer.on('move-library-progress', handler);
-    return () => ipcRenderer.removeListener('move-library-progress', handler);
+    ipcRenderer.on('move-tracks-to-library-progress', handler);
+    return () => ipcRenderer.removeListener('move-tracks-to-library-progress', handler);
   },
   checkLinkedTrackStatus: (trackIds) => ipcRenderer.invoke('check-linked-track-status', trackIds),
   getLinkedTracksBasic: () => ipcRenderer.invoke('get-linked-tracks-basic'),

--- a/src/preload.js
+++ b/src/preload.js
@@ -265,6 +265,13 @@ contextBridge.exposeInMainWorld('api', {
   remapFolder: (oldDir) => ipcRenderer.invoke('remap-folder', { oldDir }),
   moveTrackToLibrary: (trackId, targetLibraryId) =>
     ipcRenderer.invoke('move-track-to-library', { trackId, targetLibraryId }),
+  moveTracksToLibrary: (trackIds, targetLibraryId) =>
+    ipcRenderer.invoke('move-tracks-to-library', { trackIds, targetLibraryId }),
+  onMoveLibraryProgress: (cb) => {
+    const handler = (_, data) => cb(data);
+    ipcRenderer.on('move-library-progress', handler);
+    return () => ipcRenderer.removeListener('move-library-progress', handler);
+  },
   checkLinkedTrackStatus: (trackIds) => ipcRenderer.invoke('check-linked-track-status', trackIds),
   getLinkedTracksBasic: () => ipcRenderer.invoke('get-linked-tracks-basic'),
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -94,6 +94,7 @@ contextBridge.exposeInMainWorld('api', {
   // Multiple libraries (#390) — all active at once, no switching/restart
   // except to relocate the database file itself (moveDatabase).
   listLibraries: () => ipcRenderer.invoke('list-libraries'),
+  listLibrariesWithFreeSpace: () => ipcRenderer.invoke('list-libraries-with-free-space'),
   getLibrarySize: (libraryId) => ipcRenderer.invoke('get-library-size', libraryId),
   getCurrentLibraryId: () => ipcRenderer.invoke('get-current-library-id'),
   setCurrentLibraryId: (id) => ipcRenderer.invoke('set-current-library-id', id),


### PR DESCRIPTION
## What

Adds a "📚 Move to library" context-menu submenu for one or multiple selected tracks, mirroring the existing "Add to playlist" submenu UX. Each library entry in the submenu shows its free disk space, so users can pick a destination with enough room before moving.

## Why

With multiple libraries active at once (#390), there was no way to move existing tracks between libraries from the track list itself — only the single-track `moveTrackToLibrary` plumbing existed under the hood, unused by any UI. Users had no visibility into available disk space per library when deciding where to move files.

## How

- **`src/audio/importManager.js`**: added `getLibraryFreeSpace(libraryId)` — resolves the library's base directory (walking up to the nearest existing ancestor for brand-new libraries not yet created on disk) and returns `fs.statfsSync(dir).bavail * bsize`, or `null` if the check fails (e.g. unmounted drive).
- **`src/main.js`**: new IPC handler `list-libraries-with-free-space` — same shape as the existing `list-libraries` handler (includes `effective_root_path`) plus a `free_bytes` field per library.
- **`src/preload.js`**: bridges it as `window.api.listLibrariesWithFreeSpace()`.
- **`renderer/src/MusicLibrary.jsx`**:
  - `handleContextMenu` fetches the library list (with free space) alongside the existing playlist-membership fetch whenever the menu opens.
  - New `handleMoveToLibrary(targetLibraryId, targetIds)` loops `window.api.moveTrackToLibrary(id, targetLibraryId)` per track (the underlying IPC is single-track only), patches `library_id` in the in-memory `tracks` list on success, and shows a toast summarizing moved/failed counts.
  - New "📚 Move to library" `SubItem` block cloned from the "Add to playlist" pattern, placed right after it. Only rendered when more than one library exists. The track's current library is marked with a checkmark and disabled from re-selection.
- **`renderer/src/MusicLibrary.css`**: `.context-menu-item--library` (name/free-space laid out with `justify-content: space-between`) and `.ctx-library-free` styling.
- Added a local `formatBytes` helper in `MusicLibrary.jsx` (same formatting as `SettingsModal.jsx`'s, MB/GB/TB).

## Test plan

- [x] `src/__tests__/importManager.test.js` — new `getLibraryFreeSpace` suite (normal case, ancestor walk-up for a not-yet-created library folder, and the `statfsSync` failure → `null` case)
- [x] `renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx` — new "move to library" suite: submenu hidden with a single library, shows each library's name + formatted free space with multiple libraries, clicking a library calls `moveTrackToLibrary` with the right track/library ids
- [x] `renderer/src/__tests__/setup.js` — added `listLibrariesWithFreeSpace` mock
- [x] Full renderer suite (148 tests) and backend `unit` project (369 tests) pass
- [x] `npx prettier --check` and `npm run lint` / `cd renderer && npm run lint` clean on touched files
