### PR TITLE
Delete audio file when removing an imported track

### DIFF
--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -1156,8 +1156,8 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
     const n = targetIds.length;
     const msg =
       n === 1
-        ? 'Remove this track from your library? This cannot be undone.'
-        : `Remove ${n} tracks from your library? This cannot be undone.`;
+        ? 'Remove this track from your library? Imported tracks also have their audio file deleted from disk. This cannot be undone.'
+        : `Remove ${n} tracks from your library? Imported tracks also have their audio files deleted from disk. This cannot be undone.`;
     if (!window.confirm(msg)) return;
     if (currentTrack && targetIds.includes(currentTrack.id)) stop();
     setContextMenu(null);

--- a/src/__tests__/trackRepository.test.js
+++ b/src/__tests__/trackRepository.test.js
@@ -6,6 +6,7 @@ import {
   getTrackByHash,
   updateTrack,
   removeTrack,
+  getTrackCountByFilePath,
   getTrackIds,
   normalizeLibrary,
   clearTracks,
@@ -339,6 +340,22 @@ describe('trackRepository', () => {
       const id2 = addTrack({ ...SAMPLE, file_hash: 'other', file_path: '/tmp/other.mp3' });
       removeTrack(id1);
       expect(getTrackById(id2)).toBeDefined();
+    });
+  });
+
+  describe('getTrackCountByFilePath', () => {
+    it('returns 0 when no track references the path', () => {
+      expect(getTrackCountByFilePath('/tmp/nope.mp3')).toBe(0);
+    });
+
+    it('counts tracks sharing the same file_path', () => {
+      const id1 = addTrack(SAMPLE);
+      const id2 = addTrack({ ...SAMPLE, file_hash: 'dup', file_path: SAMPLE.file_path });
+      expect(getTrackCountByFilePath(SAMPLE.file_path)).toBe(2);
+      removeTrack(id1);
+      expect(getTrackCountByFilePath(SAMPLE.file_path)).toBe(1);
+      removeTrack(id2);
+      expect(getTrackCountByFilePath(SAMPLE.file_path)).toBe(0);
     });
   });
 

--- a/src/db/trackRepository.js
+++ b/src/db/trackRepository.js
@@ -410,6 +410,11 @@ export function removeTrack(id) {
   db.prepare('DELETE FROM tracks WHERE id = ?').run(id);
 }
 
+/** Counts tracks still referencing this file_path — used to avoid deleting a file that another track row still points at. */
+export function getTrackCountByFilePath(filePath) {
+  return db.prepare('SELECT COUNT(*) AS n FROM tracks WHERE file_path = ?').get(filePath).n;
+}
+
 export function normalizeLibrary(targetLufs) {
   const info = db
     .prepare(

--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,7 @@ import {
   getLinkedTracksBasic,
   remapTracksByPrefix,
   removeTrack,
+  getTrackCountByFilePath,
   updateTrack,
   resetNormalization,
   clearTracksForLibrary,
@@ -647,7 +648,20 @@ ipcMain.handle('cancel-analysis', (_, trackId) => {
   return { cancelled };
 });
 ipcMain.handle('remove-track', (_, trackId) => {
+  const track = getTrackById(trackId);
   removeTrack(trackId); // ON DELETE CASCADE removes playlist_tracks rows
+  // Imported tracks own their copy in userData/audio — delete it too, unless another
+  // track row still references the same path (SHA-1 import dedup isn't transactional,
+  // so two rows can share one file_path).
+  if (track && !track.is_linked && track.file_path) {
+    if (getTrackCountByFilePath(track.file_path) === 0) {
+      try {
+        fs.unlinkSync(track.file_path);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
   if (global.mainWindow) global.mainWindow.webContents.send('playlists-updated');
   return { ok: true };
 });


### PR DESCRIPTION
Closes #452

## What
- `remove-track` IPC handler now deletes the underlying audio file for imported tracks (`is_linked = 0`) when removed from the library, not just the DB row.
- Linked tracks are untouched on disk, same as before.
- Safety guard: before unlinking, checks `getTrackCountByFilePath()` for any other track row still referencing the same `file_path` (import dedup by SHA-1 hash is not transactional, so two rows can in rare cases share one file) — skips the filesystem delete if so.
- Updated the `handleRemove` confirm dialog in MusicLibrary to disclose that imported tracks also lose their file on disk.

## Why
`removeTrack()` only ever ran `DELETE FROM tracks`, so imported/owned copies in `userData/audio/` accumulated as orphans forever.

## Test plan
- [x] `npm test` (root) — 461 passed
- [x] `cd renderer && npx vitest run` — 158 passed
- [x] eslint + prettier clean on all touched files
- [x] Added a `getTrackCountByFilePath` unit test covering the shared-path guard