### PR TITLE
Bulk remove-tracks IPC handler with progress reporting

### DIFF
--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -1161,7 +1161,7 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
     if (!window.confirm(msg)) return;
     if (currentTrack && targetIds.includes(currentTrack.id)) stop();
     setContextMenu(null);
-    for (const id of targetIds) await window.api.removeTrack(id);
+    await window.api.removeTracks(targetIds);
     setTracks((prev) => prev.filter((t) => !targetIds.includes(t.id)));
     setSelectedIds(new Set());
     offsetRef.current = Math.max(0, offsetRef.current - targetIds.length);

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -1156,8 +1156,8 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
     const n = targetIds.length;
     const msg =
       n === 1
-        ? 'Remove this track from your library? This cannot be undone.'
-        : `Remove ${n} tracks from your library? This cannot be undone.`;
+        ? 'Remove this track from your library? Imported tracks also have their audio file deleted from disk. This cannot be undone.'
+        : `Remove ${n} tracks from your library? Imported tracks also have their audio files deleted from disk. This cannot be undone.`;
     if (!window.confirm(msg)) return;
     if (currentTrack && targetIds.includes(currentTrack.id)) stop();
     setContextMenu(null);

--- a/renderer/src/Sidebar.jsx
+++ b/renderer/src/Sidebar.jsx
@@ -37,6 +37,7 @@ function Sidebar({
   const [analysisProgress, setAnalysisProgress] = useState(null); // { done, total } | null
   const [waveformGenProgress, setWaveformGenProgress] = useState(null); // { completed, total } | null
   const [moveTracksProgress, setMoveTracksProgress] = useState(null); // { completed, total } | null
+  const [removeTracksProgress, setRemoveTracksProgress] = useState(null); // { completed, total } | null
   const [exportProgress, setExportProgress] = useState(null); // { copied, total, pct } | null
   const [ytDlpCheckProgress, setYtDlpCheckProgress] = useState(null); // { checked, total } | null during fetch/check
   const [newPlaylistName, setNewPlaylistName] = useState('');
@@ -206,6 +207,18 @@ function Sidebar({
         setTimeout(() => setMoveTracksProgress(null), 1500);
       } else {
         setMoveTracksProgress({ completed: data.completed, total: data.total });
+      }
+    });
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    if (!window.api.onRemoveTracksProgress) return;
+    const unsub = window.api.onRemoveTracksProgress((data) => {
+      if (data.done) {
+        setTimeout(() => setRemoveTracksProgress(null), 1500);
+      } else {
+        setRemoveTracksProgress({ completed: data.completed, total: data.total });
       }
     });
     return unsub;
@@ -456,6 +469,24 @@ function Sidebar({
                 className="normalize-progress-fill"
                 style={{
                   width: `${moveTracksProgress.total > 0 ? Math.round((moveTracksProgress.completed / moveTracksProgress.total) * 100) : 0}%`,
+                }}
+              />
+            </div>
+          </div>
+        )}
+        {removeTracksProgress && (
+          <div className="normalize-progress-wrap">
+            <div className="normalize-progress-label">
+              <span>Removing tracks</span>
+              <span>
+                {removeTracksProgress.completed} / {removeTracksProgress.total}
+              </span>
+            </div>
+            <div className="normalize-progress-bar">
+              <div
+                className="normalize-progress-fill"
+                style={{
+                  width: `${removeTracksProgress.total > 0 ? Math.round((removeTracksProgress.completed / removeTracksProgress.total) * 100) : 0}%`,
                 }}
               />
             </div>

--- a/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
+++ b/renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx
@@ -323,20 +323,20 @@ describe('context menu — remove from library with confirmation', () => {
     expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('Remove'));
   });
 
-  it('if window.confirm returns false, removeTrack is NOT called', async () => {
+  it('if window.confirm returns false, removeTracks is NOT called', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(false);
     renderLibrary();
     await openContextMenu('Track One');
     fireEvent.click(screen.getByText(/🗑️ Remove from library/));
-    expect(window.api.removeTrack).not.toHaveBeenCalled();
+    expect(window.api.removeTracks).not.toHaveBeenCalled();
   });
 
-  it('if window.confirm returns true, removeTrack IS called with the track ID', async () => {
+  it('if window.confirm returns true, removeTracks IS called with the track ID', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     renderLibrary();
     await openContextMenu('Track One');
     fireEvent.click(screen.getByText(/🗑️ Remove from library/));
-    await waitFor(() => expect(window.api.removeTrack).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(window.api.removeTracks).toHaveBeenCalledWith([1]));
   });
 });
 

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -62,6 +62,8 @@ window.api = {
   getZoomFactor: vi.fn().mockReturnValue(1.0),
   setZoomFactor: vi.fn(),
   removeTrack: vi.fn().mockResolvedValue({ ok: true }),
+  removeTracks: vi.fn().mockResolvedValue({ ok: true, total: 0 }),
+  onRemoveTracksProgress: vi.fn().mockImplementation(noop),
   removeLinkedFile: vi.fn().mockResolvedValue({ ok: true }),
   adjustBpm: vi.fn().mockResolvedValue([]),
   updateTrack: vi.fn().mockResolvedValue({}),

--- a/src/__tests__/trackRepository.test.js
+++ b/src/__tests__/trackRepository.test.js
@@ -6,6 +6,7 @@ import {
   getTrackByHash,
   updateTrack,
   removeTrack,
+  getTrackCountByFilePath,
   getTrackIds,
   normalizeLibrary,
   clearTracks,
@@ -339,6 +340,22 @@ describe('trackRepository', () => {
       const id2 = addTrack({ ...SAMPLE, file_hash: 'other', file_path: '/tmp/other.mp3' });
       removeTrack(id1);
       expect(getTrackById(id2)).toBeDefined();
+    });
+  });
+
+  describe('getTrackCountByFilePath', () => {
+    it('returns 0 when no track references the path', () => {
+      expect(getTrackCountByFilePath('/tmp/nope.mp3')).toBe(0);
+    });
+
+    it('counts tracks sharing the same file_path', () => {
+      const id1 = addTrack(SAMPLE);
+      const id2 = addTrack({ ...SAMPLE, file_hash: 'dup', file_path: SAMPLE.file_path });
+      expect(getTrackCountByFilePath(SAMPLE.file_path)).toBe(2);
+      removeTrack(id1);
+      expect(getTrackCountByFilePath(SAMPLE.file_path)).toBe(1);
+      removeTrack(id2);
+      expect(getTrackCountByFilePath(SAMPLE.file_path)).toBe(0);
     });
   });
 

--- a/src/__tests__/trackRepository.test.js
+++ b/src/__tests__/trackRepository.test.js
@@ -6,6 +6,7 @@ import {
   getTrackByHash,
   updateTrack,
   removeTrack,
+  removeTracks,
   getTrackCountByFilePath,
   getTrackIds,
   normalizeLibrary,
@@ -340,6 +341,22 @@ describe('trackRepository', () => {
       const id2 = addTrack({ ...SAMPLE, file_hash: 'other', file_path: '/tmp/other.mp3' });
       removeTrack(id1);
       expect(getTrackById(id2)).toBeDefined();
+    });
+  });
+
+  describe('removeTracks', () => {
+    it('deletes all given tracks in one transaction', () => {
+      const id1 = addTrack(SAMPLE);
+      const id2 = addTrack({ ...SAMPLE, file_hash: 'b', file_path: '/tmp/b.mp3' });
+      const id3 = addTrack({ ...SAMPLE, file_hash: 'c', file_path: '/tmp/c.mp3' });
+      removeTracks([id1, id2]);
+      expect(getTrackById(id1)).toBeUndefined();
+      expect(getTrackById(id2)).toBeUndefined();
+      expect(getTrackById(id3)).toBeDefined();
+    });
+
+    it('handles an empty array without error', () => {
+      expect(() => removeTracks([])).not.toThrow();
     });
   });
 

--- a/src/db/trackRepository.js
+++ b/src/db/trackRepository.js
@@ -410,6 +410,11 @@ export function removeTrack(id) {
   db.prepare('DELETE FROM tracks WHERE id = ?').run(id);
 }
 
+/** Counts tracks still referencing this file_path — used to avoid deleting a file that another track row still points at. */
+export function getTrackCountByFilePath(filePath) {
+  return db.prepare('SELECT COUNT(*) AS n FROM tracks WHERE file_path = ?').get(filePath).n;
+}
+
 export function normalizeLibrary(targetLufs) {
   const info = db
     .prepare(

--- a/src/db/trackRepository.js
+++ b/src/db/trackRepository.js
@@ -410,6 +410,14 @@ export function removeTrack(id) {
   db.prepare('DELETE FROM tracks WHERE id = ?').run(id);
 }
 
+/** Deletes many track rows in a single transaction (bulk remove — DB write only, no filesystem I/O). */
+export function removeTracks(trackIds) {
+  const del = db.prepare('DELETE FROM tracks WHERE id = ?');
+  db.transaction(() => {
+    for (const id of trackIds) del.run(id);
+  })();
+}
+
 /** Counts tracks still referencing this file_path — used to avoid deleting a file that another track row still points at. */
 export function getTrackCountByFilePath(filePath) {
   return db.prepare('SELECT COUNT(*) AS n FROM tracks WHERE file_path = ?').get(filePath).n;

--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,7 @@ import {
   getLinkedTracksBasic,
   remapTracksByPrefix,
   removeTrack,
+  removeTracks,
   getTrackCountByFilePath,
   updateTrack,
   resetNormalization,
@@ -664,6 +665,28 @@ ipcMain.handle('remove-track', (_, trackId) => {
   }
   if (global.mainWindow) global.mainWindow.webContents.send('playlists-updated');
   return { ok: true };
+});
+ipcMain.handle('remove-tracks', (_, trackIds) => {
+  const total = trackIds.length;
+  const tracks = trackIds.map((id) => getTrackById(id)).filter(Boolean);
+
+  removeTracks(trackIds); // single transaction — ON DELETE CASCADE removes playlist_tracks rows
+
+  for (let i = 0; i < tracks.length; i++) {
+    const track = tracks[i];
+    if (!track.is_linked && track.file_path && getTrackCountByFilePath(track.file_path) === 0) {
+      try {
+        fs.unlinkSync(track.file_path);
+      } catch {
+        /* already gone */
+      }
+    }
+    send('remove-tracks-progress', { completed: i + 1, total });
+  }
+
+  if (global.mainWindow) global.mainWindow.webContents.send('playlists-updated');
+  send('remove-tracks-progress', { completed: total, total, done: true });
+  return { ok: true, total };
 });
 ipcMain.handle('remove-linked-file', async (_, trackId) => {
   const track = getTrackById(trackId);

--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,7 @@ import {
   getLinkedTracksBasic,
   remapTracksByPrefix,
   removeTrack,
+  getTrackCountByFilePath,
   updateTrack,
   resetNormalization,
   clearTracksForLibrary,
@@ -647,7 +648,20 @@ ipcMain.handle('cancel-analysis', (_, trackId) => {
   return { cancelled };
 });
 ipcMain.handle('remove-track', (_, trackId) => {
+  const track = getTrackById(trackId);
   removeTrack(trackId); // ON DELETE CASCADE removes playlist_tracks rows
+  // Imported tracks own their copy in userData/audio — delete it too, unless another
+  // track row still references the same path (SHA-1 import dedup isn't transactional,
+  // so two rows can share one file_path).
+  if (track && !track.is_linked && track.file_path) {
+    if (getTrackCountByFilePath(track.file_path) === 0) {
+      try {
+        fs.unlinkSync(track.file_path);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
   if (global.mainWindow) global.mainWindow.webContents.send('playlists-updated');
   return { ok: true };
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -20,6 +20,12 @@ contextBridge.exposeInMainWorld('api', {
   reanalyzeTrack: (trackId) => ipcRenderer.invoke('reanalyze-track', trackId),
   cancelAnalysis: (trackId) => ipcRenderer.invoke('cancel-analysis', trackId),
   removeTrack: (trackId) => ipcRenderer.invoke('remove-track', trackId),
+  removeTracks: (trackIds) => ipcRenderer.invoke('remove-tracks', trackIds),
+  onRemoveTracksProgress: (cb) => {
+    const handler = (_, data) => cb(data);
+    ipcRenderer.on('remove-tracks-progress', handler);
+    return () => ipcRenderer.removeListener('remove-tracks-progress', handler);
+  },
   removeLinkedFile: (trackId) => ipcRenderer.invoke('remove-linked-file', trackId),
   updateTrack: (id, data) => ipcRenderer.invoke('update-track', { id, data }),
   getEditorWaveform: (trackId) => ipcRenderer.invoke('get-editor-waveform', trackId),


### PR DESCRIPTION
Closes #453

## What
Replaces the sequential per-track `removeTrack()` loop (used for bulk multi-select removal) with a single `removeTracks(trackIds)` DB call wrapped in `db.transaction()`, exposed via a new `remove-tracks` IPC handler. Progress is reported per-track via a `remove-tracks-progress` event, and the sidebar shows a progress bar while the operation runs (mirrors the existing `move-tracks-to-library` pattern). A single `playlists-updated` event fires once at the end instead of once per track.

## Why
The old loop issued N separate IPC round-trips and N `playlists-updated` broadcasts for a bulk removal, which is wasteful and gives no progress feedback for large selections. Wrapping the DB deletes in one transaction is also safer (all-or-nothing) than N independent deletes.

## How
- `src/db/trackRepository.js`: added `removeTracks(trackIds)` — single transaction, bulk `DELETE`.
- `src/main.js`: new `remove-tracks` IPC handler — deletes all rows in one transaction, then per-track file cleanup (reusing #452's `getTrackCountByFilePath` dedup-safety guard) with a progress event after each file, plus one final `playlists-updated` emit.
- `src/preload.js`: exposed `removeTracks` and `onRemoveTracksProgress`.
- `renderer/src/Sidebar.jsx`: added progress bar UI for the remove operation (reuses existing `.normalize-progress-*` CSS classes).
- `renderer/src/MusicLibrary.jsx`: bulk-remove context menu action now calls `window.api.removeTracks(ids)` instead of looping `removeTrack`.
- Tests updated/added in `src/__tests__/trackRepository.test.js` and `renderer/src/__tests__/MusicLibrary.contextmenu.test.jsx`; `renderer/src/__tests__/setup.js` got the new `window.api` mocks.

## Notes for reviewers
- This branch is stacked on `fix/452-delete-file-on-remove` (#458) since the file-cleanup logic here depends on #452's `getTrackCountByFilePath` guard. Please merge/review #458 first — this diff will shrink once that lands.
- Verified: `npm run lint` (root + renderer) clean, `npm test` (463 passed), `cd renderer && npm test` (158 passed), `npx prettier --check` clean on all touched files.