### PR TITLE
fix: pass cookiesBrowser to YouTube cloud search (#466)

### DIFF
--- a/renderer/src/DownloadContext.jsx
+++ b/renderer/src/DownloadContext.jsx
@@ -68,7 +68,10 @@ export function DownloadProvider({ children }) {
     const unsubTrack = window.api.onYtDlpTrackUpdate((update) => {
       if (update.type === 'init') {
         setTrackStatuses((prev) => {
-          if (prev.length >= update.total) return prev;
+          // handleDownload already seeded the canonical list (download + link rows).
+          // Only seed placeholder rows if the list is empty — otherwise we'd clobber
+          // the link rows and cause the download list to glitch / duplicate.
+          if (prev.length > 0) return prev;
           return Array.from({ length: update.total }, (_, i) => ({
             index: i,
             title: `Track ${i + 1}`,

--- a/src/__tests__/ytDlpManager.test.js
+++ b/src/__tests__/ytDlpManager.test.js
@@ -178,6 +178,27 @@ describe('searchYouTube', () => {
 
     expect(lastSpawnArgs).toContain('ytsearch20:some query');
   });
+
+  it('passes cookiesBrowser through to yt-dlp so YouTube search authenticates (#466)', async () => {
+    const resultPromise = searchYouTube('daft punk', { limit: 5, cookiesBrowser: 'firefox' });
+
+    fakeProc.stdout.emit('data', JSON.stringify({ entries: [] }));
+    fakeProc.emit('close', 0);
+    await resultPromise;
+
+    const cookieIdx = lastSpawnArgs.indexOf('--cookies-from-browser');
+    expect(cookieIdx).toBeGreaterThan(-1);
+    expect(lastSpawnArgs[cookieIdx + 1]).toBe('firefox');
+  });
+
+  it('does NOT add --cookies-from-browser when cookiesBrowser is omitted', async () => {
+    const resultPromise = searchYouTube('daft punk', { limit: 5 });
+    fakeProc.stdout.emit('data', JSON.stringify({ entries: [] }));
+    fakeProc.emit('close', 0);
+    await resultPromise;
+
+    expect(lastSpawnArgs).not.toContain('--cookies-from-browser');
+  });
 });
 
 // Regression for #404: the per-entry availability check used player_client=web

--- a/src/audio/ytDlpManager.js
+++ b/src/audio/ytDlpManager.js
@@ -17,9 +17,12 @@ const AUDIO_EXTS = new Set(['.mp3', '.flac', '.m4a', '.aac', '.wav', '.ogg', '.o
 // profile path, then pass it explicitly to avoid yt-dlp searching Firefox locations.
 
 const LIBREWOLF_BASE_DIRS = [
+  // Config-based install (active profile for most native/AUR builds)
+  `${process.env.HOME}/.config/librewolf`,
+  `${process.env.HOME}/.config/librewolf/librewolf`,
   // Native / AUR install
   `${process.env.HOME}/.librewolf`,
-  // Flatpak (most common on Linux desktops)
+  // Flatpak (most common on Linux desktops) — often an older/stale profile
   `${process.env.HOME}/.var/app/io.gitlab.librewolf-community/.librewolf`,
 ];
 
@@ -79,6 +82,7 @@ function resolveBrowser(name) {
     console.warn('[ytdlp] LibreWolf profile not found, falling back to firefox');
     return 'firefox';
   }
+  console.log('[ytdlp] resolveBrowser:', name, '->', name);
   return name;
 }
 
@@ -131,7 +135,13 @@ function extractTitleFromFilename(filePath) {
  */
 /** Returns true when yt-dlp fails because no format matched (EJS/cookie issue). */
 function isFormatUnavailableError(err) {
-  return err?.message?.includes('Requested format is not available');
+  const msg = err?.message ?? '';
+  // "Requested format is not available" is a WARNING emitted when the preferred
+  // player_client (android_vr) lacks a format; yt-dlp falls back automatically.
+  // It is NOT a real failure, so it must not trigger a cookies-less retry (which
+  // would then hit YouTube's 403 bot-block). Only genuine format errors retry.
+  if (/requested format is not available/i.test(msg)) return false;
+  return /format.*not available/i.test(msg);
 }
 
 export async function fetchPlaylistInfo(url, options = {}) {
@@ -141,7 +151,12 @@ export async function fetchPlaylistInfo(url, options = {}) {
     // unavailable/private/deleted videos are flagged before the selection screen.
     if (detectPlatform(url) === 'youtube' && info.type === 'playlist') {
       options.onBeforeCheck?.(info.entries);
-      await checkYouTubeAvailability(info.entries, options.onCheckProgress, options.onEntryChecked);
+      await checkYouTubeAvailability(
+        info.entries,
+        options.onCheckProgress,
+        options.onEntryChecked,
+        options
+      );
     }
     return info;
   } catch (err) {
@@ -165,12 +180,20 @@ const UNAVAILABLE_STATUSES = new Set(['private', 'premium_only', 'subscriber_onl
  * for each entry. This is the most reliable approach since it uses the exact same
  * mechanism as the actual download. Mutates entries in-place.
  */
-async function checkYouTubeAvailability(entries, onProgress, onEntryChecked) {
+async function checkYouTubeAvailability(entries, onProgress, onEntryChecked, options = {}) {
   const toCheck = entries.filter((e) => !e.unavailable && e.id);
   if (toCheck.length === 0) return;
 
   const ytDlp = getYtDlpRuntimePath();
   if (!fs.existsSync(ytDlp)) return; // binary not ready yet — skip check
+
+  // Resolve cookies so the availability check authenticates the same way the
+  // actual fetch does. Without cookies YouTube can return "Requested format is
+  // not available" for tracks that are in fact public -> false unavailable.
+  const cookiesArg = options.cookiesBrowser ? resolveBrowser(options.cookiesBrowser) : null;
+  if (cookiesArg) {
+    console.log('[ytdlp] availability check using cookies from:', cookiesArg);
+  }
 
   console.log(`[ytdlp] availability check for ${toCheck.length} entries via yt-dlp…`);
 
@@ -183,8 +206,11 @@ async function checkYouTubeAvailability(entries, onProgress, onEntryChecked) {
         '--no-warnings',
         '--extractor-args',
         'youtube:player_client=android_vr,web',
-        `https://www.youtube.com/watch?v=${entry.id}`,
       ];
+      if (cookiesArg) {
+        args.push('--cookies-from-browser', cookiesArg);
+      }
+      args.push(`https://www.youtube.com/watch?v=${entry.id}`);
       const proc = spawn(ytDlp, args);
       let stdout = '';
       let timedOut = false;
@@ -200,10 +226,15 @@ async function checkYouTubeAvailability(entries, onProgress, onEntryChecked) {
         if (timedOut) return;
         const availability = stdout.trim().toLowerCase();
         console.log(`[ytdlp] ${entry.id} availability=${availability || '(exit ' + code + ')'}`);
+        // Only treat as unavailable when yt-dlp explicitly reports an unavailable
+        // status. A non-zero exit with no availability text (e.g. crash in
+        // --print availability mode with cookies) must NOT be treated as
+        // unavailable — assume available to avoid false negatives that block
+        // downloads of perfectly public tracks.
         if (
-          code !== 0 ||
           UNAVAILABLE_STATUSES.has(availability) ||
-          availability === 'unavailable'
+          availability === 'unavailable' ||
+          availability === 'private'
         ) {
           entry.unavailable = true;
           entry.unavailableReason =
@@ -282,15 +313,35 @@ function _fetchPlaylistInfoOnce(url, options = {}) {
   const args = ['--flat-playlist', '--dump-single-json', '--no-warnings'];
 
   if (platform === 'youtube') {
-    args.push('--extractor-args', 'youtube:player_client=android_vr,web');
+    // No --extractor-args player_client pin. With valid cookies the default
+    // (tv-downgraded) client returns real audio formats; pinning android_vr/tv/web
+    // makes YouTube return only storyboard images -> "Requested format is not available".
   }
   if (options.cookiesBrowser) {
-    args.push('--cookies-from-browser', resolveBrowser(options.cookiesBrowser));
+    const resolved = resolveBrowser(options.cookiesBrowser);
+    console.log(
+      '[fetchPlaylistInfo] cookiesBrowser:',
+      options.cookiesBrowser,
+      '-> resolved:',
+      resolved
+    );
+    if (resolved) {
+      args.push('--cookies-from-browser', resolved);
+    } else {
+      console.warn(
+        '[fetchPlaylistInfo] cookiesBrowser set but resolveBrowser returned empty — yt-dlp will run WITHOUT cookies'
+      );
+    }
+  } else {
+    console.log(
+      '[fetchPlaylistInfo] no cookiesBrowser set — yt-dlp will run WITHOUT cookies (expect 403 bot-block from YouTube)'
+    );
   }
   args.push(url);
 
   return new Promise((resolve, reject) => {
-    console.log('[fetchPlaylistInfo] spawning yt-dlp with args:', args.join(' '));
+    console.log('[fetchPlaylistInfo] yt-dlp binary:', ytDlp, 'exists:', fs.existsSync(ytDlp));
+    console.log('[fetchPlaylistInfo] spawning yt-dlp with args:', JSON.stringify(args));
     let stdout = '';
     let stderr = '';
     const proc = spawn(ytDlp, args);
@@ -309,7 +360,8 @@ function _fetchPlaylistInfoOnce(url, options = {}) {
     proc.on('close', (code) => {
       console.log(`[fetchPlaylistInfo] process closed code=${code} stdout_len=${stdout.length}`);
       if (code !== 0) {
-        reject(new Error(`yt-dlp exited with code ${code}: ${stderr.trim().slice(0, 300)}`));
+        console.error('[fetchPlaylistInfo] FAILED. Full stderr:\n' + stderr.trim());
+        reject(new Error(`yt-dlp exited with code ${code}: ${stderr.trim().slice(0, 600)}`));
         return;
       }
       try {
@@ -463,7 +515,8 @@ async function _downloadUrlOnce(url, onProgress, options = {}) {
   args.push('--ffmpeg-location', path.dirname(getFfmpegRuntimePath()));
 
   if (platform === 'youtube') {
-    args.push('--extractor-args', 'youtube:player_client=android_vr,web');
+    // No player_client pin — see fetchPlaylistInfo rationale. Default client
+    // returns real audio formats with valid cookies.
   }
   if (options.cookiesBrowser) {
     args.push('--cookies-from-browser', resolveBrowser(options.cookiesBrowser));
@@ -685,13 +738,19 @@ async function _downloadUrlOnce(url, onProgress, options = {}) {
       while ((match = unavailablePattern.exec(stderr)) !== null) {
         const videoId = match[1].trim();
         const reason = match[2].trim();
+        // Ignore format-selection warnings: "Requested format is not available"
+        // is emitted by yt-dlp when a preferred player_client (e.g. android_vr)
+        // lacks a format; yt-dlp then falls back automatically. It is NOT a
+        // video-unavailability error, so it must not block the track.
+        const isFormatSelectionWarning = /requested format is not available/i.test(reason);
         // Only fire for actual unavailability reasons, not generic yt-dlp messages
         if (
-          reason.toLowerCase().includes('unavailable') ||
-          reason.toLowerCase().includes('private') ||
-          reason.toLowerCase().includes('deleted') ||
-          reason.toLowerCase().includes('removed') ||
-          reason.toLowerCase().includes('not available')
+          !isFormatSelectionWarning &&
+          (reason.toLowerCase().includes('unavailable') ||
+            reason.toLowerCase().includes('private') ||
+            reason.toLowerCase().includes('deleted') ||
+            reason.toLowerCase().includes('removed') ||
+            reason.toLowerCase().includes('not available'))
         ) {
           console.warn(`[ytdlp] unavailable: ${videoId} — ${reason}`);
           options.onTrackUnavailable?.({ videoId, reason });

--- a/src/audio/ytDlpManager.js
+++ b/src/audio/ytDlpManager.js
@@ -366,7 +366,10 @@ function _fetchPlaylistInfoOnce(url, options = {}) {
  */
 export async function searchYouTube(query, options = {}) {
   const limit = options.limit ?? 20;
-  const info = await fetchPlaylistInfo(`ytsearch${limit}:${query}`);
+  // Pass cookiesBrowser (and any other options) through so YouTube searches
+  // authenticate the same way fetch-info / download do. Without it, YouTube
+  // returns "Sign in to confirm you're not a bot" on search (#466).
+  const info = await fetchPlaylistInfo(`ytsearch${limit}:${query}`, options);
   return info.entries
     .filter((e) => !e.unavailable)
     .map((e) => ({

--- a/src/main.js
+++ b/src/main.js
@@ -1396,7 +1396,8 @@ ipcMain.handle('cloud-search', async (_event, { source, query, types, limit }) =
   if (!query?.trim()) return { ok: false, error: 'Empty query' };
   try {
     if (source === 'youtube') {
-      const results = await searchYouTube(query, { limit });
+      const cookiesBrowser = getSetting('ytdlp_cookies_browser', '') || null;
+      const results = await searchYouTube(query, { limit, cookiesBrowser });
       return { ok: true, results };
     }
     if (source === 'tidal') {


### PR DESCRIPTION
## Summary
Fixes #466 — YouTube downloads were blocked by `Sign in to confirm you're not a bot` (403) and tracks were falsely reported unavailable.

The original fix (commit `389b592`) forwarded `cookiesBrowser` to the cloud-search path. This PR layer builds on top of it with the fixes needed to make full playlist downloads actually work end-to-end.

## Root causes fixed
1. **Stale LibreWolf cookies → 403 on playlist fetch.** `findLibreWolfProfile()` searched the flatpak profile dir first; that profile had rotated/expired YouTube cookies. Now `~/.config/librewolf` (the active native profile) is tried before the flatpak dir.
2. **Availability check ran without cookies** → YouTube returned `Requested format is not available` for public tracks → false "unavailable" flags. The check now forwards `cookiesBrowser`.
3. **Ambiguous availability-check exits treated as unavailable.** A non-zero exit with no status text (crash in `--print availability` mode) is now treated as *available*, matching the existing timeout behaviour. Only explicit `unavailable`/`private`/`premium_only`/etc. statuses block a track.
4. **`Requested format is not available` misread as video-unavailable.** That string is a format-selection *warning* (yt-dlp falls back automatically), not a track failure. It no longer marks a track unavailable and no longer triggers a cookies-less retry (which itself hit the 403 bot-block).
5. **`player_client` pin broke format selection.** Pinning `android_vr`/`tv`/`web` made YouTube return only storyboard images for authenticated sessions → format errors on every track. The pin is removed; the default (tv-downgraded) client returns real audio formats with valid cookies.
6. **Download list UI glitch / duplicate rows.** The yt-dlp `init` IPC event clobbered the canonical (download + link) track list seeded by `handleDownload`, dropping link rows and causing the list to flicker/duplicate. `init` now only seeds when the list is empty.
7. **Bundled yt-dlp too old.** The app's bundled yt-dlp (`2026.03.17`) 403s on video data against current YouTube stream protections. It must be `>= 2026.07.04` (the system yt-dlp that downloads 6/6 correctly). Updated locally via Settings → Update yt-dlp (or `updateYtDlp`).

## Changes
- `src/audio/ytDlpManager.js`
  - `LIBREWOLF_BASE_DIRS`: `~/.config/librewolf` before flatpak.
  - `checkYouTubeAvailability()` now forwards `cookiesBrowser`.
  - Only explicit unavailable statuses block a track (exit-only is assumed available).
  - `isFormatUnavailableError()` returns false for the `Requested format is not available` warning (no cookies-less retry).
  - Removed `player_client` extractor-args pin (both fetch + download).
  - Added debug logging for cookies-browser resolution + full yt-dlp stderr.
- `renderer/src/DownloadContext.jsx`
  - `init` IPC event no longer replaces the seeded download/link list.

## Test plan
- `npx vitest run src/__tests__/ytDlpManager.test.js` — pass.
- Manual (LibreWolf, logged into YouTube):
  1. Settings → yt-dlp cookies = `librewolf`; ensure bundled yt-dlp >= 2026.07.04.
  2. Load a playlist → all tracks show available (no false "unavailable").
  3. Download → all tracks download (6/6), list renders cleanly with no duplicates.

Note: this PR does not auto-close #466 (per repo workflow) — verified fixed by reading code + manual test.
