### PR TITLE
docs: fix CONTRIBUTING.md branch flow (dev → staging → master)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,10 +96,16 @@ await app.close();
 
 ## Submitting changes
 
-1. Fork the repo and create a branch: `git checkout -b feat/my-feature`
+1. Fork the repo and create a branch off `dev`: `git checkout -b feat/my-feature`
 2. Make your changes — the pre-commit hook will lint and format automatically
-3. Open a pull request against `master`
-4. Describe what you changed and why
+3. Open a pull request against **`dev`** (not `master`)
+4. When `dev` has accumulated enough changes, a maintainer pushes it to `staging`
+   for a test/prerelease build. If that passes, a PR `dev` → `master` is opened
+   for the stable release.
+5. Describe what you changed and why
+
+> **Note:** Direct PRs to `master` are rejected by CI unless the head branch is
+> `dev`. Always target `dev` first.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #469 — `CONTRIBUTING.md` said "Open a pull request against `master`", which contradicts the actual workflow and the CI guard.

## Changes

- Step 3 now says open PR against **`dev`** (not `master`)
- Added step 4 explaining the `dev` → `staging` (prerelease) → `dev` → `master` (release) pipeline
- Added a note that direct PRs to `master` are rejected by CI unless head is `dev`

## Why

`ci.yml` has a guard job that rejects any PR to `master` whose head is not `dev`. The old CONTRIBUTING text sent contributors down a path CI would block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)