### PR TITLE
fix: Ctrl+A selects all visible rows in File Explorer (#277)

### DIFF
--- a/renderer/src/FileExplorerView.jsx
+++ b/renderer/src/FileExplorerView.jsx
@@ -501,6 +501,24 @@ export default function FileExplorerView({ style }) {
     ];
   }, [dirEntries, recursiveFiles]);
 
+  // ── Keyboard: Ctrl+A selects all visible rows (mirrors MusicLibrary) ─────
+  // MusicLibrary is unmounted while this tab is active, but other views stay
+  // mounted (hidden via display:none) — gate on visibility so Ctrl+A is only
+  // stolen when the Explorer is actually the active view.
+  useEffect(() => {
+    const onKeyDown = (e) => {
+      if (!(e.ctrlKey || e.metaKey) || e.key !== 'a') return;
+      const target = e.target;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+        return;
+      if (!containerRef.current?.offsetParent) return; // view hidden
+      e.preventDefault();
+      setSelectedPaths(new Set(displayItems.map((x) => x.path)));
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [displayItems, setSelectedPaths]);
+
   const brokenByFilename = useMemo(() => {
     const m = new Map();
     for (const t of brokenTracks) {


### PR DESCRIPTION
Fixes #277

## What
Ctrl+A in the File Explorer view now selects all visible rows (directories + files), mirroring MusicLibrary's behavior.

## How
- Added a window `keydown` listener in `FileExplorerView.jsx` that handles Ctrl/Cmd+A by selecting every path in `displayItems`.
- Gate on view visibility (`containerRef.offsetParent`) — the Explorer stays mounted but hidden (display:none) on other tabs, so the shortcut is only active when the Explorer is the visible view and can't steal Ctrl+A elsewhere.
- Skips when focus is in an INPUT/TEXTAREA/contentEditable (native select-all-text wins), same guard as MusicLibrary.

## Test
- `npm run lint` (renderer): 0 errors.