### PR TITLE
fix: renumber sequential cue names after mid-list insert (#253)

### DIFF
--- a/src/__tests__/cuePointRepository.test.js
+++ b/src/__tests__/cuePointRepository.test.js
@@ -8,6 +8,7 @@ import {
   deleteCuePoint,
   deleteAllCuePoints,
   deleteAllCuePointsLibrary,
+  renumberSequentialCuesAfter,
 } from '../db/cuePointRepository.js';
 
 const TRACK = {
@@ -157,5 +158,97 @@ describe('deleteAllCuePointsLibrary', () => {
 
   it('returns empty array when no cue points exist', () => {
     expect(deleteAllCuePointsLibrary()).toEqual([]);
+  });
+});
+
+describe('renumberSequentialCuesAfter', () => {
+  function seedThree(trackId) {
+    addCuePoint({ trackId, positionMs: 1000, label: 'Cue 1', color: '#ff0000', hotCueIndex: -1 });
+    addCuePoint({ trackId, positionMs: 2000, label: 'Cue 2', color: '#ff0000', hotCueIndex: -1 });
+    addCuePoint({ trackId, positionMs: 3000, label: 'Cue 3', color: '#ff0000', hotCueIndex: -1 });
+  }
+
+  it('renumbers following cues when a sequential cue is inserted in the middle', () => {
+    const trackId = addTrack(TRACK);
+    seedThree(trackId);
+    const inserted = addCuePoint({
+      trackId,
+      positionMs: 1500,
+      label: 'Cue 2',
+      color: '#00ff00',
+      hotCueIndex: -1,
+    });
+
+    const changed = renumberSequentialCuesAfter(trackId, inserted);
+
+    expect(changed).toBe(2);
+    const pts = getCuePoints(trackId);
+    expect(pts.map((c) => c.label)).toEqual(['Cue 1', 'Cue 2', 'Cue 3', 'Cue 4']);
+    // Colors of the renamed cues are preserved
+    expect(pts[2].color).toBe('#ff0000');
+  });
+
+  it('leaves custom-labelled cues alone and continues numbering after them', () => {
+    const trackId = addTrack(TRACK);
+    seedThree(trackId);
+    // A custom label in the middle must not be renamed
+    const drop = addCuePoint({
+      trackId,
+      positionMs: 2500,
+      label: 'Drop',
+      color: '#00ffff',
+      hotCueIndex: -1,
+    });
+    const inserted = addCuePoint({
+      trackId,
+      positionMs: 1500,
+      label: 'Cue 2',
+      color: '#00ff00',
+      hotCueIndex: -1,
+    });
+
+    const changed = renumberSequentialCuesAfter(trackId, inserted);
+
+    expect(changed).toBe(2);
+    const pts = getCuePoints(trackId);
+    expect(pts.map((c) => c.label)).toEqual(['Cue 1', 'Cue 2', 'Cue 3', 'Drop', 'Cue 4']);
+    expect(getCuePoints(trackId).find((c) => c.id === drop).label).toBe('Drop');
+  });
+
+  it('does nothing when the trigger cue has a non-sequential label', () => {
+    const trackId = addTrack(TRACK);
+    seedThree(trackId);
+    const inserted = addCuePoint({
+      trackId,
+      positionMs: 1500,
+      label: '',
+      color: '#00ff00',
+      hotCueIndex: -1,
+    });
+
+    const changed = renumberSequentialCuesAfter(trackId, inserted);
+
+    expect(changed).toBe(0);
+    expect(getCuePoints(trackId).map((c) => c.label)).toEqual(['Cue 1', '', 'Cue 2', 'Cue 3']);
+  });
+
+  it('works for the rename flow: unnamed insert, then rename to Cue 2 cascades', () => {
+    const trackId = addTrack(TRACK);
+    seedThree(trackId);
+    const inserted = addCuePoint({
+      trackId,
+      positionMs: 1500,
+      label: '',
+      color: '#00ff00',
+      hotCueIndex: -1,
+    });
+    expect(renumberSequentialCuesAfter(trackId, inserted)).toBe(0); // unnamed — nothing yet
+
+    // Simulate the update-cue-point handler: user names it "Cue 2"
+    updateCuePoint(inserted, { label: 'Cue 2' });
+    const changed = renumberSequentialCuesAfter(trackId, inserted);
+
+    expect(changed).toBe(2);
+    expect(getCuePoints(trackId).map((c) => c.label)).toEqual(['Cue 1', 'Cue 2', 'Cue 3', 'Cue 4']);
   });
 });

--- a/src/db/cuePointRepository.js
+++ b/src/db/cuePointRepository.js
@@ -63,3 +63,43 @@ export function deleteAllCuePointsLibrary() {
   db.prepare('DELETE FROM cue_points').run();
   return affected;
 }
+
+// Auto-naming scheme for sequential cues ("Cue 1", "Cue 2", ...). Cues with
+// custom labels (e.g. "Mix In", "Drop") must never be touched by renumbering.
+const SEQUENTIAL_CUE_LABEL = /^Cue (\d+)$/;
+
+/**
+ * After a cue is added or renamed to a sequential name (`Cue N`), renumber
+ * every following cue (sorted by position) that still uses the same
+ * auto-naming scheme, so names stay unique and ordered (#253). Cues with
+ * custom labels are left alone. Returns how many labels were rewritten.
+ */
+export function renumberSequentialCuesAfter(trackId, cueId) {
+  const cues = db
+    .prepare(`SELECT * FROM cue_points WHERE track_id = ? ORDER BY position_ms ASC, id ASC`)
+    .all(trackId);
+  const idx = cues.findIndex((c) => c.id === cueId);
+  if (idx === -1) return 0;
+  const match = SEQUENTIAL_CUE_LABEL.exec(cues[idx].label ?? '');
+  if (!match) return 0;
+  let nextNum = parseInt(match[1], 10) + 1;
+  let updated = 0;
+  const update = db.prepare('UPDATE cue_points SET label = ? WHERE id = ?');
+  for (let j = idx + 1; j < cues.length; j++) {
+    if (!SEQUENTIAL_CUE_LABEL.test(cues[j].label ?? '')) continue;
+    const newLabel = `Cue ${nextNum++}`;
+    if (cues[j].label !== newLabel) {
+      update.run(newLabel, cues[j].id);
+      updated++;
+    }
+  }
+  return updated;
+}
+
+/**
+ * Fetch a single cue point by id (used to resolve the track before a
+ * rename-triggered renumber).
+ */
+export function getCuePointById(id) {
+  return db.prepare('SELECT * FROM cue_points WHERE id = ?').get(id);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -140,8 +140,10 @@ import { resolveExportFormat } from './usb/deviceFormats.js';
 import { getResetCleanupTargets, startResetCleanup } from './resetCleanup.js';
 import {
   getCuePoints,
+  getCuePointById,
   addCuePoint,
   updateCuePoint,
+  renumberSequentialCuesAfter,
   deleteCuePoint,
   deleteAllCuePoints,
   deleteAllCuePointsLibrary,
@@ -751,11 +753,20 @@ ipcMain.handle('get-cue-points', (_, trackId) => getCuePoints(trackId));
 
 ipcMain.handle('add-cue-point', (_, { trackId, positionMs, label, color, hotCueIndex }) => {
   const id = addCuePoint({ trackId, positionMs, label, color, hotCueIndex });
+  // Adding a sequentially-named cue shifts the positional order — renumber the
+  // following auto-named cues so names stay unique (#253).
+  renumberSequentialCuesAfter(trackId, id);
   return { id };
 });
 
 ipcMain.handle('update-cue-point', (_, { id, label, color, hotCueIndex, enabled }) => {
+  const before = getCuePointById(id);
   updateCuePoint(id, { label, color, hotCueIndex, enabled });
+  // Renaming a cue to a sequential name (e.g. the newly inserted "Cue 2")
+  // must cascade a renumber onto the following auto-named cues (#253).
+  if (before && typeof label === 'string') {
+    renumberSequentialCuesAfter(before.track_id, id);
+  }
   return { ok: true };
 });
 


### PR DESCRIPTION
Fixes #253

## Problem
Inserting a cue between two existing ones left the following cues with their old names → duplicate/out-of-order labels (`Cue 2`, `Cue 2`, `Cue 3`).

## Fix
- New `renumberSequentialCuesAfter(trackId, cueId)` in `src/db/cuePointRepository.js`: after a cue with a sequential label (`Cue N`) is added or renamed, every following cue (sorted by position) that still uses the auto-naming scheme is renumbered so names stay unique and ordered. Cues with custom labels (e.g. `Mix In`, `Drop`) are never touched.
- `add-cue-point` IPC: renumbers after insert (covers add-with-label paths).
- `update-cue-point` IPC: renumbers when a cue is renamed to a `Cue N` label — covers the editor flow where the user inserts an unnamed cue, then names it `Cue 2` (old `Cue 2` → `Cue 3`, old `Cue 3` → `Cue 4`).

## Test
- 4 new unit tests (insert-in-middle, custom labels preserved, non-sequential trigger no-op, rename cascade): 18/18 pass.
- `npm run lint`: clean.