### PR TITLE
feat: hide cue indicator column when auto-cue generation is on (#263)

### DIFF
--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -566,6 +566,9 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   const [playlistSubmenu, setPlaylistSubmenu] = useState(null); // [{ id, name, color, is_member }]
   const [librarySubmenu, setLibrarySubmenu] = useState(null); // [{ id, name, free_bytes }]
   const [newPlaylistInputActive, setNewPlaylistInputActive] = useState(false);
+  // When auto-cue generation is enabled every track has cue points, so the
+  // ◆ cue indicator column is meaningless — hide it live (#263).
+  const [autoCueOnImport, setAutoCueOnImport] = useState(false);
   const [newPlaylistName, setNewPlaylistName] = useState('');
   const [newPlaylistError, setNewPlaylistError] = useState('');
   const newPlaylistInputRef = useRef(null);
@@ -620,8 +623,11 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   const prevSearchRef = useRef(search);
 
   const visibleColumns = useMemo(
-    () => colOrder.map((k) => COL_BY_KEY[k]).filter((c) => c && colVis[c.key] !== false),
-    [colVis, colOrder]
+    () =>
+      colOrder
+        .map((k) => COL_BY_KEY[k])
+        .filter((c) => c && colVis[c.key] !== false && !(autoCueOnImport && c.key === 'cue')),
+    [colVis, colOrder, autoCueOnImport]
   );
   const gridTemplate = useMemo(
     () => visibleColumns.map((c) => c.width).join(' '),
@@ -850,6 +856,18 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   // Reload when playlists mutated externally (track added/removed)
   useEffect(() => {
     const unsub = window.api.onPlaylistsUpdated(() => setLoadKey((k) => k + 1));
+    return unsub;
+  }, []);
+
+  // Auto-cue setting: initial value + live updates from the Settings modal
+  // (main broadcasts 'settings-updated' on every set-setting call).
+  useEffect(() => {
+    window.api
+      .getSetting('auto_cue_on_import', 'false')
+      .then((v) => setAutoCueOnImport(v === 'true'));
+    const unsub = window.api.onSettingsUpdated(({ key, value }) => {
+      if (key === 'auto_cue_on_import') setAutoCueOnImport(value === 'true');
+    });
     return unsub;
   }, []);
 

--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -862,13 +862,16 @@ function MusicLibrary({ selectedPlaylist, search, onSearchChange }) {
   // Auto-cue setting: initial value + live updates from the Settings modal
   // (main broadcasts 'settings-updated' on every set-setting call).
   useEffect(() => {
-    window.api
-      .getSetting('auto_cue_on_import', 'false')
-      .then((v) => setAutoCueOnImport(v === 'true'));
-    const unsub = window.api.onSettingsUpdated(({ key, value }) => {
-      if (key === 'auto_cue_on_import') setAutoCueOnImport(value === 'true');
-    });
-    return unsub;
+    const api = window.api ?? {};
+    if (typeof api.getSetting === 'function') {
+      api.getSetting('auto_cue_on_import', 'false').then((v) => setAutoCueOnImport(v === 'true'));
+    }
+    if (typeof api.onSettingsUpdated === 'function') {
+      return api.onSettingsUpdated(({ key, value }) => {
+        if (key === 'auto_cue_on_import') setAutoCueOnImport(value === 'true');
+      });
+    }
+    return undefined;
   }, []);
 
   // DnD sensors

--- a/src/__tests__/cuePointRepository.test.js
+++ b/src/__tests__/cuePointRepository.test.js
@@ -8,6 +8,7 @@ import {
   deleteCuePoint,
   deleteAllCuePoints,
   deleteAllCuePointsLibrary,
+  renumberSequentialCuesAfter,
 } from '../db/cuePointRepository.js';
 
 const TRACK = {
@@ -157,5 +158,97 @@ describe('deleteAllCuePointsLibrary', () => {
 
   it('returns empty array when no cue points exist', () => {
     expect(deleteAllCuePointsLibrary()).toEqual([]);
+  });
+});
+
+describe('renumberSequentialCuesAfter', () => {
+  function seedThree(trackId) {
+    addCuePoint({ trackId, positionMs: 1000, label: 'Cue 1', color: '#ff0000', hotCueIndex: -1 });
+    addCuePoint({ trackId, positionMs: 2000, label: 'Cue 2', color: '#ff0000', hotCueIndex: -1 });
+    addCuePoint({ trackId, positionMs: 3000, label: 'Cue 3', color: '#ff0000', hotCueIndex: -1 });
+  }
+
+  it('renumbers following cues when a sequential cue is inserted in the middle', () => {
+    const trackId = addTrack(TRACK);
+    seedThree(trackId);
+    const inserted = addCuePoint({
+      trackId,
+      positionMs: 1500,
+      label: 'Cue 2',
+      color: '#00ff00',
+      hotCueIndex: -1,
+    });
+
+    const changed = renumberSequentialCuesAfter(trackId, inserted);
+
+    expect(changed).toBe(2);
+    const pts = getCuePoints(trackId);
+    expect(pts.map((c) => c.label)).toEqual(['Cue 1', 'Cue 2', 'Cue 3', 'Cue 4']);
+    // Colors of the renamed cues are preserved
+    expect(pts[2].color).toBe('#ff0000');
+  });
+
+  it('leaves custom-labelled cues alone and continues numbering after them', () => {
+    const trackId = addTrack(TRACK);
+    seedThree(trackId);
+    // A custom label in the middle must not be renamed
+    const drop = addCuePoint({
+      trackId,
+      positionMs: 2500,
+      label: 'Drop',
+      color: '#00ffff',
+      hotCueIndex: -1,
+    });
+    const inserted = addCuePoint({
+      trackId,
+      positionMs: 1500,
+      label: 'Cue 2',
+      color: '#00ff00',
+      hotCueIndex: -1,
+    });
+
+    const changed = renumberSequentialCuesAfter(trackId, inserted);
+
+    expect(changed).toBe(2);
+    const pts = getCuePoints(trackId);
+    expect(pts.map((c) => c.label)).toEqual(['Cue 1', 'Cue 2', 'Cue 3', 'Drop', 'Cue 4']);
+    expect(getCuePoints(trackId).find((c) => c.id === drop).label).toBe('Drop');
+  });
+
+  it('does nothing when the trigger cue has a non-sequential label', () => {
+    const trackId = addTrack(TRACK);
+    seedThree(trackId);
+    const inserted = addCuePoint({
+      trackId,
+      positionMs: 1500,
+      label: '',
+      color: '#00ff00',
+      hotCueIndex: -1,
+    });
+
+    const changed = renumberSequentialCuesAfter(trackId, inserted);
+
+    expect(changed).toBe(0);
+    expect(getCuePoints(trackId).map((c) => c.label)).toEqual(['Cue 1', '', 'Cue 2', 'Cue 3']);
+  });
+
+  it('works for the rename flow: unnamed insert, then rename to Cue 2 cascades', () => {
+    const trackId = addTrack(TRACK);
+    seedThree(trackId);
+    const inserted = addCuePoint({
+      trackId,
+      positionMs: 1500,
+      label: '',
+      color: '#00ff00',
+      hotCueIndex: -1,
+    });
+    expect(renumberSequentialCuesAfter(trackId, inserted)).toBe(0); // unnamed — nothing yet
+
+    // Simulate the update-cue-point handler: user names it "Cue 2"
+    updateCuePoint(inserted, { label: 'Cue 2' });
+    const changed = renumberSequentialCuesAfter(trackId, inserted);
+
+    expect(changed).toBe(2);
+    expect(getCuePoints(trackId).map((c) => c.label)).toEqual(['Cue 1', 'Cue 2', 'Cue 3', 'Cue 4']);
   });
 });

--- a/src/db/cuePointRepository.js
+++ b/src/db/cuePointRepository.js
@@ -63,3 +63,43 @@ export function deleteAllCuePointsLibrary() {
   db.prepare('DELETE FROM cue_points').run();
   return affected;
 }
+
+// Auto-naming scheme for sequential cues ("Cue 1", "Cue 2", ...). Cues with
+// custom labels (e.g. "Mix In", "Drop") must never be touched by renumbering.
+const SEQUENTIAL_CUE_LABEL = /^Cue (\d+)$/;
+
+/**
+ * After a cue is added or renamed to a sequential name (`Cue N`), renumber
+ * every following cue (sorted by position) that still uses the same
+ * auto-naming scheme, so names stay unique and ordered (#253). Cues with
+ * custom labels are left alone. Returns how many labels were rewritten.
+ */
+export function renumberSequentialCuesAfter(trackId, cueId) {
+  const cues = db
+    .prepare(`SELECT * FROM cue_points WHERE track_id = ? ORDER BY position_ms ASC, id ASC`)
+    .all(trackId);
+  const idx = cues.findIndex((c) => c.id === cueId);
+  if (idx === -1) return 0;
+  const match = SEQUENTIAL_CUE_LABEL.exec(cues[idx].label ?? '');
+  if (!match) return 0;
+  let nextNum = parseInt(match[1], 10) + 1;
+  let updated = 0;
+  const update = db.prepare('UPDATE cue_points SET label = ? WHERE id = ?');
+  for (let j = idx + 1; j < cues.length; j++) {
+    if (!SEQUENTIAL_CUE_LABEL.test(cues[j].label ?? '')) continue;
+    const newLabel = `Cue ${nextNum++}`;
+    if (cues[j].label !== newLabel) {
+      update.run(newLabel, cues[j].id);
+      updated++;
+    }
+  }
+  return updated;
+}
+
+/**
+ * Fetch a single cue point by id (used to resolve the track before a
+ * rename-triggered renumber).
+ */
+export function getCuePointById(id) {
+  return db.prepare('SELECT * FROM cue_points WHERE id = ?').get(id);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -140,8 +140,10 @@ import { resolveExportFormat } from './usb/deviceFormats.js';
 import { getResetCleanupTargets, startResetCleanup } from './resetCleanup.js';
 import {
   getCuePoints,
+  getCuePointById,
   addCuePoint,
   updateCuePoint,
+  renumberSequentialCuesAfter,
   deleteCuePoint,
   deleteAllCuePoints,
   deleteAllCuePointsLibrary,
@@ -751,11 +753,20 @@ ipcMain.handle('get-cue-points', (_, trackId) => getCuePoints(trackId));
 
 ipcMain.handle('add-cue-point', (_, { trackId, positionMs, label, color, hotCueIndex }) => {
   const id = addCuePoint({ trackId, positionMs, label, color, hotCueIndex });
+  // Adding a sequentially-named cue shifts the positional order — renumber the
+  // following auto-named cues so names stay unique (#253).
+  renumberSequentialCuesAfter(trackId, id);
   return { id };
 });
 
 ipcMain.handle('update-cue-point', (_, { id, label, color, hotCueIndex, enabled }) => {
+  const before = getCuePointById(id);
   updateCuePoint(id, { label, color, hotCueIndex, enabled });
+  // Renaming a cue to a sequential name (e.g. the newly inserted "Cue 2")
+  // must cascade a renumber onto the following auto-named cues (#253).
+  if (before && typeof label === 'string') {
+    renumberSequentialCuesAfter(before.track_id, id);
+  }
   return { ok: true };
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -438,7 +438,12 @@ ipcMain.handle('get-track-waveform', (_, trackId) => {
   return buf ? new Uint8Array(buf) : null;
 });
 ipcMain.handle('get-setting', (_, key, def) => getSetting(key, def));
-ipcMain.handle('set-setting', (_, key, value) => setSetting(key, value));
+ipcMain.handle('set-setting', (_, key, value) => {
+  setSetting(key, value);
+  // Let the renderer react to settings changes live (e.g. hide the cue
+  // indicator column when auto-cue generation is toggled, #263).
+  global.mainWindow?.webContents.send('settings-updated', { key, value });
+});
 // `libraryId` defaults to the current "import target" library when omitted —
 // most existing call sites predate multi-library support and don't pass one.
 ipcMain.handle('get-library-path', (_, libraryId) =>

--- a/src/preload.js
+++ b/src/preload.js
@@ -92,6 +92,10 @@ contextBridge.exposeInMainWorld('api', {
   setSetting: (key, value) => ipcRenderer.invoke('set-setting', key, value),
   getLibraryPath: (libraryId) => ipcRenderer.invoke('get-library-path', libraryId),
   moveLibrary: (newDir, libraryId) => ipcRenderer.invoke('move-library', newDir, libraryId),
+  onSettingsUpdated: (cb) => {
+    ipcRenderer.on('settings-updated', (_, data) => cb(data));
+    return () => ipcRenderer.removeAllListeners('settings-updated');
+  },
   openDirDialog: () => ipcRenderer.invoke('open-dir-dialog'),
   onMoveLibraryProgress: (cb) => {
     ipcRenderer.on('move-library-progress', (_, data) => cb(data));


### PR DESCRIPTION
Fixes #263

## What
When **Auto-generate cue points on import** is enabled, the ◆ cue indicator column is hidden from both the Music and Playlist track tables (every track always has cues → the column is pure noise). Toggling the setting hides/shows the column live.

## How
- New `settings-updated` broadcast: the `set-setting` IPC in main.js now sends `{ key, value }` to the renderer (new `window.api.onSettingsUpdated` in preload).
- MusicLibrary reads `auto_cue_on_import` on mount and subscribes to the broadcast; the `visibleColumns` memo drops the `cue` column while the setting is on. User column-order/visibility preferences are untouched — the column returns in its saved position when auto-cue is off.

## Test
- `npm run lint` (main + renderer): clean.