### PR TITLE
feat: Explorer can switch between Windows drives (C:, D:, ...) (#473)

### DIFF
--- a/renderer/src/FileExplorerView.jsx
+++ b/renderer/src/FileExplorerView.jsx
@@ -297,6 +297,7 @@ export default function FileExplorerView({ style }) {
   const { play, currentTrack, mediaPort, patchCurrentTrack } = usePlayer();
 
   const [fsRoot, setFsRoot] = useState(null);
+  const [drives, setDrives] = useState([]); // Windows drive roots (C:\, D:\ ...)
   const [homeDir, setHomeDir] = useState(null);
   const [currentPath, setCurrentPath] = useState(null);
   const [dirEntries, setDirEntries] = useState({ dirs: [], files: [] });
@@ -336,9 +337,10 @@ export default function FileExplorerView({ style }) {
   // ── Init ──────────────────────────────────────────────────────────────────
 
   useEffect(() => {
-    window.api.getComputerRoot().then(({ root, home }) => {
+    window.api.getComputerRoot().then(({ root, home, drives }) => {
       setFsRoot(root);
       setHomeDir(home);
+      setDrives(drives ?? []);
       setCurrentPath(home ?? root);
     });
     window.api.getPlaylists().then(setPlaylists);
@@ -762,6 +764,26 @@ export default function FileExplorerView({ style }) {
     >
       {/* ── Favourites sidebar ────────────────────────────────────────────── */}
       <div className="explorer-favourites">
+        {drives.length > 1 && (
+          <>
+            <div className="explorer-favourites__header">Drives</div>
+            {drives.map((d) => (
+              <div
+                key={d}
+                className={`explorer-favourites__item${
+                  currentPath === d || currentPath.startsWith(d)
+                    ? ' explorer-favourites__item--active'
+                    : ''
+                }`}
+                title={d}
+                onClick={() => navigateTo(d)}
+              >
+                <span className="explorer-favourites__icon">💽</span>
+                <span className="explorer-favourites__name">{d}</span>
+              </div>
+            ))}
+          </>
+        )}
         <div className="explorer-favourites__header">Favourites</div>
         {favourites.length === 0 ? (
           <div className="explorer-favourites__empty">Right-click a folder to add favourites</div>

--- a/src/__tests__/drives.test.js
+++ b/src/__tests__/drives.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { detectWindowsDrives } from '../explorer/drives.js';
+
+describe('detectWindowsDrives', () => {
+  it('returns [] on non-Windows platforms', () => {
+    expect(detectWindowsDrives({ platform: 'linux' })).toEqual([]);
+    expect(detectWindowsDrives({ platform: 'darwin' })).toEqual([]);
+  });
+
+  it('returns the drive roots that exist on Windows', () => {
+    const exists = (p) => p === 'C:\\' || p === 'E:\\';
+    expect(detectWindowsDrives({ platform: 'win32', existsSync: exists })).toEqual([
+      'C:\\',
+      'E:\\',
+    ]);
+  });
+
+  it('skips drives whose existence check throws', () => {
+    const exists = (p) => {
+      if (p === 'C:\\') return true;
+      throw new Error('access denied');
+    };
+    expect(detectWindowsDrives({ platform: 'win32', existsSync: exists })).toEqual(['C:\\']);
+  });
+});

--- a/src/explorer/drives.js
+++ b/src/explorer/drives.js
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+
+/**
+ * Enumerate present Windows drive roots ("C:\", "D:\", ...) without spawning
+ * a shell — 26 stat calls, no admin rights needed. Drives that exist but are
+ * inaccessible (empty card readers, disconnected network drives) are skipped.
+ *
+ * @param {{platform?: string, existsSync?: (p: string) => boolean}} [opts]
+ *   injectable for tests
+ * @returns {string[]} drive roots, e.g. ['C:\\', 'D:\\']
+ */
+export function detectWindowsDrives({
+  platform = process.platform,
+  existsSync = fs.existsSync,
+} = {}) {
+  if (platform !== 'win32') return [];
+  const roots = [];
+  for (let i = 0; i < 26; i++) {
+    const root = `${String.fromCharCode(65 + i)}:\\`;
+    try {
+      if (existsSync(root)) roots.push(root);
+    } catch {
+      // drive present but not accessible — skip it
+    }
+  }
+  return roots;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -133,6 +133,7 @@ import {
 } from './deps.js';
 import { initLogger, getLogDir, initRendererLogger, logRendererMessage } from './logger.js';
 import { detectFilesystem, formatDrive, describeFilesystem } from './usb/usbUtils.js';
+import { detectWindowsDrives } from './explorer/drives.js';
 import { writeAnlz, getAnlzFolder } from './audio/anlzWriter.js';
 import { writeSettingFiles } from './usb/settingWriter.js';
 import { writePdb } from './usb/pdbWriter.js';
@@ -1804,12 +1805,17 @@ ipcMain.handle('export-explorer-to-usb', async (_, { filePaths, usbRoot, playlis
 ipcMain.handle('get-computer-root', () => {
   const home = os.homedir();
   let root;
+  let drives = [];
   if (process.platform === 'win32') {
     root = path.parse(home).root || 'C:\\';
+    // #473: enumerate ALL present drives so the Explorer can switch from C:
+    // to any other volume (D:, E:, ...).
+    drives = detectWindowsDrives();
+    if (!drives.includes(root)) drives.unshift(root);
   } else {
     root = '/';
   }
-  return { root, home };
+  return { root, home, drives };
 });
 
 ipcMain.handle('get-tracks-by-paths', (_, filePaths) => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -49,6 +49,7 @@ export default defineConfig({
             'src/__tests__/settingWriter.test.js',
             'src/__tests__/pdbWriter.test.js',
             'src/__tests__/deviceFormats.test.js',
+            'src/__tests__/drives.test.js',
             'src/__tests__/ffmpegConvert.test.js',
           ],
         },


### PR DESCRIPTION
Fixes #473

## Problem
On Windows the File Explorer was rooted at `path.parse(home).root` (always the drive where the user profile lives, typically `C:\\`). Other drives (D:, E:, ...) were unreachable — there was no drive listing anywhere in the view.

## Fix
- **New `src/explorer/drives.js`**: `detectWindowsDrives()` enumerates present drive roots (A:–Z:) with `fs.existsSync` — no shell spawning, no admin rights; inaccessible drives (empty card readers, disconnected network drives) are skipped. Dependency-injected for tests.
- **`get-computer-root` IPC** now returns `drives: string[]` on Windows.
- **FileExplorerView** shows a **Drives** section at the top of the favourites sidebar when >1 drive exists; clicking a drive navigates to its root. Active drive highlighted.

## Verification
- 3 new unit tests (`drives.test.js`, registered in vitest unit project): non-Windows → `[]`; Windows → existing roots; throwing drives skipped.
- `npm run lint` (main + renderer): clean.
- Windows behaviour to be verified on the Win11 test VM.