### PR TITLE
feat(deps): first-run overlay polish - full step checklist, ready marks, collapsed console

### DIFF
--- a/renderer/src/DepsOverlay.css
+++ b/renderer/src/DepsOverlay.css
@@ -193,3 +193,40 @@
 .deps-btn--primary:hover {
   background: #25c85f;
 }
+
+/* ── Collapsible console ─────────────────────────────────────── */
+.deps-console {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.deps-log-toggle {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: #7f849c;
+  font-size: 11.5px;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.deps-log-toggle:hover {
+  color: #cdd6f4;
+  background: #313244;
+}
+
+.deps-bar-fill--indet {
+  width: 35%;
+  animation: deps-indet 1.2s ease-in-out infinite;
+}
+
+@keyframes deps-indet {
+  0% {
+    transform: translateX(-120%);
+  }
+  100% {
+    transform: translateX(320%);
+  }
+}

--- a/renderer/src/DepsOverlay.jsx
+++ b/renderer/src/DepsOverlay.jsx
@@ -5,7 +5,7 @@ const KNOWN_STEPS = [
   { id: 'ffmpeg', label: 'FFmpeg' },
   { id: 'analyzer', label: 'mixxx-analyzer' },
   { id: 'ytdlp', label: 'yt-dlp' },
-  { id: 'tidal', label: 'tidal-dl-ng (optional)' },
+  { id: 'tidal', label: 'tidal-dl-ng' },
 ];
 
 function fmt(bytes) {
@@ -57,7 +57,6 @@ export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose
 
   const {
     stepId,
-    stepTotal,
     stepPct,
     bytesDownloaded,
     bytesTotal,
@@ -66,21 +65,17 @@ export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose
     pct,
     error,
     stepsCompleted,
-    optional,
   } = progress ?? {};
 
   const isError = !!error;
   const running = !done && !isError;
 
-  // Step checklist. Required rows are the first stepTotal entries; the
-  // optional tidal row appears when it becomes the active step.
-  const hasSteps = running && stepTotal > 0;
-  const activeSteps = hasSteps
-    ? KNOWN_STEPS.filter((s) => {
-        const idx = KNOWN_STEPS.indexOf(s);
-        return idx < stepTotal || s.id === stepId;
-      })
-    : [];
+  // Step checklist. Show the FULL list (FFmpeg, mixxx-analyzer, yt-dlp,
+  // tidal-dl-ng) up front, installer style: pending rows stay visible until
+  // they run. Required rows flip to done as stepsCompleted advances; the
+  // auto-installed tidal row activates after them.
+  const hasSteps = running;
+  const activeSteps = hasSteps ? KNOWN_STEPS : [];
   const doneCount =
     stepsCompleted ??
     Math.max(
@@ -108,14 +103,13 @@ export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose
             {activeSteps.map((s, i) => {
               const isDoneStep = i < doneCount;
               const isActive = s.id === stepId && running && !isDoneStep;
-              const rowLabel = optional && s.id === 'tidal' ? 'tidal-dl-ng (optional)' : s.label;
               return (
                 <div
                   key={s.id}
                   className={`deps-step${isActive ? ' active' : ''}${isDoneStep ? ' done' : ''}`}
                 >
                   <span className="deps-step-icon">{isDoneStep ? '✓' : isActive ? '↓' : '·'}</span>
-                  <span className="deps-step-label">{rowLabel}</span>
+                  <span className="deps-step-label">{s.label}</span>
                   {isActive && hasBytes && (
                     <span className="deps-step-meta">
                       {fmt(bytesDownloaded)} / {fmt(bytesTotal)}
@@ -138,12 +132,6 @@ export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose
         {indeterminate && (
           <div className="deps-bar-track">
             <div className="deps-bar-fill deps-bar-fill--indet" />
-          </div>
-        )}
-
-        {running && stepTotal > 1 && !optional && (
-          <div className="deps-overall">
-            Step {doneCount + 1} of {stepTotal}
           </div>
         )}
 

--- a/renderer/src/DepsOverlay.jsx
+++ b/renderer/src/DepsOverlay.jsx
@@ -65,6 +65,7 @@ export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose
     pct,
     error,
     stepsCompleted,
+    readyStepIds,
   } = progress ?? {};
 
   const isError = !!error;
@@ -101,7 +102,8 @@ export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose
         {hasSteps && (
           <div className="deps-steps">
             {activeSteps.map((s, i) => {
-              const isDoneStep = i < doneCount;
+              const wasReady = Array.isArray(readyStepIds) && readyStepIds.includes(s.id);
+              const isDoneStep = i < doneCount || wasReady;
               const isActive = s.id === stepId && running && !isDoneStep;
               return (
                 <div

--- a/renderer/src/DepsOverlay.jsx
+++ b/renderer/src/DepsOverlay.jsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import './DepsOverlay.css';
 
 const KNOWN_STEPS = [
   { id: 'ffmpeg', label: 'FFmpeg' },
   { id: 'analyzer', label: 'mixxx-analyzer' },
   { id: 'ytdlp', label: 'yt-dlp' },
-  { id: 'tidal', label: 'tidal-dl-ng' },
+  { id: 'tidal', label: 'tidal-dl-ng (optional)' },
 ];
 
 function fmt(bytes) {
@@ -26,14 +26,17 @@ function fmtEta(sec) {
 }
 
 /**
- * First-time setup overlay.
+ * First-time setup overlay, installer-console style.
  *
- * Behaves like a classic Windows installer console: every step streams into a
- * scrollable log the user can read, and when the run finishes the window STAYS
- * open with a Close button. It never auto-dismisses after real work.
+ * - Required dependency steps render as a checklist (done/active/pending).
+ * - The optional tidal-dl-ng step renders as a normal step row too (marked
+ *   "optional"), with the required rows staying checked while it runs.
+ * - The raw log console is COLLAPSED by default; "Show log" expands it.
+ * - When a run finishes the overlay STAYS open with a Close button; it never
+ *   auto-dismisses after real work.
  *
  * props:
- *   progress - live progress event ({ stepId, pct, msg, error, ... }) or null
+ *   progress - live progress event ({ stepId, stepTotal, pct, error, ... })
  *   log      - accumulated console lines [{ text, kind: 'log' | 'error' }]
  *   done     - true when the run finished successfully (progress was cleared)
  *   onRetry  - re-run dependency install
@@ -41,18 +44,19 @@ function fmtEta(sec) {
  */
 export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose }) {
   const logRef = useRef(null);
+  const [showLog, setShowLog] = useState(false);
 
   // Keep the newest line visible while the log grows (console behaviour).
   useEffect(() => {
+    if (!showLog) return;
     const el = logRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [log.length]);
+  }, [log.length, showLog]);
 
   if (!progress && !done) return null;
 
   const {
     stepId,
-    stepIndex,
     stepTotal,
     stepPct,
     bytesDownloaded,
@@ -61,25 +65,36 @@ export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose
     etaSec,
     pct,
     error,
+    stepsCompleted,
+    optional,
   } = progress ?? {};
 
   const isError = !!error;
   const running = !done && !isError;
 
-  // Step list (only meaningful while a multi-step run is live).
-  const hasSteps = running && stepTotal > 0 && stepId !== undefined;
+  // Step checklist. Required rows are the first stepTotal entries; the
+  // optional tidal row appears when it becomes the active step.
+  const hasSteps = running && stepTotal > 0;
   const activeSteps = hasSteps
-    ? KNOWN_STEPS.filter((s) => KNOWN_STEPS.indexOf(s) < stepTotal || s.id === stepId).slice(
-        0,
-        stepTotal
-      )
+    ? KNOWN_STEPS.filter((s) => {
+        const idx = KNOWN_STEPS.indexOf(s);
+        return idx < stepTotal || s.id === stepId;
+      })
     : [];
-  const currentIdx = activeSteps.findIndex((s) => s.id === stepId);
+  const doneCount =
+    stepsCompleted ??
+    Math.max(
+      0,
+      activeSteps.findIndex((s) => s.id === stepId)
+    );
 
   const speed = fmtSpeed(bytesPerSec);
   const eta = fmtEta(etaSec);
   const hasBytes = bytesTotal > 0 && bytesDownloaded > 0;
   const showBar = running && (stepPct >= 0 || pct >= 0);
+  // Optional step streams log lines without a percentage: show an animated
+  // indeterminate bar instead of nothing.
+  const indeterminate = running && !!stepId && pct != null && pct < 0;
 
   return (
     <div className="deps-overlay">
@@ -91,15 +106,16 @@ export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose
         {hasSteps && (
           <div className="deps-steps">
             {activeSteps.map((s, i) => {
-              const isActive = s.id === stepId && !isError;
-              const isDoneStep = i < currentIdx;
+              const isDoneStep = i < doneCount;
+              const isActive = s.id === stepId && running && !isDoneStep;
+              const rowLabel = optional && s.id === 'tidal' ? 'tidal-dl-ng (optional)' : s.label;
               return (
                 <div
                   key={s.id}
                   className={`deps-step${isActive ? ' active' : ''}${isDoneStep ? ' done' : ''}`}
                 >
                   <span className="deps-step-icon">{isDoneStep ? '✓' : isActive ? '↓' : '·'}</span>
-                  <span className="deps-step-label">{s.label}</span>
+                  <span className="deps-step-label">{rowLabel}</span>
                   {isActive && hasBytes && (
                     <span className="deps-step-meta">
                       {fmt(bytesDownloaded)} / {fmt(bytesTotal)}
@@ -113,29 +129,42 @@ export function DepsOverlay({ progress, log = [], done = false, onRetry, onClose
           </div>
         )}
 
-        {showBar && (
+        {showBar && !indeterminate && (
           <div className="deps-bar-track">
             <div className="deps-bar-fill" style={{ width: `${stepPct >= 0 ? stepPct : pct}%` }} />
           </div>
         )}
 
-        {running && stepTotal > 1 && (
+        {indeterminate && (
+          <div className="deps-bar-track">
+            <div className="deps-bar-fill deps-bar-fill--indet" />
+          </div>
+        )}
+
+        {running && stepTotal > 1 && !optional && (
           <div className="deps-overall">
-            Step {stepIndex} of {stepTotal}
+            Step {doneCount + 1} of {stepTotal}
           </div>
         )}
 
         {log.length > 0 && (
-          <div className="deps-log" ref={logRef}>
-            {log.map((l, i) => (
-              <div
-                key={i}
-                className={`deps-log-line${l.kind === 'error' ? ' deps-log-line--err' : ''}`}
-              >
-                {l.text}
+          <div className="deps-console">
+            <button type="button" className="deps-log-toggle" onClick={() => setShowLog((s) => !s)}>
+              {showLog ? 'Hide log ▴' : `Show log (${log.length}) ▾`}
+            </button>
+            {showLog && (
+              <div className="deps-log" ref={logRef}>
+                {log.map((l, i) => (
+                  <div
+                    key={i}
+                    className={`deps-log-line${l.kind === 'error' ? ' deps-log-line--err' : ''}`}
+                  >
+                    {l.text}
+                  </div>
+                ))}
+                {running && <div className="deps-log-cursor">▌</div>}
               </div>
-            ))}
-            {running && <div className="deps-log-cursor">▌</div>}
+            )}
           </div>
         )}
 

--- a/src/deps.js
+++ b/src/deps.js
@@ -723,6 +723,9 @@ export async function ensureDeps(onProgress) {
   await fs.promises.mkdir(tmp, { recursive: true });
   let stepIndex = 0;
   let currentStep = null;
+  // How many REQUIRED steps have fully finished; lets the overlay keep the
+  // required rows checked while the optional (tidal) step is running.
+  let stepsCompleted = 0;
 
   // Per-step speed/ETA tracker — reset when step changes
   let _lastBytes = 0,
@@ -760,6 +763,7 @@ export async function ensureDeps(onProgress) {
       stepLabel: currentStep?.label ?? null,
       stepIndex,
       stepTotal: totalSteps,
+      stepsCompleted,
       stepPct: pct,
       bytesDownloaded: bytesReceived ?? 0,
       bytesTotal: bytesTotal ?? -1,
@@ -774,52 +778,71 @@ export async function ensureDeps(onProgress) {
       stepIndex++;
       resetTracker();
       await downloadFFmpeg(tmp, stepCb);
+      stepsCompleted++;
     }
     if (!analyzerReady) {
       currentStep = STEP_DEFS.find((s) => s.id === 'analyzer');
       stepIndex++;
       resetTracker();
       await downloadAnalyzer(tmp, stepCb);
+      stepsCompleted++;
     }
     if (!ytDlpReady) {
       currentStep = STEP_DEFS.find((s) => s.id === 'ytdlp');
       stepIndex++;
       resetTracker();
       await downloadYtDlp(tmp, stepCb);
+      stepsCompleted++;
     }
     if (!tidalReady) {
+      // Required steps are all done now - report them as completed so the
+      // overlay keeps them checked while the optional step runs.
+      stepsCompleted = totalSteps;
+      currentStep = { id: 'tidal', label: 'tidal-dl-ng (optional)' };
       onProgress?.({
         msg: '[optional] Installing tidal-dl-ng…',
         pct: 0,
-        stepId: null,
+        stepId: 'tidal',
+        stepLabel: 'tidal-dl-ng (optional)',
+        optional: true,
         stepIndex,
         stepTotal: totalSteps,
+        stepsCompleted,
       });
       try {
         await installTidalDlNgDep((msg) =>
           onProgress?.({
             msg: `[optional] ${msg}`,
             pct: -1,
-            stepId: null,
+            stepId: 'tidal',
+            stepLabel: 'tidal-dl-ng (optional)',
+            optional: true,
             stepIndex,
             stepTotal: totalSteps,
+            stepsCompleted,
           })
         );
         onProgress?.({
           msg: '[optional] tidal-dl-ng installed.',
           pct: 100,
-          stepId: null,
+          stepId: 'tidal',
+          stepLabel: 'tidal-dl-ng (optional)',
+          optional: true,
           stepIndex,
           stepTotal: totalSteps,
+          stepsCompleted,
         });
       } catch (err) {
         console.warn('[deps] tidal-dl-ng install failed (non-fatal):', err.message);
         onProgress?.({
           msg: '[optional] tidal-dl-ng install failed — Python 3.12+ may not be available.',
           pct: -1,
-          stepId: null,
+          stepId: 'tidal',
+          stepLabel: 'tidal-dl-ng (optional)',
+          optional: true,
           stepIndex,
           stepTotal: totalSteps,
+          stepsCompleted,
         });
       }
     }

--- a/src/deps.js
+++ b/src/deps.js
@@ -712,6 +712,16 @@ export async function ensureDeps(onProgress) {
   ].filter(Boolean);
   const totalSteps = STEP_DEFS.length;
 
+  // Steps whose binary is already present. The overlay shows these as
+  // checked from the start ("already installed"), so a row never looks like
+  // it "finished instantly" without downloading anything.
+  const readyStepIds = [
+    ffmpegReady && 'ffmpeg',
+    analyzerReady && 'analyzer',
+    ytDlpReady && 'ytdlp',
+    tidalReady && 'tidal',
+  ].filter(Boolean);
+
   if (totalSteps === 0 && tidalReady) {
     onProgress?.({ msg: 'Dependencies up to date.', pct: 100, stepIndex: 0, stepTotal: 0 });
     return;
@@ -764,6 +774,7 @@ export async function ensureDeps(onProgress) {
       stepIndex,
       stepTotal: totalSteps,
       stepsCompleted,
+      readyStepIds,
       stepPct: pct,
       bytesDownloaded: bytesReceived ?? 0,
       bytesTotal: bytesTotal ?? -1,
@@ -808,6 +819,7 @@ export async function ensureDeps(onProgress) {
         stepIndex,
         stepTotal: totalSteps,
         stepsCompleted,
+        readyStepIds,
       });
       try {
         await installTidalDlNgDep((msg) =>
@@ -820,6 +832,7 @@ export async function ensureDeps(onProgress) {
             stepIndex,
             stepTotal: totalSteps,
             stepsCompleted,
+            readyStepIds,
           })
         );
         onProgress?.({
@@ -831,6 +844,7 @@ export async function ensureDeps(onProgress) {
           stepIndex,
           stepTotal: totalSteps,
           stepsCompleted,
+          readyStepIds,
         });
       } catch (err) {
         console.warn('[deps] tidal-dl-ng install failed (non-fatal):', err.message);
@@ -843,6 +857,7 @@ export async function ensureDeps(onProgress) {
           stepIndex,
           stepTotal: totalSteps,
           stepsCompleted,
+          readyStepIds,
         });
       }
     }

--- a/src/deps.js
+++ b/src/deps.js
@@ -798,12 +798,12 @@ export async function ensureDeps(onProgress) {
       // Required steps are all done now - report them as completed so the
       // overlay keeps them checked while the optional step runs.
       stepsCompleted = totalSteps;
-      currentStep = { id: 'tidal', label: 'tidal-dl-ng (optional)' };
+      currentStep = { id: 'tidal', label: 'tidal-dl-ng' };
       onProgress?.({
-        msg: '[optional] Installing tidal-dl-ng…',
+        msg: 'Installing tidal-dl-ng…',
         pct: 0,
         stepId: 'tidal',
-        stepLabel: 'tidal-dl-ng (optional)',
+        stepLabel: 'tidal-dl-ng',
         optional: true,
         stepIndex,
         stepTotal: totalSteps,
@@ -812,10 +812,10 @@ export async function ensureDeps(onProgress) {
       try {
         await installTidalDlNgDep((msg) =>
           onProgress?.({
-            msg: `[optional] ${msg}`,
+            msg,
             pct: -1,
             stepId: 'tidal',
-            stepLabel: 'tidal-dl-ng (optional)',
+            stepLabel: 'tidal-dl-ng',
             optional: true,
             stepIndex,
             stepTotal: totalSteps,
@@ -823,10 +823,10 @@ export async function ensureDeps(onProgress) {
           })
         );
         onProgress?.({
-          msg: '[optional] tidal-dl-ng installed.',
+          msg: 'tidal-dl-ng installed.',
           pct: 100,
           stepId: 'tidal',
-          stepLabel: 'tidal-dl-ng (optional)',
+          stepLabel: 'tidal-dl-ng',
           optional: true,
           stepIndex,
           stepTotal: totalSteps,
@@ -835,10 +835,10 @@ export async function ensureDeps(onProgress) {
       } catch (err) {
         console.warn('[deps] tidal-dl-ng install failed (non-fatal):', err.message);
         onProgress?.({
-          msg: '[optional] tidal-dl-ng install failed — Python 3.12+ may not be available.',
+          msg: 'tidal-dl-ng install failed — Python 3.12+ may not be available.',
           pct: -1,
           stepId: 'tidal',
-          stepLabel: 'tidal-dl-ng (optional)',
+          stepLabel: 'tidal-dl-ng',
           optional: true,
           stepIndex,
           stepTotal: totalSteps,


### PR DESCRIPTION
Follow-up to #317, verified with a fully clean dependency dir.

- Full 4-step checklist visible up front (FFmpeg, mixxx-analyzer, yt-dlp, tidal-dl-ng), installer style.
- Steps already satisfied (binary present) are checked from the start via new `readyStepIds` in progress payloads - no more rows that look like they 'finished instantly'.
- Optional tidal step now renders as a normal row (label without 'optional'), required rows stay checked while it runs; animated indeterminate bar while it streams log lines.
- Console log collapsed by default with 'Show log (N)' toggle.
- Removed '[optional]' prefixes from log lines.