### PR TITLE
feat(metadata): write analyzed BPM & Key into file tags

### DIFF
--- a/renderer/src/MusicLibrary.jsx
+++ b/renderer/src/MusicLibrary.jsx
@@ -2085,6 +2085,22 @@ function MusicLibrary({
     toastTimerRef.current = setTimeout(() => setToast(null), 4000);
   }, []);
 
+  // #474 — write the analyzed BPM/key into the selected tracks' own file tags
+  const handleWriteBpmKeyTags = useCallback(async () => {
+    const targetIds = contextMenu?.targetIds ?? [];
+    setContextMenu(null);
+    if (targetIds.length === 0) return;
+    try {
+      const res = await window.api.writeBpmKeyTags({ trackIds: targetIds });
+      showToast(
+        `BPM & Key tags — written: ${res.written}, skipped: ${res.skipped}`,
+        res.written > 0
+      );
+    } catch (err) {
+      showToast(`BPM & Key tag write failed: ${err.message}`, false);
+    }
+  }, [contextMenu, showToast]);
+
   const handleNormalizeTracks = useCallback(async () => {
     const targetIds = contextMenu?.targetIds ?? [];
     setContextMenu(null);
@@ -3076,6 +3092,12 @@ function MusicLibrary({
                         </div>
                       </SubItem>
                     </SubItem>
+
+                    {/* ── Write BPM & Key tags (#474) ── */}
+                    <div className="context-menu-separator" />
+                    <div className="context-menu-item" onClick={handleWriteBpmKeyTags}>
+                      🏷️ Save BPM &amp; Key to file{selectionLabel}
+                    </div>
 
                     {/* ── Remove ── */}
                     {isPlaylistView ? (

--- a/renderer/src/SettingsModal.jsx
+++ b/renderer/src/SettingsModal.jsx
@@ -36,6 +36,10 @@ function SettingsModal({ onClose }) {
   const [activeSection, setActiveSection] = useState('library');
   const [targetInput, setTargetInput] = useState(String(DEFAULT_TARGET));
   const [autoNormalizeOnImport, setAutoNormalizeOnImport] = useState(false);
+  // #474 — write analyzed BPM & key into the file's own tags
+  const [autoWriteLibrary, setAutoWriteLibrary] = useState(false);
+  const [autoWriteLinked, setAutoWriteLinked] = useState(false);
+  const [overwriteTags, setOverwriteTags] = useState(false);
   const [autoCueOnImport, setAutoCueOnImport] = useState(false);
   const [generatingCues, setGeneratingCues] = useState(false);
   const [cueGenProgress, setCueGenProgress] = useState(null); // { completed, total } | null
@@ -123,6 +127,16 @@ function SettingsModal({ onClose }) {
       .getSetting('cloud_preview_playback_mode', 'overlay')
       .then((v) => setCloudPreviewPlaybackMode(v || 'overlay'));
     window.api.getSetting('waveform_color_mode', 'rgb').then((v) => setWaveformColorMode(v));
+    // #474 — BPM/key tag writing
+    window.api
+      .getSetting('metadata_autowrite_library', 'false')
+      .then((v) => setAutoWriteLibrary(v === 'true'));
+    window.api
+      .getSetting('metadata_autowrite_linked', 'false')
+      .then((v) => setAutoWriteLinked(v === 'true'));
+    window.api
+      .getSetting('metadata_overwrite_tags', 'false')
+      .then((v) => setOverwriteTags(v === 'true'));
   }, []);
 
   useEffect(() => {
@@ -199,6 +213,22 @@ function SettingsModal({ onClose }) {
   const handleAutoNormalizeToggle = (checked) => {
     setAutoNormalizeOnImport(checked);
     window.api.setSetting('auto_normalize_on_import', String(checked));
+  };
+
+  // #474 — BPM/key tag writing settings
+  const handleAutoWriteLibraryToggle = (checked) => {
+    setAutoWriteLibrary(checked);
+    window.api.setSetting('metadata_autowrite_library', String(checked));
+  };
+
+  const handleAutoWriteLinkedToggle = (checked) => {
+    setAutoWriteLinked(checked);
+    window.api.setSetting('metadata_autowrite_linked', String(checked));
+  };
+
+  const handleOverwriteTagsToggle = (checked) => {
+    setOverwriteTags(checked);
+    window.api.setSetting('metadata_overwrite_tags', String(checked));
   };
 
   const handleGenerateCueLibrary = async (overwrite) => {
@@ -362,6 +392,7 @@ function SettingsModal({ onClose }) {
 
   const sections = [
     { id: 'library', label: 'Library' },
+    { id: 'metadata', label: 'Metadata' },
     { id: 'normalization', label: 'Normalization' },
     { id: 'cuepoints', label: 'Cue Points' },
     { id: 'waveform', label: 'Waveform' },
@@ -615,6 +646,72 @@ function SettingsModal({ onClose }) {
                     </button>
                   </div>
                 )}
+              </div>
+            </>
+          )}
+
+          {activeSection === 'metadata' && (
+            <>
+              <h3>Metadata</h3>
+              <div className="settings-group">
+                <div className="settings-group-title">Write BPM &amp; Key to file tags</div>
+                <p className="settings-group-desc">
+                  DjManager analyses BPM and musical key and keeps them in its own database. These
+                  options additionally write the analysed values into the files themselves, so other
+                  applications can read them. Supported: MP3 (ID3 TBPM/TKEY) and FLAC/OGG/Opus
+                  (Vorbis BPM/KEY). M4A/WAV/AIFF are skipped — they have no interoperable tag slot.
+                  Files are rewritten through a temporary copy, so a failure can never corrupt the
+                  original.
+                </p>
+
+                <div className="settings-row">
+                  <label htmlFor="meta-autowrite-library">Auto-write for library tracks</label>
+                  <div className="settings-toggle-row">
+                    <input
+                      id="meta-autowrite-library"
+                      type="checkbox"
+                      checked={autoWriteLibrary}
+                      onChange={(e) => handleAutoWriteLibraryToggle(e.target.checked)}
+                    />
+                    <span className="settings-toggle-desc">
+                      After a library track is analysed, write its BPM &amp; Key into the file.
+                      Imported files are DjManager&apos;s own managed copies. Off by default.
+                    </span>
+                  </div>
+                </div>
+
+                <div className="settings-row">
+                  <label htmlFor="meta-autowrite-linked">Auto-write for linked files</label>
+                  <div className="settings-toggle-row">
+                    <input
+                      id="meta-autowrite-linked"
+                      type="checkbox"
+                      checked={autoWriteLinked}
+                      onChange={(e) => handleAutoWriteLinkedToggle(e.target.checked)}
+                    />
+                    <span className="settings-toggle-desc">
+                      Same, but for linked files — those are your own originals on disk, so this
+                      edits files outside the library folder. Off by default.
+                    </span>
+                  </div>
+                </div>
+
+                <div className="settings-row">
+                  <label htmlFor="meta-overwrite-tags">Overwrite existing BPM/Key tags</label>
+                  <div className="settings-toggle-row">
+                    <input
+                      id="meta-overwrite-tags"
+                      type="checkbox"
+                      checked={overwriteTags}
+                      onChange={(e) => handleOverwriteTagsToggle(e.target.checked)}
+                    />
+                    <span className="settings-toggle-desc">
+                      On: a tag that differs from the analysed value is replaced. Off (default):
+                      only missing tags are filled, existing values are left untouched. Applies to
+                      both auto-write and the manual “Save BPM &amp; Key” action.
+                    </span>
+                  </div>
+                </div>
               </div>
             </>
           )}

--- a/src/__tests__/ffmpegConvert.test.js
+++ b/src/__tests__/ffmpegConvert.test.js
@@ -107,3 +107,65 @@ describe('convertAudio — format conversion arg building', () => {
     expect(args).toContain('libmp3lame');
   });
 });
+
+// ── #474 — metadata written into the exported file ──────────────────────────
+
+describe('convertAudio — export metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spawn.mockReturnValue(makeFakeProc());
+  });
+
+  const argsOf = () => spawn.mock.calls[0][1];
+
+  it('writes title/artist/album plus ID3 BPM/key for an mp3', async () => {
+    await convertAudio('/src/a.m4a', '/dest/a.mp3', {
+      format: 'mp3',
+      metadata: { title: 'Track', artist: 'Artist', album: 'Album', bpm: 128.4, key: '9B' },
+    });
+    const args = argsOf();
+    expect(args).toContain('title=Track');
+    expect(args).toContain('artist=Artist');
+    expect(args).toContain('album=Album');
+    expect(args).toContain('TBPM=128');
+    expect(args).toContain('TKEY=9B');
+  });
+
+  it('uses the Vorbis names when converting to flac', async () => {
+    await convertAudio('/src/a.m4a', '/dest/a.flac', {
+      format: 'flac',
+      metadata: { bpm: 174, key: '11A' },
+    });
+    const args = argsOf();
+    expect(args).toContain('BPM=174');
+    expect(args).toContain('KEY=11A');
+    expect(args).not.toContain('TBPM=174');
+  });
+
+  it('always deletes the MP4 container fields inherited from the source', async () => {
+    await convertAudio('/src/a.m4a', '/dest/a.mp3', { format: 'mp3' });
+    const args = argsOf();
+    expect(args).toContain('major_brand=');
+    expect(args).toContain('minor_version=');
+    expect(args).toContain('compatible_brands=');
+  });
+
+  it('writes no BPM/key when there are none (blind export)', async () => {
+    await convertAudio('/src/a.m4a', '/dest/a.mp3', {
+      format: 'mp3',
+      metadata: { title: 'Track', bpm: null, key: null },
+    });
+    const args = argsOf();
+    expect(args).toContain('title=Track');
+    expect(args.some((a) => a.startsWith('TBPM='))).toBe(false);
+    expect(args.some((a) => a.startsWith('TKEY='))).toBe(false);
+  });
+
+  it('adds no metadata args at all without a metadata object', async () => {
+    await convertAudio('/src/a.m4a', '/dest/a.mp3', { format: 'mp3' });
+    const args = argsOf();
+    expect(args.some((a) => a === 'title=' || a.startsWith('TBPM=') || a.startsWith('TKEY='))).toBe(
+      false
+    );
+  });
+});

--- a/src/__tests__/id3Writer.test.js
+++ b/src/__tests__/id3Writer.test.js
@@ -13,6 +13,19 @@ vi.mock('../audio/ffmpeg.js', () => ({
   ffprobe: vi.fn(async () => ({ format: { tags: probeTags } })),
 }));
 
+// MP4 tag writing is exercised in mp4Tags.test.js — here we only check that
+// .m4a/.mp4 is routed there with the right policy.
+let mp4Existing = { bpm: null, key: null };
+const mp4Writes = [];
+vi.mock('../audio/mp4Tags.js', () => ({
+  supportsMp4Tags: (p) => /\.(m4a|mp4)$/i.test(p || ''),
+  readMp4Tags: () => mp4Existing,
+  writeMp4Tags: (filePath, opts) => {
+    mp4Writes.push({ filePath, ...opts });
+    return { ok: true, inserted: 2, replaced: 0, chunkOffsetsPatched: 9 };
+  },
+}));
+
 // Record every ffmpeg/ffprobe invocation instead of spawning processes.
 const execCalls = [];
 let ffmpegShouldFail = false;
@@ -34,10 +47,14 @@ vi.mock('fs', () => ({
     existsSync: vi.fn(() => true),
     renameSync: vi.fn(),
     unlinkSync: vi.fn(),
+    readFileSync: vi.fn(() => Buffer.alloc(0)),
+    writeFileSync: vi.fn(),
   },
   existsSync: vi.fn(() => true),
   renameSync: vi.fn(),
   unlinkSync: vi.fn(),
+  readFileSync: vi.fn(() => Buffer.alloc(0)),
+  writeFileSync: vi.fn(),
 }));
 
 import fs from 'fs';
@@ -61,12 +78,13 @@ beforeEach(() => {
 });
 
 describe('supportsBpmKeyTags', () => {
-  it('accepts mp3/flac/ogg/opus and rejects m4a/wav/aiff', () => {
+  it('accepts the containers that have a place to put BPM/key', () => {
     expect(supportsBpmKeyTags('/music/a.mp3')).toBe(true);
     expect(supportsBpmKeyTags('/music/a.flac')).toBe(true);
     expect(supportsBpmKeyTags('/music/a.ogg')).toBe(true);
     expect(supportsBpmKeyTags('/music/a.opus')).toBe(true);
-    expect(supportsBpmKeyTags('/music/a.m4a')).toBe(false);
+    expect(supportsBpmKeyTags('/music/a.m4a')).toBe(true);
+    expect(supportsBpmKeyTags('/music/a.mp4')).toBe(true);
     expect(supportsBpmKeyTags('/music/a.wav')).toBe(false);
     expect(supportsBpmKeyTags('/music/a.aiff')).toBe(false);
   });
@@ -104,8 +122,8 @@ describe('writeBpmKeyTags', () => {
     expect(metadataArgs()).not.toContain('TBPM=174');
   });
 
-  it('skips containers with no interoperable slot (m4a/wav/aiff)', async () => {
-    for (const ext of ['m4a', 'wav', 'aiff']) {
+  it('skips containers with no interoperable slot (wav/aiff)', async () => {
+    for (const ext of ['wav', 'aiff']) {
       const res = await writeBpmKeyTags(`/music/a.${ext}`, { bpm: 128, key: '8A' });
       expect(res).toEqual({ ok: false, reason: 'unsupported-format' });
     }
@@ -193,5 +211,64 @@ describe('writeId3Tags (existing text tags — regression)', () => {
     expect(metadataArgs()).toContain('artist=Artist');
     expect(metadataArgs()).toContain('genre=House, Techno');
     expect(fs.renameSync).toHaveBeenCalled();
+  });
+});
+
+// ── #474 (m4a) + container cleanup ───────────────────────────────────────────
+
+describe('MP4 files go through the atom writer', () => {
+  it('routes .m4a writes there with both values', async () => {
+    mp4Existing = { bpm: null, key: null };
+    mp4Writes.length = 0;
+    const res = await writeBpmKeyTags('/music/a.m4a', { bpm: 128, key: '9B' });
+    expect(res).toMatchObject({ ok: true, wrote: ['bpm', 'key'] });
+    expect(mp4Writes).toEqual([{ filePath: '/music/a.m4a', bpm: 128, key: '9B' }]);
+  });
+
+  it('fills only the missing field (fill-missing policy)', async () => {
+    mp4Existing = { bpm: 146, key: null };
+    mp4Writes.length = 0;
+    const res = await writeBpmKeyTags('/music/a.m4a', { bpm: 128, key: '9B' });
+    expect(res.wrote).toEqual(['key']);
+    expect(mp4Writes[0]).toMatchObject({ bpm: null, key: '9B' });
+  });
+
+  it('rewrites both fields when overwriting is on', async () => {
+    mp4Existing = { bpm: 146, key: '1A' };
+    mp4Writes.length = 0;
+    const res = await writeBpmKeyTags('/music/a.m4a', { bpm: 128, key: '9B', overwrite: true });
+    expect(res.wrote).toEqual(['bpm', 'key']);
+    expect(mp4Writes[0]).toMatchObject({ bpm: 128, key: '9B' });
+  });
+
+  it('leaves an .m4a alone when it already matches', async () => {
+    mp4Existing = { bpm: 128, key: '9B' };
+    mp4Writes.length = 0;
+    const res = await writeBpmKeyTags('/music/a.m4a', { bpm: 128, key: '9B' });
+    expect(res).toMatchObject({ ok: true, reason: 'already-current' });
+    expect(mp4Writes).toEqual([]);
+  });
+
+  it('rounds a fractional BPM before it reaches the atom', async () => {
+    mp4Existing = { bpm: null, key: null };
+    mp4Writes.length = 0;
+    await writeBpmKeyTags('/music/a.m4a', { bpm: 127.6, key: null });
+    expect(mp4Writes[0].bpm).toBe(128);
+  });
+});
+
+describe('inherited MP4 container fields are cleaned up', () => {
+  it('deletes them when writing BPM/key to an mp3', async () => {
+    probeTags = {};
+    await writeBpmKeyTags('/music/a.mp3', { bpm: 120, key: null });
+    const args = metadataArgs();
+    expect(args).toContain('major_brand=');
+    expect(args).toContain('minor_version=');
+    expect(args).toContain('compatible_brands=');
+  });
+
+  it('deletes them when writing text tags too', async () => {
+    await writeId3Tags('/music/a.mp3', { title: 'Song' });
+    expect(metadataArgs()).toContain('compatible_brands=');
   });
 });

--- a/src/__tests__/id3Writer.test.js
+++ b/src/__tests__/id3Writer.test.js
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// deps.js pulls in electron — stub it out.
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('../deps.js', () => ({
+  getFfmpegRuntimePath: () => '/usr/bin/ffmpeg',
+  getFfprobeRuntimePath: () => '/usr/bin/ffprobe',
+}));
+
+// ffprobe drives "what tags already exist" — each test sets `probeTags`.
+let probeTags = {};
+vi.mock('../audio/ffmpeg.js', () => ({
+  ffprobe: vi.fn(async () => ({ format: { tags: probeTags } })),
+}));
+
+// Record every ffmpeg/ffprobe invocation instead of spawning processes.
+const execCalls = [];
+let ffmpegShouldFail = false;
+vi.mock('child_process', () => ({
+  // promisify appends its callback after the original args — accept it in
+  // either position (2-arg calls land it 3rd, with-options calls 4th).
+  execFile: (file, args, optsOrCb, maybeCb) => {
+    const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
+    execCalls.push([file, ...(Array.isArray(args) ? args : [args])]);
+    if (file.endsWith('ffmpeg') && ffmpegShouldFail) {
+      return cb(new Error('ffmpeg exploded'));
+    }
+    return cb(null, { stdout: '', stderr: '' });
+  },
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn(() => true),
+    renameSync: vi.fn(),
+    unlinkSync: vi.fn(),
+  },
+  existsSync: vi.fn(() => true),
+  renameSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+import fs from 'fs';
+import {
+  writeBpmKeyTags,
+  writeId3Tags,
+  readBpmKeyTags,
+  supportsBpmKeyTags,
+} from '../audio/id3Writer.js';
+
+const metadataArgs = () => {
+  const call = execCalls.find((c) => c[0].endsWith('ffmpeg'));
+  return call ?? [];
+};
+
+beforeEach(() => {
+  execCalls.length = 0;
+  probeTags = {};
+  ffmpegShouldFail = false;
+  vi.clearAllMocks();
+});
+
+describe('supportsBpmKeyTags', () => {
+  it('accepts mp3/flac/ogg/opus and rejects m4a/wav/aiff', () => {
+    expect(supportsBpmKeyTags('/music/a.mp3')).toBe(true);
+    expect(supportsBpmKeyTags('/music/a.flac')).toBe(true);
+    expect(supportsBpmKeyTags('/music/a.ogg')).toBe(true);
+    expect(supportsBpmKeyTags('/music/a.opus')).toBe(true);
+    expect(supportsBpmKeyTags('/music/a.m4a')).toBe(false);
+    expect(supportsBpmKeyTags('/music/a.wav')).toBe(false);
+    expect(supportsBpmKeyTags('/music/a.aiff')).toBe(false);
+  });
+});
+
+describe('readBpmKeyTags', () => {
+  it('reads BPM/key regardless of the naming convention in the file', async () => {
+    probeTags = { TBPM: '128', initialkey: '8A' };
+    expect(await readBpmKeyTags('/music/a.mp3')).toEqual({ bpm: '128', key: '8A' });
+
+    probeTags = { BPM: '174', KEY: '9B' };
+    expect(await readBpmKeyTags('/music/a.flac')).toEqual({ bpm: '174', key: '9B' });
+
+    probeTags = {};
+    expect(await readBpmKeyTags('/music/a.mp3')).toEqual({ bpm: null, key: null });
+  });
+});
+
+describe('writeBpmKeyTags', () => {
+  it('writes ID3 TBPM/TKEY for MP3', async () => {
+    const res = await writeBpmKeyTags('/music/a.mp3', { bpm: 128, key: '8A' });
+
+    expect(res).toEqual({ ok: true, wrote: ['bpm', 'key'] });
+    expect(metadataArgs()).toContain('TBPM=128');
+    expect(metadataArgs()).toContain('TKEY=8A');
+    expect(fs.renameSync).toHaveBeenCalled();
+  });
+
+  it('writes Vorbis BPM/KEY for FLAC', async () => {
+    const res = await writeBpmKeyTags('/music/a.flac', { bpm: 174, key: '9B' });
+
+    expect(res.ok).toBe(true);
+    expect(metadataArgs()).toContain('BPM=174');
+    expect(metadataArgs()).toContain('KEY=9B');
+    expect(metadataArgs()).not.toContain('TBPM=174');
+  });
+
+  it('skips containers with no interoperable slot (m4a/wav/aiff)', async () => {
+    for (const ext of ['m4a', 'wav', 'aiff']) {
+      const res = await writeBpmKeyTags(`/music/a.${ext}`, { bpm: 128, key: '8A' });
+      expect(res).toEqual({ ok: false, reason: 'unsupported-format' });
+    }
+    expect(execCalls).toHaveLength(0);
+  });
+
+  it('reports missing files and empty values without touching ffmpeg', async () => {
+    fs.existsSync.mockReturnValueOnce(false);
+    expect(await writeBpmKeyTags('/music/gone.mp3', { bpm: 128 })).toEqual({
+      ok: false,
+      reason: 'missing-file',
+    });
+    expect(await writeBpmKeyTags('/music/a.mp3', { bpm: null, key: null })).toEqual({
+      ok: false,
+      reason: 'no-values',
+    });
+    expect(execCalls).toHaveLength(0);
+  });
+
+  it('fill-missing (default): leaves an existing tag alone entirely', async () => {
+    probeTags = { TBPM: '120', TKEY: '8A' };
+    const res = await writeBpmKeyTags('/music/a.mp3', { bpm: 128, key: '9B' });
+
+    expect(res).toEqual({ ok: true, reason: 'already-current', wrote: [] });
+    expect(execCalls).toHaveLength(0);
+  });
+
+  it('fill-missing: writes only the tag that is absent', async () => {
+    probeTags = { TBPM: '120' };
+    const res = await writeBpmKeyTags('/music/a.mp3', { bpm: 128, key: '9B' });
+
+    expect(res.wrote).toEqual(['key']);
+    expect(metadataArgs()).toContain('TKEY=9B');
+    expect(metadataArgs()).not.toContain('TBPM=128');
+  });
+
+  it('overwrite: replaces a differing value but not an equal one', async () => {
+    probeTags = { TBPM: '120', TKEY: '9B' };
+    const res = await writeBpmKeyTags('/music/a.mp3', {
+      bpm: 128,
+      key: '9B',
+      overwrite: true,
+    });
+
+    expect(res.wrote).toEqual(['bpm']);
+    expect(metadataArgs()).toContain('TBPM=128');
+  });
+
+  it('overwrite: rewrites when the stored tag differs (key compared case-insensitively)', async () => {
+    probeTags = { TBPM: '128', TKEY: '8a' };
+    const res = await writeBpmKeyTags('/music/a.mp3', {
+      bpm: 128,
+      key: '8A',
+      overwrite: true,
+    });
+
+    expect(res).toEqual({ ok: true, reason: 'already-current', wrote: [] });
+  });
+
+  it('reports an ffmpeg failure and cleans up the temp file', async () => {
+    ffmpegShouldFail = true;
+    const res = await writeBpmKeyTags('/music/a.mp3', { bpm: 128 });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('write-failed');
+    expect(fs.renameSync).not.toHaveBeenCalled();
+    expect(fs.unlinkSync).toHaveBeenCalledWith('/music/a.mp3.id3tmp.mp3');
+  });
+
+  it('rounds fractional BPM values', async () => {
+    await writeBpmKeyTags('/music/a.flac', { bpm: 127.6, key: null });
+    expect(metadataArgs()).toContain('BPM=128');
+  });
+});
+
+describe('writeId3Tags (existing text tags — regression)', () => {
+  it('still writes the mapped text/genre fields', async () => {
+    await writeId3Tags('/music/a.mp3', {
+      title: 'Song',
+      artist: 'Artist',
+      genres: JSON.stringify(['House', 'Techno']),
+    });
+
+    expect(metadataArgs()).toContain('title=Song');
+    expect(metadataArgs()).toContain('artist=Artist');
+    expect(metadataArgs()).toContain('genre=House, Techno');
+    expect(fs.renameSync).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/mp4Tags.test.js
+++ b/src/__tests__/mp4Tags.test.js
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  supportsMp4Tags,
+  readMp4Tags,
+  patchMp4Tags,
+  writeMp4Tags,
+  buildFreeformItem,
+  INITIALKEY_MEAN,
+  INITIALKEY_NAME,
+} from '../audio/mp4Tags.js';
+
+// ── Synthetic but structurally valid MP4 ─────────────────────────────────────
+// ftyp + moov(trak.mdia.minf.stbl[stco], udta.meta[hqlr, ilst]) + mdat, so the
+// same code paths as a real file run: box walking, ancestor size bumps and the
+// stco shift that a moov-before-mdat file needs.
+
+function box(tag, ...parts) {
+  const body = Buffer.concat(parts);
+  const out = Buffer.alloc(8 + body.length);
+  out.writeUInt32BE(8 + body.length, 0);
+  out.write(tag, 4, 'latin1');
+  body.copy(out, 8);
+  return out;
+}
+
+function textItem(tag, value) {
+  const data = Buffer.concat([Buffer.alloc(8), Buffer.from(value, 'utf8')]);
+  const dataBox = Buffer.alloc(8 + data.length);
+  dataBox.writeUInt32BE(8 + data.length, 0);
+  dataBox.write('data', 4, 'latin1');
+  data.copy(dataBox, 8);
+  return box(tag, dataBox);
+}
+
+function intItem(tag, value) {
+  const data = Buffer.concat([Buffer.alloc(8), Buffer.from([(value >> 8) & 0xff, value & 0xff])]);
+  const dataBox = Buffer.alloc(8 + data.length);
+  dataBox.writeUInt32BE(8 + data.length, 0);
+  dataBox.write('data', 4, 'latin1');
+  data.copy(dataBox, 8);
+  return box(tag, dataBox);
+}
+
+function makeMp4({ moovFirst = true, tmpo = null, initialKey = null, withArtwork = true } = {}) {
+  const items = [textItem('\u00a9nam', 'Old Title'), textItem('\u00a9ART', 'Old Artist')];
+  if (withArtwork) items.push(textItem('covr', 'x'.repeat(120)));
+  if (tmpo != null) items.push(intItem('tmpo', tmpo));
+  if (initialKey) items.push(buildFreeformItem(INITIALKEY_MEAN, INITIALKEY_NAME, initialKey));
+
+  const hdlr = box('hdlr', Buffer.alloc(25));
+  const ilst = box('ilst', ...items);
+  const meta = box('meta', Buffer.alloc(4), hdlr, ilst);
+  const udta = box('udta', meta);
+
+  const stco = box(
+    'stco',
+    Buffer.alloc(4),
+    (() => {
+      const c = Buffer.alloc(4);
+      c.writeUInt32BE(2, 0);
+      return c;
+    })(),
+    (() => {
+      const o = Buffer.alloc(8);
+      o.writeUInt32BE(1000, 0);
+      o.writeUInt32BE(2000, 4);
+      return o;
+    })()
+  );
+  const stbl = box('stbl', stco);
+  const minf = box('minf', stbl);
+  const mdia = box('mdia', minf);
+  const trak = box('trak', mdia);
+  const moov = box('moov', trak, udta);
+  const mdat = box('mdat', Buffer.alloc(64, 0xab));
+  const ftyp = box('ftyp', Buffer.from('isom', 'latin1'));
+
+  return moovFirst ? Buffer.concat([ftyp, moov, mdat]) : Buffer.concat([ftyp, mdat, moov]);
+}
+
+/** Every stco offset, plus the total number of bytes the ilst holds. */
+function stcoOffsets(buf) {
+  const i = buf.indexOf(Buffer.from('stco', 'latin1'));
+  const count = buf.readUInt32BE(i + 8);
+  const out = [];
+  for (let k = 0; k < count; k += 1) out.push(buf.readUInt32BE(i + 12 + 4 * k));
+  return out;
+}
+
+/** Walk the tree and fail loudly on any inconsistent box. */
+function assertBoxesValid(buf, start = 0, end = buf.length) {
+  let i = start;
+  while (i + 8 <= end) {
+    const size = buf.readUInt32BE(i);
+    const tag = buf.toString('latin1', i + 4, i + 8);
+    if (size < 8 || i + size > end) throw new Error(`broken box ${tag} size=${size} at ${i}`);
+    if (['moov', 'udta', 'meta', 'ilst', 'trak', 'mdia', 'minf', 'stbl'].includes(tag)) {
+      assertBoxesValid(buf, i + 8 + (tag === 'meta' ? 4 : 0), i + size);
+    }
+    i += size;
+  }
+}
+
+describe('mp4Tags — reading', () => {
+  it('reads bpm and the freeform INITIALKEY item', () => {
+    const buf = makeMp4({ tmpo: 146, initialKey: '9B' });
+    expect(readMp4Tags(buf)).toEqual({ bpm: 146, key: '9B' });
+  });
+
+  it('returns nulls when the file has neither', () => {
+    expect(readMp4Tags(makeMp4())).toEqual({ bpm: null, key: null });
+  });
+
+  it('ignores other freeform items (UPC, lyrics)', () => {
+    const buf = Buffer.concat([
+      makeMp4({ tmpo: 120 }),
+      buildFreeformItem('com.apple.iTunes', 'UPC', '5054284715865'),
+    ]);
+    // the extra item sits outside ilst, so it must not be picked up as the key
+    expect(readMp4Tags(buf).key).toBeNull();
+  });
+});
+
+describe('mp4Tags — patching', () => {
+  it('inserts tmpo and the key item, preserving everything else', () => {
+    const src = makeMp4();
+    const { buffer, inserted, replaced } = patchMp4Tags(src, { bpm: 128, key: '9B' });
+
+    expect(inserted).toBe(2);
+    expect(replaced).toBe(0);
+    expect(readMp4Tags(buffer)).toEqual({ bpm: 128, key: '9B' });
+    expect(buffer.toString('latin1')).toContain('Old Title');
+    expect(buffer.toString('latin1')).toContain('Old Artist');
+    expect(buffer.length).toBeGreaterThan(src.length);
+    expect(() => assertBoxesValid(buffer)).not.toThrow();
+  });
+
+  it('replaces an existing tmpo instead of adding a second one', () => {
+    const src = makeMp4({ tmpo: 146 });
+    const { buffer, replaced } = patchMp4Tags(src, { bpm: 128 });
+    expect(replaced).toBe(1);
+    const matches = buffer.toString('latin1').split('tmpo').length - 1;
+    expect(matches).toBe(1);
+    expect(readMp4Tags(buffer).bpm).toBe(128);
+  });
+
+  it('replaces an existing INITIALKEY item instead of duplicating it', () => {
+    const src = makeMp4({ initialKey: '9B' });
+    const { buffer } = patchMp4Tags(src, { key: '12A' });
+    expect(buffer.toString('latin1').split(INITIALKEY_NAME).length - 1).toBe(1);
+    expect(readMp4Tags(buffer).key).toBe('12A');
+  });
+
+  it('shifts every stco chunk offset when moov sits before mdat', () => {
+    const src = makeMp4({ moovFirst: true });
+    const before = stcoOffsets(src);
+    const { buffer, chunkOffsetsPatched } = patchMp4Tags(src, { bpm: 128, key: '9B' });
+    const after = stcoOffsets(buffer);
+
+    const delta = buffer.length - src.length;
+    expect(chunkOffsetsPatched).toBe(2);
+    expect(delta).toBeGreaterThan(0);
+    expect(after).toEqual(before.map((offset) => offset + delta));
+  });
+
+  it('leaves chunk offsets alone when mdat comes first', () => {
+    const src = makeMp4({ moovFirst: false });
+    const before = stcoOffsets(src);
+    const { buffer, chunkOffsetsPatched } = patchMp4Tags(src, { bpm: 128, key: '9B' });
+    expect(chunkOffsetsPatched).toBe(0);
+    expect(stcoOffsets(buffer)).toEqual(before);
+    expect(readMp4Tags(buffer).bpm).toBe(128);
+  });
+
+  it('is size-neutral when the same values are written again', () => {
+    const first = patchMp4Tags(makeMp4(), { bpm: 128, key: '9B' }).buffer;
+    const second = patchMp4Tags(first, { bpm: 128, key: '9B' }).buffer;
+    expect(second.length).toBe(first.length);
+    expect(readMp4Tags(second)).toEqual({ bpm: 128, key: '9B' });
+  });
+
+  it('does nothing without values', () => {
+    const src = makeMp4();
+    const res = patchMp4Tags(src, {});
+    expect(res.inserted).toBe(0);
+    expect(res.buffer).toBe(src);
+  });
+
+  it('refuses anything that is not an MP4', () => {
+    expect(() =>
+      patchMp4Tags(Buffer.from('ID3\x04\x00\x00\x00\x00\x00\x00', 'latin1'), { bpm: 1 })
+    ).toThrow();
+  });
+});
+
+describe('mp4Tags — file level', () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'djman-mp4-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes to disk atomically and reads the values back', () => {
+    const file = path.join(dir, 'track.m4a');
+    fs.writeFileSync(file, makeMp4({ tmpo: 146 }));
+
+    const res = writeMp4Tags(file, { bpm: 128, key: '9B' });
+    expect(res.ok).toBe(true);
+    expect(res.wrote).toEqual(['bpm', 'key']);
+    expect(res.replaced).toBe(1);
+
+    const onDisk = fs.readFileSync(file);
+    expect(readMp4Tags(onDisk)).toEqual({ bpm: 128, key: '9B' });
+    expect(() => assertBoxesValid(onDisk)).not.toThrow();
+    expect(fs.existsSync(`${file}.mp4tmp`)).toBe(false);
+  });
+
+  it('reports a missing file instead of throwing', () => {
+    expect(writeMp4Tags(path.join(dir, 'nope.m4a'), { bpm: 1 })).toEqual({
+      ok: false,
+      reason: 'missing-file',
+    });
+  });
+
+  it('knows which containers it handles', () => {
+    expect(supportsMp4Tags('/music/a.m4a')).toBe(true);
+    expect(supportsMp4Tags('/music/a.MP4')).toBe(true);
+    expect(supportsMp4Tags('/music/a.mp3')).toBe(false);
+    expect(supportsMp4Tags('/music/a.flac')).toBe(false);
+  });
+});

--- a/src/audio/ffmpeg.js
+++ b/src/audio/ffmpeg.js
@@ -43,11 +43,24 @@ const FORMAT_CODEC = {
  * Copy srcPath to destPath via ffmpeg, optionally applying a gain adjustment
  * and/or converting to a different output format/codec.
  * destPath is always overwritten (-y). Parent directory must already exist.
+ *
+ * `metadata` (optional) writes real tags into the output so the file is
+ * self-describing for other software: { title, artist, album, bpm, key }.
+ * BPM/key land in the container's own field (ID3 TBPM/TKEY for mp3, Vorbis
+ * BPM/KEY for flac/ogg). MP4 output is handled by the caller, which edits the
+ * ilst atoms directly (ffmpeg cannot write the key field there).
+ *
+ * Junk inherited from a container change is always dropped: a .m4a converted to
+ * .mp3 used to carry `TXXX major_brand/minor_version/compatible_brands` (fields
+ * of the MP4 container that mean nothing inside an MP3). Passing an empty value
+ * makes ffmpeg delete the tag.
  */
+const JUNK_CONTAINER_TAGS = ['major_brand', 'minor_version', 'compatible_brands'];
+
 export function convertAudio(
   srcPath,
   destPath,
-  { gainDb = 0, sourceBitrateKbps = null, format = null } = {}
+  { gainDb = 0, sourceBitrateKbps = null, format = null, metadata = null } = {}
 ) {
   const ffmpegPath = getFfmpegRuntimePath();
   if (!fs.existsSync(ffmpegPath))
@@ -88,6 +101,19 @@ export function convertAudio(
     // Preserve source bitrate to avoid silent quality downgrade (ffmpeg default is 128 kbps)
     if (sourceBitrateKbps) args.push('-b:a', `${Math.round(sourceBitrateKbps)}k`);
   }
+
+  for (const junk of JUNK_CONTAINER_TAGS) {
+    args.push('-metadata', `${junk}=`);
+  }
+
+  if (metadata) {
+    for (const [key, value] of Object.entries(bpmKeyMetadata(format, metadata))) {
+      if (value !== null && value !== undefined && value !== '') {
+        args.push('-metadata', `${key}=${value}`);
+      }
+    }
+  }
+
   args.push(destPath);
 
   return new Promise((resolve, reject) => {
@@ -100,4 +126,24 @@ export function convertAudio(
     });
     proc.on('error', reject);
   });
+}
+
+/** ffmpeg metadata keys that carry a title/artist/album plus BPM/key per format. */
+export function bpmKeyMetadata(format, { title, artist, album, bpm, key } = {}) {
+  const out = {};
+  if (title) out.title = title;
+  if (artist) out.artist = artist;
+  if (album) out.album = album;
+  if (bpm == null && !key) return out;
+
+  if (format === 'flac' || format === 'ogg' || format === 'opus') {
+    // Vorbis comments
+    if (bpm != null) out.BPM = String(Math.round(Number(bpm)));
+    if (key) out.KEY = String(key);
+  } else {
+    // ID3 frames (mp3, and the ID3 chunk ffmpeg writes into wav/aiff/adts)
+    if (bpm != null) out.TBPM = String(Math.round(Number(bpm)));
+    if (key) out.TKEY = String(key);
+  }
+  return out;
 }

--- a/src/audio/id3Writer.js
+++ b/src/audio/id3Writer.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { getFfmpegRuntimePath } from '../deps.js';
 import { ffprobe as runFfprobe } from './ffmpeg.js';
+import { supportsMp4Tags, readMp4Tags, writeMp4Tags } from './mp4Tags.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -37,6 +38,8 @@ const KEY_TAG_NAMES = ['key', 'KEY', 'initialkey', 'INITIALKEY', 'TKEY', 'tkey']
 
 /** True when the file's container can carry BPM/key tags (#474). */
 export function supportsBpmKeyTags(filePath) {
+  // MP4 goes through the atom writer, not ffmpeg, but it is supported.
+  if (supportsMp4Tags(filePath)) return true;
   return Boolean(BPM_KEY_FIELDS[path.extname(filePath ?? '').toLowerCase()]);
 }
 
@@ -63,7 +66,14 @@ export async function readBpmKeyTags(filePath) {
  * ffmpeg metadata write through a temp file + atomic rename. `-map_metadata 0`
  * keeps every existing tag; only the passed keys are overridden. The temp file
  * is always cleaned up, so a failure can never corrupt the original.
+ *
+ * MP4 container fields that leaked into the tag as `TXXX major_brand` /
+ * `minor_version` / `compatible_brands` (they arrive whenever an m4a is turned
+ * into an mp3) are deleted instead of copied forward: ffmpeg removes a tag when
+ * it is given an empty value.
  */
+const JUNK_CONTAINER_TAGS = ['major_brand', 'minor_version', 'compatible_brands'];
+
 async function runMetadataWrite(filePath, metadataArgs) {
   const ffmpeg = getFfmpegRuntimePath();
   if (!fs.existsSync(ffmpeg)) throw new Error('ffmpeg binary not found');
@@ -77,6 +87,7 @@ async function runMetadataWrite(filePath, metadataArgs) {
       filePath,
       '-map_metadata',
       '0',
+      ...JUNK_CONTAINER_TAGS.flatMap((tag) => ['-metadata', `${tag}=`]),
       ...metadataArgs,
       '-codec',
       'copy',
@@ -147,16 +158,20 @@ export async function writeBpmKeyTags(
 ) {
   if (!filePath || !fs.existsSync(filePath)) return { ok: false, reason: 'missing-file' };
 
-  const ext = path.extname(filePath).toLowerCase();
-  const fields = BPM_KEY_FIELDS[ext];
-  if (!fields) return { ok: false, reason: 'unsupported-format' };
-
   const bpmValue =
     bpm == null || bpm === '' || !Number.isFinite(Number(bpm))
       ? null
       : String(Math.round(Number(bpm)));
   const keyValue = key == null || String(key).trim() === '' ? null : String(key).trim();
   if (bpmValue == null && keyValue == null) return { ok: false, reason: 'no-values' };
+
+  // MP4 (.m4a/.mp4) has no ffmpeg-writable key field — edit the atoms ourselves.
+  if (supportsMp4Tags(filePath)) {
+    return writeMp4BpmKeyTags(filePath, { bpm: bpmValue, key: keyValue, overwrite });
+  }
+
+  const fields = BPM_KEY_FIELDS[path.extname(filePath).toLowerCase()];
+  if (!fields) return { ok: false, reason: 'unsupported-format' };
 
   // Existing tags decide whether anything is left to do.
   let existing = { bpm: null, key: null };
@@ -206,4 +221,33 @@ function bpmTagIsCurrent(existing, value, overwrite) {
 function keyTagIsCurrent(existing, value, overwrite) {
   if (existing == null) return false;
   return overwrite ? String(existing).toLowerCase() === String(value).toLowerCase() : true;
+}
+
+/**
+ * #474 — BPM/key into an .m4a/.mp4 by editing the `ilst` atoms ourselves
+ * (`tmpo` + a freeform `INITIALKEY` item). Same fill-missing / overwrite policy
+ * as the ffmpeg path; nothing else in the file is touched.
+ *
+ * @param {string} filePath
+ * @param {{ bpm?: number|string|null, key?: string|null, overwrite?: boolean }} opts
+ * @returns {{ ok: boolean, reason?: string, wrote?: string[], error?: string }}
+ */
+export function writeMp4BpmKeyTags(filePath, { bpm = null, key = null, overwrite = false } = {}) {
+  let existing = { bpm: null, key: null };
+  try {
+    existing = readMp4Tags(fs.readFileSync(filePath));
+  } catch (err) {
+    if (!overwrite) return { ok: false, reason: 'unreadable-tags', error: err.message };
+  }
+
+  const wantsBpm = bpm != null && !bpmTagIsCurrent(existing.bpm, bpm, overwrite);
+  const wantsKey = key != null && !keyTagIsCurrent(existing.key, key, overwrite);
+  if (!wantsBpm && !wantsKey) return { ok: true, reason: 'already-current', wrote: [] };
+
+  const res = writeMp4Tags(filePath, {
+    bpm: wantsBpm ? Math.round(Number(bpm)) : null,
+    key: wantsKey ? key : null,
+  });
+  if (!res.ok) return { ok: false, reason: res.reason, error: res.error };
+  return { ok: true, wrote: [wantsBpm ? 'bpm' : null, wantsKey ? 'key' : null].filter(Boolean) };
 }

--- a/src/audio/id3Writer.js
+++ b/src/audio/id3Writer.js
@@ -3,6 +3,7 @@ import { promisify } from 'util';
 import fs from 'fs';
 import path from 'path';
 import { getFfmpegRuntimePath } from '../deps.js';
+import { ffprobe as runFfprobe } from './ffmpeg.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -16,6 +17,83 @@ const TAG_MAP = {
   comments: 'comment',
 };
 
+// #474 — containers that accept plain, widely readable BPM/key tag names.
+//   MP3          → ID3v2 frames TBPM (tempo) / TKEY (initial key)
+//   FLAC/OGG/Opus → Vorbis comments BPM / KEY (Picard / Mixed In Key convention)
+// M4A/WAV/AIFF are deliberately NOT supported: they have no interoperable slot
+// (ffmpeg would write a non-standard atom other apps ignore), and rewriting a
+// WAV/AIFF header for tags is not worth the risk.
+const BPM_KEY_FIELDS = {
+  '.mp3': { bpm: 'TBPM', key: 'TKEY' },
+  '.flac': { bpm: 'BPM', key: 'KEY' },
+  '.ogg': { bpm: 'BPM', key: 'KEY' },
+  '.oga': { bpm: 'BPM', key: 'KEY' },
+  '.opus': { bpm: 'BPM', key: 'KEY' },
+};
+
+// Tag names seen in the wild for BPM/key, across ID3 + Vorbis conventions.
+const BPM_TAG_NAMES = ['bpm', 'BPM', 'TBPM', 'tbpm'];
+const KEY_TAG_NAMES = ['key', 'KEY', 'initialkey', 'INITIALKEY', 'TKEY', 'tkey'];
+
+/** True when the file's container can carry BPM/key tags (#474). */
+export function supportsBpmKeyTags(filePath) {
+  return Boolean(BPM_KEY_FIELDS[path.extname(filePath ?? '').toLowerCase()]);
+}
+
+/** Pick the first present tag value from a tags object (case-tolerant). */
+function pickTag(tags, names) {
+  for (const name of names) {
+    const value = tags?.[name];
+    if (value != null && String(value).trim() !== '') return String(value).trim();
+  }
+  return null;
+}
+
+/**
+ * Read the BPM/key tags already present in a file.
+ * @returns {Promise<{ bpm: string|null, key: string|null }>}
+ */
+export async function readBpmKeyTags(filePath) {
+  const data = await runFfprobe(filePath);
+  const tags = data?.format?.tags || {};
+  return { bpm: pickTag(tags, BPM_TAG_NAMES), key: pickTag(tags, KEY_TAG_NAMES) };
+}
+
+/**
+ * ffmpeg metadata write through a temp file + atomic rename. `-map_metadata 0`
+ * keeps every existing tag; only the passed keys are overridden. The temp file
+ * is always cleaned up, so a failure can never corrupt the original.
+ */
+async function runMetadataWrite(filePath, metadataArgs) {
+  const ffmpeg = getFfmpegRuntimePath();
+  if (!fs.existsSync(ffmpeg)) throw new Error('ffmpeg binary not found');
+
+  const ext = path.extname(filePath);
+  const tmp = `${filePath}.id3tmp${ext}`;
+  try {
+    await execFileAsync(ffmpeg, [
+      '-y',
+      '-i',
+      filePath,
+      '-map_metadata',
+      '0',
+      ...metadataArgs,
+      '-codec',
+      'copy',
+      tmp,
+    ]);
+    fs.renameSync(tmp, filePath);
+  } finally {
+    if (fs.existsSync(tmp)) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
 /**
  * Write metadata tags back to the audio file using ffmpeg.
  * Uses a temp-file + atomic rename to avoid corrupting the original.
@@ -24,9 +102,6 @@ const TAG_MAP = {
  */
 export async function writeId3Tags(filePath, tags) {
   if (!filePath || !fs.existsSync(filePath)) return;
-
-  const ffmpeg = getFfmpegRuntimePath();
-  if (!fs.existsSync(ffmpeg)) return; // deps not ready yet
 
   const metadataArgs = [];
 
@@ -47,30 +122,88 @@ export async function writeId3Tags(filePath, tags) {
 
   if (metadataArgs.length === 0) return;
 
-  const ext = path.extname(filePath);
-  const tmp = `${filePath}.id3tmp${ext}`;
   try {
-    await execFileAsync(ffmpeg, [
-      '-y',
-      '-i',
-      filePath,
-      '-map_metadata',
-      '0',
-      ...metadataArgs,
-      '-codec',
-      'copy',
-      tmp,
-    ]);
-    fs.renameSync(tmp, filePath);
+    await runMetadataWrite(filePath, metadataArgs);
   } catch (err) {
     console.error('[id3Writer] failed to write tags:', err.message);
-  } finally {
-    if (fs.existsSync(tmp)) {
-      try {
-        fs.unlinkSync(tmp);
-      } catch {
-        /* ignore */
-      }
-    }
   }
+}
+
+/**
+ * #474 — write the analyzed BPM/key into the file's own tags.
+ *
+ * Only containers with interoperable slots are written (MP3, FLAC, OGG/Opus).
+ * With `overwrite: false` a tag that is already present is left alone (fill
+ * missing only); values identical to what is already there are never rewritten,
+ * so re-analysis does not churn files.
+ *
+ * @param {string} filePath
+ * @param {{ bpm?: number|string|null, key?: string|null, overwrite?: boolean }} opts
+ * @returns {Promise<{ ok: boolean, reason?: string, wrote?: string[], error?: string }>}
+ */
+export async function writeBpmKeyTags(
+  filePath,
+  { bpm = null, key = null, overwrite = false } = {}
+) {
+  if (!filePath || !fs.existsSync(filePath)) return { ok: false, reason: 'missing-file' };
+
+  const ext = path.extname(filePath).toLowerCase();
+  const fields = BPM_KEY_FIELDS[ext];
+  if (!fields) return { ok: false, reason: 'unsupported-format' };
+
+  const bpmValue =
+    bpm == null || bpm === '' || !Number.isFinite(Number(bpm))
+      ? null
+      : String(Math.round(Number(bpm)));
+  const keyValue = key == null || String(key).trim() === '' ? null : String(key).trim();
+  if (bpmValue == null && keyValue == null) return { ok: false, reason: 'no-values' };
+
+  // Existing tags decide whether anything is left to do.
+  let existing = { bpm: null, key: null };
+  try {
+    existing = await readBpmKeyTags(filePath);
+  } catch (err) {
+    // Unreadable tags: treat as absent (overwrite policy then applies).
+    if (!overwrite) return { ok: false, reason: 'unreadable-tags', error: err.message };
+  }
+
+  const wantsBpm = bpmValue != null && !bpmTagIsCurrent(existing.bpm, bpmValue, overwrite);
+  const wantsKey = keyValue != null && !keyTagIsCurrent(existing.key, keyValue, overwrite);
+  if (!wantsBpm && !wantsKey) return { ok: true, reason: 'already-current', wrote: [] };
+
+  const metadataArgs = [];
+  const wrote = [];
+  if (wantsBpm) {
+    metadataArgs.push('-metadata', `${fields.bpm}=${bpmValue}`);
+    wrote.push('bpm');
+  }
+  if (wantsKey) {
+    metadataArgs.push('-metadata', `${fields.key}=${keyValue}`);
+    wrote.push('key');
+  }
+
+  try {
+    await runMetadataWrite(filePath, metadataArgs);
+  } catch (err) {
+    return { ok: false, reason: 'write-failed', error: err.message };
+  }
+  return { ok: true, wrote };
+}
+
+/** A BPM tag is left alone when present (fill-missing) or equal (overwrite). */
+function bpmTagIsCurrent(existing, value, overwrite) {
+  if (existing == null) return false;
+  const a = Number(existing);
+  const b = Number(value);
+  const equal =
+    Number.isFinite(a) && Number.isFinite(b)
+      ? a === b
+      : String(existing).trim() === String(value).trim();
+  return overwrite ? equal : true;
+}
+
+/** A key tag is left alone when present (fill-missing) or equal (overwrite). */
+function keyTagIsCurrent(existing, value, overwrite) {
+  if (existing == null) return false;
+  return overwrite ? String(existing).toLowerCase() === String(value).toLowerCase() : true;
 }

--- a/src/audio/importManager.js
+++ b/src/audio/importManager.js
@@ -28,6 +28,7 @@ import {
 import { generateCuePoints } from './cueGen.js';
 import { getCuePoints, addCuePoint } from '../db/cuePointRepository.js';
 import { generateWaveformOverview } from './waveformGenerator.js';
+import { writeBpmKeyTags } from './id3Writer.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -60,7 +61,7 @@ export function cancelAnalysis(trackId) {
 
 // ─── File hashing ────────────────────────────────────────────────────────────
 
-function hashFile(filePath) {
+export function hashFile(filePath) {
   const hash = crypto.createHash('sha1');
   const stream = fs.createReadStream(filePath);
 
@@ -69,6 +70,66 @@ function hashFile(filePath) {
     stream.on('end', () => resolve(hash.digest('hex')));
     stream.on('error', reject);
   });
+}
+
+// ─── #474: mirror analyzed BPM/key into the file's own tags ───────────────────
+// Settings (all off by default):
+//   metadata_autowrite_library — auto-write for imported (managed) files
+//   metadata_autowrite_linked  — auto-write for linked (user-owned) files
+//   metadata_overwrite_tags    — overwrite differing tags; off = fill missing only
+// Writing tags rewrites the file, which changes its content hash — the stored
+// file_hash is refreshed after a successful write so dedup stays correct.
+
+function settingFlag(key) {
+  return getSetting(key, 'false') === 'true';
+}
+
+/**
+ * Write one track's analyzed BPM/key into its file tags.
+ * Shared by the analysis hook and the manual "Save BPM & Key" action.
+ * @param {number} trackId
+ * @param {{ overwrite?: boolean }} [opts]  defaults to the metadata_overwrite_tags setting
+ * @returns {Promise<{ trackId: number, ok: boolean, reason?: string, wrote?: string[], error?: string }>}
+ */
+export async function writeBpmKeyTagsForTrack(trackId, { overwrite = null } = {}) {
+  const track = getTrackById(trackId);
+  if (!track?.file_path) return { trackId, ok: false, reason: 'no-track' };
+
+  const bpm = track.bpm_override ?? track.bpm ?? null;
+  const key = track.key_camelot ?? null;
+  if (bpm == null && !key) return { trackId, ok: false, reason: 'no-values' };
+
+  const useOverwrite =
+    overwrite == null ? settingFlag('metadata_overwrite_tags') : Boolean(overwrite);
+  const res = await writeBpmKeyTags(track.file_path, { bpm, key, overwrite: useOverwrite });
+
+  if (res.ok && (res.wrote?.length ?? 0) > 0) {
+    try {
+      updateTrack(trackId, { file_hash: await hashFile(track.file_path) });
+    } catch (err) {
+      console.warn(`[metadata] could not refresh file_hash for track ${trackId}:`, err.message);
+    }
+  }
+  return { trackId, ...res };
+}
+
+/** Auto-write after analysis — no-op unless the matching target setting is on. */
+async function autoWriteBpmKeyTags(trackId) {
+  const track = getTrackById(trackId);
+  if (!track) return;
+  const enabled = track.is_linked
+    ? settingFlag('metadata_autowrite_linked')
+    : settingFlag('metadata_autowrite_library');
+  if (!enabled) return;
+
+  const res = await writeBpmKeyTagsForTrack(trackId);
+  if (!res.ok && !['no-values', 'already-current', 'unsupported-format'].includes(res.reason)) {
+    console.warn(
+      `[metadata] BPM/key tag write skipped for track ${trackId}:`,
+      res.reason,
+      res.error ?? ''
+    );
+  }
 }
 
 // The oldest library (lowest id — seeded as "Default" by the #390 migration)
@@ -434,6 +495,13 @@ export function spawnAnalysis(trackId, filePath, { silent = false } = {}) {
     }
 
     updateTrack(trackId, update);
+
+    // #474 — mirror the analyzed BPM/key into the file's own tags when the
+    // matching auto-write setting is on (fire-and-forget — never blocks
+    // analysis progress or the track-updated event).
+    autoWriteBpmKeyTags(trackId).catch((err) =>
+      console.warn(`[metadata] BPM/key tag write failed for track ${trackId}:`, err.message)
+    );
 
     // Generate waveform overview for in-app seek bar (fire-and-forget — does not
     // block analysis progress or track-updated event)

--- a/src/audio/mp4Tags.js
+++ b/src/audio/mp4Tags.js
@@ -1,0 +1,282 @@
+import fs from 'fs';
+import path from 'path';
+
+// #474 — MP4/M4A tag writing with no external dependency.
+//
+// ffmpeg cannot write the "initial key" field of an MP4: every spelling of
+// `-metadata INITIALKEY=...` / `----:com.apple.iTunes:INITIALKEY=...` is silently
+// dropped by its mov muxer (verified on copies of real files). So we edit the
+// `moov.udta.meta.ilst` atom list ourselves:
+//
+//   tmpo                 16-bit integer BPM (read by iTunes, Traktor, rekordbox)
+//   ---- (freeform)      mean="com.apple.iTunes", name="INITIALKEY",
+//                        UTF-8 value  — what Mixed In Key and Serato write
+//
+// Growing the metadata moves every byte after it, so:
+//   * the sizes of ilst / meta / udta / moov are bumped by the inserted bytes;
+//   * when moov sits before mdat, all stco/co64 chunk offsets are shifted by the
+//     same amount, otherwise players read garbage where the audio used to be
+//     (this is the mistake the first prototype made: mutagen could read the
+//     tags but the audio no longer decoded).
+//
+// Everything else in the file (artwork, UPC, unsynced lyrics, isrc, ...) is left
+// exactly as it was.
+
+const CONTAINERS = new Set(['moov', 'udta', 'trak', 'mdia', 'minf', 'stbl', 'meta', 'ilst']);
+const FULL_BOX_EXTRA_HEADER = { meta: 4 };
+
+export const INITIALKEY_MEAN = 'com.apple.iTunes';
+export const INITIALKEY_NAME = 'INITIALKEY';
+
+/** Walk size+type boxes in [start, end), calling visit(tag, begin, end, depth). */
+function walkBoxes(buf, start, end, visit, depth = 0) {
+  let i = start;
+  while (i + 8 <= end) {
+    let size = buf.readUInt32BE(i);
+    const tag = buf.toString('latin1', i + 4, i + 8);
+    let header = 8;
+    if (size === 1) {
+      if (i + 16 > end) return;
+      size = Number(buf.readBigUInt64BE(i + 8));
+      header = 16;
+    } else if (size === 0) {
+      size = end - i;
+    }
+    if (size < header || i + size > end) return;
+    visit(tag, i, i + size, depth, header);
+    if (CONTAINERS.has(tag)) {
+      walkBoxes(buf, i + header + (FULL_BOX_EXTRA_HEADER[tag] ?? 0), i + size, visit, depth + 1);
+    }
+    i += size;
+  }
+}
+
+/** First box with this tag anywhere in the tree, as { begin, end }. */
+export function findBox(buf, tag, start = 0, end = buf.length) {
+  let hit = null;
+  walkBoxes(buf, start, end, (t, begin, boxEnd) => {
+    if (!hit && t === tag) hit = { begin, end: boxEnd };
+  });
+  return hit;
+}
+
+function dataAtom(payload, typeCode) {
+  const body = Buffer.alloc(8 + payload.length);
+  body.writeUInt32BE(typeCode, 0);
+  body.writeUInt32BE(0, 4); // locale
+  payload.copy(body, 8);
+  const box = Buffer.alloc(8 + body.length);
+  box.writeUInt32BE(8 + body.length, 0);
+  box.write('data', 4, 'latin1');
+  body.copy(box, 8);
+  return box;
+}
+
+function subBox(tag, text) {
+  const payload = Buffer.concat([Buffer.alloc(4), Buffer.from(text, 'utf8')]);
+  const box = Buffer.alloc(8 + payload.length);
+  box.writeUInt32BE(8 + payload.length, 0);
+  box.write(tag, 4, 'latin1');
+  payload.copy(box, 8);
+  return box;
+}
+
+function itemBox(tag, subs) {
+  const body = Buffer.concat([Buffer.from(tag, 'latin1'), ...subs]);
+  const box = Buffer.alloc(4 + body.length);
+  box.writeUInt32BE(4 + body.length, 0);
+  body.copy(box, 4);
+  return box;
+}
+
+/** ilst item holding a 16-bit integer (tmpo). */
+export function buildIntItem(tag, value) {
+  const payload = Buffer.alloc(2);
+  payload.writeUInt16BE(Number(value) & 0xffff, 0);
+  return itemBox(tag, [dataAtom(payload, 0x15)]);
+}
+
+/** ilst "----" item: mean + name + an UTF-8 data atom. */
+export function buildFreeformItem(mean, name, value) {
+  return itemBox('----', [
+    subBox('mean', mean),
+    subBox('name', name),
+    dataAtom(Buffer.from(value, 'utf8'), 0x01),
+  ]);
+}
+
+/** Existing ilst entries as { tag, begin, end } (absolute offsets in `buf`). */
+function listIlstItems(buf, ilst) {
+  const items = [];
+  walkBoxes(buf, ilst.begin + 8, ilst.end, (tag, begin, end, depth) => {
+    if (depth === 0) items.push({ tag, begin, end });
+  });
+  return items;
+}
+
+/** Read the BPM/key our writer (or another tag editor) left in an MP4 file. */
+export function readMp4Tags(buf) {
+  const ilst = findBox(buf, 'ilst');
+  if (!ilst) return { bpm: null, key: null };
+  let bpm = null;
+  let key = null;
+  for (const item of listIlstItems(buf, ilst)) {
+    if (item.tag === 'tmpo') {
+      const data = findBox(buf, 'data', item.begin + 8, item.end);
+      if (data && data.end - data.begin >= 18) {
+        bpm = buf.readUInt16BE(data.end - 2);
+      }
+    } else if (item.tag === '----') {
+      let mean = null;
+      let name = null;
+      let value = null;
+      walkBoxes(buf, item.begin + 8, item.end, (tag, begin, end, depth) => {
+        if (depth !== 0) return;
+        const text = buf.toString('utf8', begin + 12, end);
+        if (tag === 'mean') mean = text;
+        else if (tag === 'name') name = text;
+        else if (tag === 'data' && end - begin > 16) value = buf.toString('utf8', begin + 16, end);
+      });
+      if (mean === INITIALKEY_MEAN && name?.toUpperCase() === INITIALKEY_NAME) key = value;
+    }
+  }
+  return { bpm, key };
+}
+
+/**
+ * Insert/replace tmpo and the INITIALKEY freeform item in an MP4 buffer.
+ * Returns { buffer, inserted, replaced, chunkOffsetsPatched }.
+ * The input buffer is never modified.
+ */
+export function patchMp4Tags(
+  buf,
+  { bpm = null, key = null, mean = INITIALKEY_MEAN, name = INITIALKEY_NAME } = {}
+) {
+  const moov = findBox(buf, 'moov');
+  if (!moov) throw new Error('not an MP4 file (no moov box)');
+  const udta = findBox(buf, 'udta', moov.begin + 8, moov.end);
+  if (!udta) throw new Error('MP4 has no udta box');
+  const meta = findBox(buf, 'meta', udta.begin + 8, udta.end);
+  if (!meta) throw new Error('MP4 has no meta box');
+  const ilst = findBox(buf, 'ilst', meta.begin + 12, meta.end);
+  if (!ilst) throw new Error('MP4 has no ilst box');
+
+  const wanted = [];
+  if (bpm != null)
+    wanted.push({ tag: 'tmpo', build: () => buildIntItem('tmpo', Math.round(Number(bpm))) });
+  if (key) wanted.push({ tag: '----', build: () => buildFreeformItem(mean, name, key) });
+
+  const existing = listIlstItems(buf, ilst);
+  const drop = [];
+  const add = [];
+  for (const want of wanted) {
+    if (want.tag === 'tmpo') {
+      for (const item of existing.filter((i) => i.tag === 'tmpo')) drop.push(item);
+      add.push(want.build());
+    } else if (want.tag === '----') {
+      for (const item of existing) {
+        if (item.tag !== '----') continue;
+        const read = readKeyItem(buf, item);
+        if (read.mean === mean && read.name?.toUpperCase() === name.toUpperCase()) drop.push(item);
+      }
+      add.push(want.build());
+    }
+  }
+  if (add.length === 0) {
+    return { buffer: buf, inserted: 0, replaced: 0, chunkOffsetsPatched: 0 };
+  }
+
+  const kept = Buffer.concat(
+    existing
+      .filter((item) => !drop.includes(item))
+      .map((item) => buf.subarray(item.begin, item.end))
+  );
+  const added = Buffer.concat(add);
+  const newIlstBody = Buffer.concat([kept, added]);
+  const newIlst = Buffer.alloc(8 + newIlstBody.length);
+  newIlst.writeUInt32BE(8 + newIlstBody.length, 0);
+  newIlst.write('ilst', 4, 'latin1');
+  newIlstBody.copy(newIlst, 8);
+
+  const delta = newIlst.length - (ilst.end - ilst.begin);
+  const out = Buffer.concat([buf.subarray(0, ilst.begin), newIlst, buf.subarray(ilst.end)]);
+
+  for (const ancestor of [meta, udta, moov]) {
+    out.writeUInt32BE(out.readUInt32BE(ancestor.begin) + delta, ancestor.begin);
+  }
+
+  const mdat = findBox(buf, 'mdat');
+  let chunkOffsetsPatched = 0;
+  if (delta !== 0 && mdat && moov.begin < mdat.begin) {
+    // Everything after the insert point moved, so every chunk offset must too.
+    walkBoxes(out, 0, out.length, (tag, begin, end) => {
+      if (tag !== 'stco' && tag !== 'co64') return;
+      const count = out.readUInt32BE(begin + 12);
+      const wide = tag === 'co64';
+      let pos = begin + 16;
+      for (let n = 0; n < count && pos + (wide ? 8 : 4) <= end; n += 1) {
+        if (wide) {
+          out.writeBigUInt64BE(out.readBigUInt64BE(pos) + BigInt(delta), pos);
+          pos += 8;
+        } else {
+          out.writeUInt32BE(out.readUInt32BE(pos) + delta, pos);
+          pos += 4;
+        }
+        chunkOffsetsPatched += 1;
+      }
+    });
+  }
+
+  return { buffer: out, inserted: add.length, replaced: drop.length, chunkOffsetsPatched };
+}
+
+function readKeyItem(buf, item) {
+  let mean = null;
+  let name = null;
+  walkBoxes(buf, item.begin + 8, item.end, (tag, begin, end, depth) => {
+    if (depth !== 0) return;
+    if (tag === 'mean') mean = buf.toString('utf8', begin + 12, end);
+    else if (tag === 'name') name = buf.toString('utf8', begin + 12, end);
+  });
+  return { mean, name };
+}
+
+/** Containers this module can write. */
+export function supportsMp4Tags(filePath) {
+  const ext = path.extname(filePath ?? '').toLowerCase();
+  return ext === '.m4a' || ext === '.mp4';
+}
+
+/** Write BPM/key into an .m4a/.mp4 file, atomically (temp file + rename). */
+export function writeMp4Tags(filePath, opts = {}) {
+  if (!fs.existsSync(filePath)) return { ok: false, reason: 'missing-file' };
+  let patched;
+  let original;
+  try {
+    original = fs.readFileSync(filePath);
+    patched = patchMp4Tags(original, opts);
+  } catch (err) {
+    return { ok: false, reason: 'unreadable-container', error: err.message };
+  }
+  if (patched.inserted === 0) return { ok: true, wrote: [], reason: 'no-values' };
+  if (patched.buffer === original) return { ok: true, wrote: [], reason: 'already-current' };
+
+  const tmp = `${filePath}.mp4tmp`;
+  try {
+    fs.writeFileSync(tmp, patched.buffer);
+    fs.renameSync(tmp, filePath);
+  } catch (err) {
+    try {
+      if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    return { ok: false, reason: 'write-failed', error: err.message };
+  }
+  return {
+    ok: true,
+    wrote: [opts.bpm != null ? 'bpm' : null, opts.key ? 'key' : null].filter(Boolean),
+    replaced: patched.replaced,
+    chunkOffsetsPatched: patched.chunkOffsetsPatched,
+  };
+}

--- a/src/main.js
+++ b/src/main.js
@@ -91,6 +91,7 @@ import {
   moveTrackToLibrary,
   getLibraryDiskUsage,
   getLibraryFreeSpace,
+  writeBpmKeyTagsForTrack,
 } from './audio/importManager.js';
 import {
   listLibraries,
@@ -519,6 +520,22 @@ ipcMain.handle('get-unavailable-linked-tracks', () =>
 ipcMain.handle('get-track-waveform', (_, trackId) => {
   const buf = getTrackWaveform(trackId);
   return buf ? new Uint8Array(buf) : null;
+});
+// #474 — write the analyzed BPM/key into the tracks' own file tags (manual
+// action from the library context menu). Respects the metadata settings:
+// `metadata_overwrite_tags` decides whether differing tags are overwritten,
+// otherwise only missing tags are filled.
+ipcMain.handle('write-bpm-key-tags', async (_event, { trackIds = [] } = {}) => {
+  const results = [];
+  for (const id of trackIds) {
+    try {
+      results.push(await writeBpmKeyTagsForTrack(id));
+    } catch (err) {
+      results.push({ trackId: id, ok: false, reason: 'error', error: err.message });
+    }
+  }
+  const written = results.filter((r) => r.ok && (r.wrote?.length ?? 0) > 0).length;
+  return { ok: true, written, skipped: results.length - written, results };
 });
 ipcMain.handle('get-setting', (_, key, def) => getSetting(key, def));
 ipcMain.handle('set-setting', (_, key, value) => {

--- a/src/main.js
+++ b/src/main.js
@@ -165,7 +165,7 @@ let mainWindow;
 import { startMediaServer as _startMediaServer } from './audio/mediaServer.js';
 import { moveFileSafe } from './utils/fsMove.js';
 import { getArtworkBase } from './audio/importManager.js';
-import { writeId3Tags } from './audio/id3Writer.js';
+import { writeId3Tags, writeBpmKeyTags } from './audio/id3Writer.js';
 
 // Serve audio files over a local HTTP server so Chromium's media pipeline can
 // issue standard Range requests during seeking. Custom Electron protocols have
@@ -2225,7 +2225,13 @@ async function copyTrackToUsb(
   track,
   usbRoot,
   usedNames,
-  { useNormalized = false, targetLufs = null, targetDevice = null, forceMp3 = false } = {}
+  {
+    useNormalized = false,
+    targetLufs = null,
+    targetDevice = null,
+    forceMp3 = false,
+    blind = false,
+  } = {}
 ) {
   const srcPath = track.file_path;
   const srcExt = path.extname(srcPath || '');
@@ -2266,9 +2272,44 @@ async function copyTrackToUsb(
     } else {
       fs.copyFileSync(srcPath, destPath);
     }
+    // #474 — the exported file must describe itself: title/artist/album always,
+    // BPM/key unless this is a blind (real DJ mode) export.
+    await writeExportTags(destPath, track, blind);
   }
 
   return { path: `/music/${finalName}`, meta };
+}
+
+/**
+ * #474 — write the library metadata into the file that lands on the stick.
+ * The exported file then describes itself for any other tool (tag viewer,
+ * Rekordbox import, Mixed In Key, ...): title/artist/album always, BPM and key
+ * unless this is a blind (real DJ mode) export, which must carry nothing to
+ * sync to. Failures are logged, never fatal: the audio already copied fine.
+ */
+async function writeExportTags(destPath, track, blind = false) {
+  try {
+    await writeId3Tags(destPath, {
+      title: track.title || null,
+      artist: track.artist || null,
+      album: track.album || null,
+    });
+  } catch (err) {
+    console.warn(`Tag write failed for ${path.basename(destPath)}:`, err.message);
+  }
+  if (blind) return;
+
+  const bpm = track.bpm_override ?? track.bpm ?? null;
+  const key = track.key_camelot || track.key_raw || null;
+  if (bpm == null && !key) return;
+  try {
+    const res = await writeBpmKeyTags(destPath, { bpm, key, overwrite: false });
+    if (res?.ok === false && res.reason && !['no-values', 'already-current'].includes(res.reason)) {
+      console.warn(`BPM/key tag write failed for ${path.basename(destPath)}: ${res.reason}`);
+    }
+  } catch (err) {
+    console.warn(`BPM/key tag write failed for ${path.basename(destPath)}:`, err.message);
+  }
 }
 
 /** Writes the Rekordbox PDB database file using the pure-JS writer. */
@@ -2379,6 +2420,7 @@ ipcMain.handle(
             targetLufs,
             targetDevice,
             forceMp3,
+            blind,
           });
           usbPaths.set(t.id, usbPath);
           if (meta) usbMeta.set(t.id, meta);
@@ -2543,6 +2585,7 @@ ipcMain.handle(
             targetLufs,
             targetDevice,
             forceMp3,
+            blind,
           });
           usbPaths.set(t.id, usbPath);
           if (meta) usbMeta.set(t.id, meta);

--- a/src/preload.js
+++ b/src/preload.js
@@ -230,6 +230,7 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.invoke('cloud-search', { source, query, types, limit }),
   cloudSearchPreview: (payload) => ipcRenderer.invoke('cloud-search-preview', payload),
   tidalDownloadUrl: (opts) => ipcRenderer.invoke('tidal-download-url', opts),
+  writeBpmKeyTags: ({ trackIds }) => ipcRenderer.invoke('write-bpm-key-tags', { trackIds }),
   onTidalProgress: (cb) => {
     const handler = (_, data) => cb(data);
     ipcRenderer.on('tidal-progress', handler);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -39,6 +39,7 @@ export default defineConfig({
             'src/__tests__/importManager.test.js',
             'src/__tests__/dbLocation.test.js',
             'src/__tests__/autoTagger.test.js',
+            'src/__tests__/id3Writer.test.js',
             'src/__tests__/ytDlpManager.test.js',
             'src/__tests__/tidalDlManager.test.js',
             'src/__tests__/mediaServer.test.js',

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -40,6 +40,7 @@ export default defineConfig({
             'src/__tests__/dbLocation.test.js',
             'src/__tests__/autoTagger.test.js',
             'src/__tests__/id3Writer.test.js',
+            'src/__tests__/mp4Tags.test.js',
             'src/__tests__/ytDlpManager.test.js',
             'src/__tests__/tidalDlManager.test.js',
             'src/__tests__/mediaServer.test.js',


### PR DESCRIPTION
Refs #474

Analysis kept BPM and key only inside the database. This writes them into the files themselves, so any tag viewer, Rekordbox import or other tool sees them, and it covers the containers the library actually uses.

## What gets written where
| container | BPM | key | how |
|---|---|---|---|
| MP3 | ID3 `TBPM` | ID3 `TKEY` | ffmpeg metadata |
| FLAC / OGG / Opus | Vorbis `BPM` | Vorbis `KEY` | ffmpeg metadata |
| **M4A / MP4** | `tmpo` atom | freeform `----` item, `mean=com.apple.iTunes`, `name=INITIALKEY` | our own atom writer |
| WAV / AIFF | - | - | skipped, no interoperable slot |

The key written is the database value as-is (Camelot, e.g. `9B`), which is what Mixed In Key and Serato put in these fields.

## Why M4A needed its own writer
ffmpeg **cannot** write the key field of an MP4: `-metadata INITIALKEY=…`, `-metadata initialkey=…`, `-metadata "----:com.apple.iTunes:INITIALKEY=…"` and `-metadata "com.apple.iTunes:INITIALKEY=…"` are all silently dropped by its mov muxer (verified on copies of real files; `tmpo` and the standard `©nam/©ART/©alb` work). So `src/audio/mp4Tags.js` edits `moov.udta.meta.ilst` directly, with no new dependency:

- inserts/replaces `tmpo` and the freeform `INITIALKEY` item, never duplicating either;
- bumps the ancestor sizes (`ilst`/`meta`/`udta`/`moov`);
- shifts every `stco`/`co64` chunk offset by the inserted amount, because these files keep `moov` before `mdat`. Without that the tags read back perfectly but the audio stops decoding (the first prototype did exactly that);
- leaves artwork, UPC, unsynced lyrics, isrc and every other item alone;
- writes atomically (temp file + rename) and `readMp4Tags()` feeds the same fill-missing / overwrite policy as the ffmpeg path.

## Export behaves now
`copyTrackToUsb()` tags what lands on the stick: **title, artist, album** from the database plus **BPM** (`bpm_override ?? bpm`) and **key** (`key_camelot ?? key_raw`).

**The export mirrors the library, it does not just fill gaps.** BPM/key are written with `overwrite: true`, so the values the analyzer put in the database win over whatever the source file happens to carry. Verified on real files: a Traktor-tagged source no longer ships its own notation (`12d`, `1m`, `5m`) while the library says `7B`, `8A`, `12A`; one exported track also corrected a stale source BPM (104) to the library's 138. Identical values are still skipped, and a value the library does not have is never stripped from the file. Only the copy on the stick is touched, never the library file. `convertAudio()` uses the same per-format keys when it re-encodes.

Caveat, deliberately left as is: a track already present on the target is reused from `export-manifest.json` and its file is not rewritten, so a re-export to the same target does not refresh tags of files it did not copy. Wipe the target (or export fresh) to force it.

A blind *real DJ mode* export (#258) writes the text tags but **no BPM/key** - it must carry nothing to sync to.

## Container cleanup
Converting an m4a to mp3 used to drag the MP4 container fields into the ID3 tag as `TXXX major_brand` / `minor_version` / `compatible_brands` - fields of an MP4 that mean nothing inside an MP3, and the reason a tag viewer showed them as unknown entries. Both writers now delete them (ffmpeg removes a tag when given an empty value).

## Verified on real files, not only in tests
- **m4a** (253 s library track): `tmpo` 87 → 90, `INITIALKEY` created, **10 chunk offsets shifted**, mutagen reads `[90]` and `[MP4FreeForm(b'4B')]`, ffmpeg decodes cleanly, duration intact.
- **mp3 → mp3** with the app's own args: junk keys gone, title/artist/album written, `TBPM`/`TKEY` preserved.
- **m4a → mp3** the way the export does it: title/artist/album + `TBPM`/`TKEY` present, junk gone, other fields (UPC, URL, rating, disc, track) preserved, audio clean.

## Safety
- Both auto-write settings stay **off** by default; a file is only touched when you ask (context-menu *Save BPM & Key to file*, or the auto-write toggle).
- Library and linked files: **fill-missing by default**, an existing tag is left alone unless the overwrite setting is enabled. The export path is the exception and always mirrors the library (see above). Identical values are never rewritten in either path.
- After a successful write the stored `file_hash` is recomputed, so a rewritten file is not mistaken for a new one on re-import.
- Tag failures in an export are logged, never fatal: the audio is already copied.

## Tests
- `src/__tests__/mp4Tags.test.js` (new, 14 cases): read/patch round trips, replacing instead of duplicating, ancestor size bumps, `stco` shifted by exactly the delta, mdat-first files left alone, size-neutral rewrite, box-tree validity, real-file round trip, missing file, container detection.
- `id3Writer.test.js`: m4a routing and policy (both values, fill-missing, overwrite, already-current, fractional BPM), plus the junk-clearing args.
- `ffmpegConvert.test.js`: ID3 vs Vorbis key names, junk clearing, no BPM/key when there are none, no metadata args without a metadata object.
- Root 534/534, renderer 197/197, lint 0 errors.

## Open question from the review thread
Cue points are still exported in blind mode (they are your workflow, and #259 reads them back). Waiting on meiremax's answer before deciding whether that changes.