### PR TITLE
feat(export): real DJ mode — blank waveform and no BPM on the stick

### DIFF
--- a/renderer/src/ExportModal.jsx
+++ b/renderer/src/ExportModal.jsx
@@ -33,7 +33,14 @@ const DEVICE_OPTIONS = [
   { key: 'xdj-700', label: 'XDJ-700' },
 ];
 
-function ExportFormatOptions({ targetDevice, setTargetDevice, forceMp3, setForceMp3 }) {
+function ExportFormatOptions({
+  targetDevice,
+  setTargetDevice,
+  forceMp3,
+  setForceMp3,
+  blindMode,
+  setBlindMode,
+}) {
   return (
     <div className="export-format-options">
       <label className="export-device-option">
@@ -51,6 +58,17 @@ function ExportFormatOptions({ targetDevice, setTargetDevice, forceMp3, setForce
         <input type="checkbox" checked={forceMp3} onChange={(e) => setForceMp3(e.target.checked)} />
         <span>Re-encode all tracks to MP3</span>
       </label>
+      <label
+        className="export-normalized-option"
+        title="Export without waveforms and BPM — the standalone player shows nothing to sync to"
+      >
+        <input
+          type="checkbox"
+          checked={blindMode}
+          onChange={(e) => setBlindMode(e.target.checked)}
+        />
+        <span>Real DJ mode — no waveforms / no BPM (mix blind)</span>
+      </label>
     </div>
   );
 }
@@ -67,6 +85,18 @@ function ExportModal({ onClose, playlistId, initialMode }) {
   const [useNormalized, setUseNormalized] = useState(true);
   const [targetDevice, setTargetDevice] = useState('');
   const [forceMp3, setForceMp3] = useState(false);
+  // #258 — "Real DJ mode": exported USB carries no waveforms/BPM. Persisted as
+  // a setting so explorer exports (which have no toggle) honour it too.
+  const [blindMode, setBlindModeState] = useState(false);
+  useEffect(() => {
+    window.api
+      .getSetting('export_blind_mode', 'false')
+      .then((v) => setBlindModeState(v === 'true'));
+  }, []);
+  const setBlindMode = useCallback((checked) => {
+    setBlindModeState(checked);
+    window.api.setSetting('export_blind_mode', String(checked));
+  }, []);
 
   const handleKeyDown = useCallback(
     (e) => {
@@ -132,6 +162,7 @@ function ExportModal({ onClose, playlistId, initialMode }) {
         useNormalized,
         targetDevice: targetDevice || null,
         forceMp3,
+        blindMode,
       });
     } else {
       res = await window.api.exportAll({
@@ -140,6 +171,7 @@ function ExportModal({ onClose, playlistId, initialMode }) {
         useNormalized,
         targetDevice: targetDevice || null,
         forceMp3,
+        blindMode,
       });
     }
     if (res.ok) {
@@ -191,6 +223,8 @@ function ExportModal({ onClose, playlistId, initialMode }) {
               setTargetDevice={setTargetDevice}
               forceMp3={forceMp3}
               setForceMp3={setForceMp3}
+              blindMode={blindMode}
+              setBlindMode={setBlindMode}
             />
             <div className="export-options">
               <button className="export-option-btn" onClick={() => pickFolder('rekordbox')}>
@@ -235,6 +269,8 @@ function ExportModal({ onClose, playlistId, initialMode }) {
               setTargetDevice={setTargetDevice}
               forceMp3={forceMp3}
               setForceMp3={setForceMp3}
+              blindMode={blindMode}
+              setBlindMode={setBlindMode}
             />
             <div className="export-confirm-actions">
               <button className="export-option-btn" onClick={() => pickFolder(mode)}>

--- a/renderer/src/ExportModal.jsx
+++ b/renderer/src/ExportModal.jsx
@@ -60,14 +60,14 @@ function ExportFormatOptions({
       </label>
       <label
         className="export-normalized-option"
-        title="Export without waveforms and BPM — the standalone player shows nothing to sync to"
+        title="Export with a blank waveform and no BPM. The stick still carries analysis data, so the player will not generate its own - there is simply nothing to mix against."
       >
         <input
           type="checkbox"
           checked={blindMode}
           onChange={(e) => setBlindMode(e.target.checked)}
         />
-        <span>Real DJ mode — no waveforms / no BPM (mix blind)</span>
+        <span>Real DJ mode - blank waveform, no BPM (mix blind)</span>
       </label>
     </div>
   );

--- a/src/__tests__/anlzWriter.test.js
+++ b/src/__tests__/anlzWriter.test.js
@@ -127,6 +127,83 @@ describe('writeAnlz', () => {
     });
   });
 
+  // #258 — real DJ mode: the ANLZ must still exist, so the player does not
+  // analyse the track itself, but it carries no waveform and no beat grid.
+  describe('blind mode', () => {
+    const blindOpts = { ...baseOpts, blind: true, cuePoints: [] };
+
+    /** Buffers written for the DAT / EXT file. */
+    function writtenFiles() {
+      const bySuffix = {};
+      for (const [filePath, buf] of fs.writeFileSync.mock.calls) {
+        const suffix = filePath.slice(-3);
+        bySuffix[suffix] = buf;
+      }
+      return bySuffix;
+    }
+
+    it('never generates a waveform', async () => {
+      const { generateWaveform } = await import('../audio/waveformGenerator.js');
+      await writeAnlz(blindOpts);
+      expect(generateWaveform).not.toHaveBeenCalled();
+    });
+
+    it('writes DAT and EXT but no 2EX', async () => {
+      await writeAnlz(blindOpts);
+      const suffixes = fs.writeFileSync.mock.calls.map((c) => c[0].slice(-3));
+      expect(suffixes).toEqual(['DAT', 'EXT']);
+    });
+
+    it('omits every waveform section', async () => {
+      await writeAnlz(blindOpts);
+      const { DAT, EXT } = writtenFiles();
+      const datTags = parseSections(DAT).map((s) => s.tag);
+      expect(datTags).not.toContain('PWAV');
+      expect(datTags).not.toContain('PWV2');
+      expect(datTags).not.toContain('PWV3');
+      const extTags = parseSections(EXT).map((s) => s.tag);
+      expect(extTags).not.toContain('PWV3');
+      expect(extTags).not.toContain('PWV5');
+      expect(extTags).not.toContain('PWV4');
+    });
+
+    it('leaves both beat grids header-only', async () => {
+      await writeAnlz(blindOpts);
+      const { DAT, EXT } = writtenFiles();
+      const pqtz = parseSections(DAT).find((s) => s.tag === 'PQTZ');
+      const pqt2 = parseSections(EXT).find((s) => s.tag === 'PQT2');
+      expect(pqtz).toBeTruthy();
+      expect(pqtz.lenTag).toBe(24); // header only — not a single beat entry
+      expect(pqt2).toBeTruthy();
+      expect(pqt2.lenTag).toBe(56); // header only — no beat entries
+    });
+
+    it('still keeps the path tag and the seek table', async () => {
+      await writeAnlz(blindOpts);
+      const { DAT } = writtenFiles();
+      const datTags = parseSections(DAT).map((s) => s.tag);
+      expect(datTags).toContain('PPTH');
+      expect(datTags).toContain('PVBR');
+    });
+
+    it('still writes cue points', async () => {
+      await writeAnlz({
+        ...blindOpts,
+        cuePoints: [{ hot_cue_index: 0, position_ms: 1000, color: '#ff0000', label: 'Intro' }],
+      });
+      const { DAT, EXT } = writtenFiles();
+      expect(parseSections(DAT).map((s) => s.tag)).toContain('PCOB');
+      expect(parseSections(EXT).map((s) => s.tag)).toContain('PCO2');
+    });
+
+    it('a normal (non-blind) export is untouched by the option', async () => {
+      await writeAnlz(baseOpts);
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
+      const { DAT } = writtenFiles();
+      expect(parseSections(DAT).map((s) => s.tag)).toContain('PWAV');
+    });
+  });
+
   it('DAT file starts with PMAI magic bytes', async () => {
     await writeAnlz(baseOpts);
 

--- a/src/__tests__/blindMode.test.js
+++ b/src/__tests__/blindMode.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  BLIND_MODE_SETTING,
+  resolveBlindMode,
+  applyBlindMode,
+  shouldWriteAnlz,
+} from '../usb/blindMode.js';
+
+describe('#258 real DJ mode (blind export)', () => {
+  describe('resolveBlindMode', () => {
+    it('uses the stored setting when the export passes no explicit value', () => {
+      expect(resolveBlindMode(null, () => 'true')).toBe(true);
+      expect(resolveBlindMode(undefined, () => 'false')).toBe(false);
+      expect(resolveBlindMode(null, () => '')).toBe(false);
+    });
+
+    it('lets an explicit export value win over the stored setting', () => {
+      const on = vi.fn(() => 'true');
+      const off = vi.fn(() => 'false');
+      expect(resolveBlindMode(false, on)).toBe(false);
+      expect(resolveBlindMode(true, off)).toBe(true);
+    });
+
+    it('defaults to off without a settings reader', () => {
+      expect(resolveBlindMode(null)).toBe(false);
+      expect(resolveBlindMode(undefined, null)).toBe(false);
+    });
+
+    it('reads the documented setting key', () => {
+      const get = vi.fn(() => 'false');
+      resolveBlindMode(null, get);
+      expect(get).toHaveBeenCalledWith(BLIND_MODE_SETTING, 'false');
+      expect(BLIND_MODE_SETTING).toBe('export_blind_mode');
+    });
+  });
+
+  describe('applyBlindMode', () => {
+    const track = {
+      id: 7,
+      title: 'Siku Siku Mocz',
+      artist: 'Mako',
+      bpm: 128,
+      key_raw: '9B',
+      analyzePath: '/music/a/ANLZ0000.DAT',
+      file_path: '/music/a.m4a',
+      rating: 4,
+    };
+
+    it('passes the track through untouched when blind mode is off', () => {
+      expect(applyBlindMode(track, false)).toBe(track);
+    });
+
+    it('blanks BPM and the analyse path when blind mode is on', () => {
+      const out = applyBlindMode(track, true);
+      expect(out.bpm).toBe(0);
+      expect(out.analyzePath).toBe('');
+    });
+
+    it('keeps everything else a player reads (title, key, cues, rating)', () => {
+      const out = applyBlindMode({ ...track, cuePoints: [{ position: 12 }] }, true);
+      expect(out.title).toBe('Siku Siku Mocz');
+      expect(out.artist).toBe('Mako');
+      expect(out.key_raw).toBe('9B');
+      expect(out.rating).toBe(4);
+      expect(out.cuePoints).toEqual([{ position: 12 }]);
+      expect(out.id).toBe(7);
+    });
+
+    it('does not mutate the input track', () => {
+      applyBlindMode(track, true);
+      expect(track.bpm).toBe(128);
+      expect(track.analyzePath).toBe('/music/a/ANLZ0000.DAT');
+    });
+  });
+
+  describe('shouldWriteAnlz', () => {
+    it('writes ANLZ normally and skips it in blind mode', () => {
+      expect(shouldWriteAnlz(false)).toBe(true);
+      expect(shouldWriteAnlz(true)).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/blindMode.test.js
+++ b/src/__tests__/blindMode.test.js
@@ -1,10 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import {
-  BLIND_MODE_SETTING,
-  resolveBlindMode,
-  applyBlindMode,
-  shouldWriteAnlz,
-} from '../usb/blindMode.js';
+import { BLIND_MODE_SETTING, resolveBlindMode, applyBlindMode } from '../usb/blindMode.js';
 
 describe('#258 real DJ mode (blind export)', () => {
   describe('resolveBlindMode', () => {
@@ -50,10 +45,12 @@ describe('#258 real DJ mode (blind export)', () => {
       expect(applyBlindMode(track, false)).toBe(track);
     });
 
-    it('blanks BPM and the analyse path when blind mode is on', () => {
+    it('blanks BPM but KEEPS the analyse path', () => {
       const out = applyBlindMode(track, true);
       expect(out.bpm).toBe(0);
-      expect(out.analyzePath).toBe('');
+      // The path must stay: the blind ANLZ exists precisely so the player does
+      // not treat the track as unanalysed and build its own waveform + grid.
+      expect(out.analyzePath).toBe('/music/a/ANLZ0000.DAT');
     });
 
     it('keeps everything else a player reads (title, key, cues, rating)', () => {
@@ -70,13 +67,6 @@ describe('#258 real DJ mode (blind export)', () => {
       applyBlindMode(track, true);
       expect(track.bpm).toBe(128);
       expect(track.analyzePath).toBe('/music/a/ANLZ0000.DAT');
-    });
-  });
-
-  describe('shouldWriteAnlz', () => {
-    it('writes ANLZ normally and skips it in blind mode', () => {
-      expect(shouldWriteAnlz(false)).toBe(true);
-      expect(shouldWriteAnlz(true)).toBe(false);
     });
   });
 });

--- a/src/audio/anlzWriter.js
+++ b/src/audio/anlzWriter.js
@@ -757,6 +757,9 @@ function buildSectionWithBigHeader(fourcc, specificHeader, data) {
  * @param {number}  [opts.beatgridOffset=0] - Grid shift in ms (beatgrid_offset from DB)
  * @param {string}  opts.usbRoot            - Absolute path to USB root on disk
  * @param {Array}   [opts.cuePoints]        - Cue point rows from cue_points table
+ * @param {boolean} [opts.blind=false]      - #258 "real DJ mode": write an ANLZ
+ *   that still looks analysed (so the player does NOT run its own analysis) but
+ *   carries no beat grid and no waveform at all. Cue points are still written.
  */
 export async function writeAnlz(opts) {
   const {
@@ -768,6 +771,7 @@ export async function writeAnlz(opts) {
     usbRoot,
     ffmpegPath,
     cuePoints,
+    blind = false,
   } = opts;
 
   const folderHash = getFolderName(usbFilePath);
@@ -775,8 +779,11 @@ export async function writeAnlz(opts) {
   fs.mkdirSync(anlzDir, { recursive: true });
 
   // ── Generate waveforms from source audio ─────────────────────────────────
+  // Blind mode skips generation entirely: no ffmpeg pass, and the waveform
+  // sections below are omitted, which is the state a failed export produced —
+  // the stick shows no waveform instead of the player analysing one itself.
   let waveforms = null;
-  if (sourceFilePath) {
+  if (!blind && sourceFilePath) {
     try {
       waveforms = await generateWaveform(sourceFilePath, ffmpegPath || 'ffmpeg');
     } catch (err) {
@@ -785,7 +792,8 @@ export async function writeAnlz(opts) {
   }
 
   // ── Compute beat array once — shared by PQTZ (DAT) and PQT2 (EXT) ──────────
-  const beats = computeBeats(beatgrid, bpm, beatgridOffset);
+  // Blind mode forces an empty beat array: both grids come out header-only.
+  const beats = blind ? [] : computeBeats(beatgrid, bpm, beatgridOffset);
 
   // ── PVBR seek table ───────────────────────────────────────────────────────────
   // Native Rekordbox always includes PVBR between PPTH and PQTZ in the DAT file.

--- a/src/main.js
+++ b/src/main.js
@@ -139,7 +139,7 @@ import { initLogger, getLogDir, initRendererLogger, logRendererMessage } from '.
 import { detectFilesystem, formatDrive, describeFilesystem } from './usb/usbUtils.js';
 import { detectWindowsDrives } from './explorer/drives.js';
 import { writeAnlz, getAnlzFolder } from './audio/anlzWriter.js';
-import { resolveBlindMode, applyBlindMode, shouldWriteAnlz } from './usb/blindMode.js';
+import { resolveBlindMode, applyBlindMode } from './usb/blindMode.js';
 import { writeSettingFiles } from './usb/settingWriter.js';
 import { writePdb } from './usb/pdbWriter.js';
 import { resolveExportFormat } from './usb/deviceFormats.js';
@@ -1906,22 +1906,21 @@ ipcMain.handle(
         const usbFilePath = `/music/${filename}`;
 
         // Write minimal ANLZ (path + beatgrid only, no waveform for speed).
-        // #258 — blind mode writes no ANLZ at all.
-        if (shouldWriteAnlz(blind)) {
-          try {
-            const anlzDat = await writeAnlz({
-              usbFilePath,
-              sourceFilePath: null,
-              beatgrid: null,
-              bpm: meta.bpm || 0,
-              beatgridOffset: 0,
-              usbRoot,
-              ffmpegPath: getFfmpegRuntimePath(),
-              cuePoints: [],
-            });
-            anlzPaths.set(i, anlzDat);
-          } catch {}
-        }
+        // #258 — in blind mode the same file is written with an empty grid.
+        try {
+          const anlzDat = await writeAnlz({
+            usbFilePath,
+            sourceFilePath: null,
+            beatgrid: null,
+            bpm: meta.bpm || 0,
+            beatgridOffset: 0,
+            usbRoot,
+            ffmpegPath: getFfmpegRuntimePath(),
+            cuePoints: [],
+            blind,
+          });
+          anlzPaths.set(i, anlzDat);
+        } catch {}
 
         let fileSize = 0;
         try {
@@ -2399,7 +2398,9 @@ ipcMain.handle(
         const t = tracks[i];
         const usbFilePath = usbPaths.get(t.id);
         if (!usbFilePath) continue;
-        if (shouldWriteAnlz(blind)) {
+        // #258 — blind mode still writes the ANLZ (so the player does not
+        // analyse the track itself) but with no waveform and an empty grid.
+        {
           const anlzFolder = getAnlzFolder(usbFilePath).replace(/\\/g, '/');
           anlzPaths.set(t.id, `/${anlzFolder}/ANLZ0000.DAT`);
           const sourceFilePath = t.file_path || null;
@@ -2413,6 +2414,7 @@ ipcMain.handle(
               usbRoot,
               ffmpegPath: getFfmpegRuntimePath(),
               cuePoints: getCuePoints(t.id).filter((c) => c.enabled !== 0),
+              blind,
             });
           } catch (err) {
             console.warn(`ANLZ write failed for track ${t.id}:`, err.message);
@@ -2596,7 +2598,9 @@ ipcMain.handle(
         const t = allTracks[i];
         const usbFilePath = usbPaths.get(t.id);
         if (!usbFilePath) continue;
-        if (shouldWriteAnlz(blind)) {
+        // #258 — blind mode still writes the ANLZ (so the player does not
+        // analyse the track itself) but with no waveform and an empty grid.
+        {
           try {
             await writeAnlz({
               usbFilePath,
@@ -2607,6 +2611,7 @@ ipcMain.handle(
               usbRoot,
               ffmpegPath: getFfmpegRuntimePath(),
               cuePoints: getCuePoints(t.id).filter((c) => c.enabled !== 0),
+              blind,
             });
           } catch (err) {
             console.warn(`ANLZ write failed for track ${t.id}:`, err.message);

--- a/src/main.js
+++ b/src/main.js
@@ -139,6 +139,7 @@ import { initLogger, getLogDir, initRendererLogger, logRendererMessage } from '.
 import { detectFilesystem, formatDrive, describeFilesystem } from './usb/usbUtils.js';
 import { detectWindowsDrives } from './explorer/drives.js';
 import { writeAnlz, getAnlzFolder } from './audio/anlzWriter.js';
+import { resolveBlindMode, applyBlindMode, shouldWriteAnlz } from './usb/blindMode.js';
 import { writeSettingFiles } from './usb/settingWriter.js';
 import { writePdb } from './usb/pdbWriter.js';
 import { resolveExportFormat } from './usb/deviceFormats.js';
@@ -1844,129 +1845,141 @@ ipcMain.handle('get-explorer-track-metadata', async (_, filePath) => {
   }
 });
 
-ipcMain.handle('export-explorer-to-usb', async (_, { filePaths, usbRoot, playlistName }) => {
-  try {
-    const total = filePaths.length;
-    send('export-explorer-progress', { msg: `Exporting ${total} tracks to USB…`, pct: 0 });
-
-    const usedNames = new Map();
-    const pdbTracks = [];
-    const anlzPaths = new Map();
-
-    for (let i = 0; i < filePaths.length; i++) {
-      const srcPath = filePaths[i];
-      const ext = path.extname(srcPath);
-
-      // Extract metadata
-      let meta = {
-        title: path.basename(srcPath, ext),
-        artist: '',
-        album: '',
-        bpm: null,
-        key_raw: '',
-        duration: 0,
-        bitrate: 0,
-      };
-      try {
-        const { ffprobe: runFfprobe } = await import('./audio/ffmpeg.js');
-        const data = await runFfprobe(srcPath);
-        const tags = data.format?.tags || {};
-        const stream = data.streams?.find((s) => s.codec_type === 'audio') || {};
-        const bpmTag = tags.bpm || tags.BPM || tags.TBPM || tags['tbpm'];
-        meta = {
-          title: tags.title || path.basename(srcPath, ext),
-          artist: tags.artist || '',
-          album: tags.album || '',
-          bpm: bpmTag ? parseFloat(bpmTag) || null : null,
-          key_raw: tags.key || tags.KEY || tags.initialkey || tags.INITIALKEY || '',
-          duration: parseFloat(data.format?.duration) || 0,
-          bitrate: parseInt(stream.bit_rate || data.format?.bit_rate || 0, 10) || 0,
-        };
-      } catch {}
-
-      // Copy to USB /music/
-      const rawBase =
-        [meta.artist, meta.title].filter(Boolean).join(' - ') || path.basename(srcPath, ext);
-      const safeBase = rawBase.replace(/[<>:"/\\|?*\x00-\x1f]/g, '_').trim();
-      let filename = `${safeBase}${ext}`;
-      let n = 1;
-      while (usedNames.has(filename.toLowerCase())) {
-        filename = `${safeBase} (${n++})${ext}`;
-      }
-      usedNames.set(filename.toLowerCase(), true);
-
-      const destDir = path.join(usbRoot, 'music');
-      fs.mkdirSync(destDir, { recursive: true });
-      const destPath = path.join(destDir, filename);
-      if (!fs.existsSync(destPath)) fs.copyFileSync(srcPath, destPath);
-      const usbFilePath = `/music/${filename}`;
-
-      // Write minimal ANLZ (path + beatgrid only, no waveform for speed)
-      try {
-        const anlzDat = await writeAnlz({
-          usbFilePath,
-          sourceFilePath: null,
-          beatgrid: null,
-          bpm: meta.bpm || 0,
-          beatgridOffset: 0,
-          usbRoot,
-          ffmpegPath: getFfmpegRuntimePath(),
-          cuePoints: [],
-        });
-        anlzPaths.set(i, anlzDat);
-      } catch {}
-
-      let fileSize = 0;
-      try {
-        fileSize = fs.statSync(destPath).size;
-      } catch {}
-
-      pdbTracks.push({
-        id: i + 1,
-        title: meta.title,
-        artist: meta.artist,
-        album: meta.album,
-        duration: meta.duration,
-        bpm: meta.bpm || 0,
-        key_raw: meta.key_raw,
-        file_path: usbFilePath,
-        track_number: i + 1,
-        year: '',
-        label: '',
-        genres: [],
-        file_size: fileSize,
-        bitrate: meta.bitrate,
-        comments: '',
-        rating: 0,
-        analyzePath: anlzPaths.get(i) || '',
-      });
-
-      const pct = Math.round(((i + 1) / total) * 90);
-      send('export-explorer-progress', { msg: `Copying ${i + 1}/${total}: ${filename}`, pct });
-    }
-
-    send('export-explorer-progress', { msg: 'Writing PDB database…', pct: 92 });
-
-    const pdbPlaylists = playlistName
-      ? [{ id: 1, name: playlistName, track_ids: pdbTracks.map((t) => t.id) }]
-      : [];
-
-    const outputPath = path.join(usbRoot, 'PIONEER', 'rekordbox', 'export.pdb');
-    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-    writePdb({ tracks: pdbTracks, playlists: pdbPlaylists }, outputPath);
-
-    send('export-explorer-progress', { msg: 'Writing settings files…', pct: 96 });
+ipcMain.handle(
+  'export-explorer-to-usb',
+  async (_, { filePaths, usbRoot, playlistName, blindMode = null }) => {
+    const blind = resolveBlindMode(blindMode, getSetting);
     try {
-      await writeSettingFiles(usbRoot);
-    } catch {}
+      const total = filePaths.length;
+      send('export-explorer-progress', { msg: `Exporting ${total} tracks to USB…`, pct: 0 });
 
-    send('export-explorer-progress', null);
-    return { ok: true, trackCount: pdbTracks.length, usbRoot };
-  } catch (err) {
-    send('export-explorer-progress', null);
-    return { ok: false, error: err.message };
+      const usedNames = new Map();
+      const pdbTracks = [];
+      const anlzPaths = new Map();
+
+      for (let i = 0; i < filePaths.length; i++) {
+        const srcPath = filePaths[i];
+        const ext = path.extname(srcPath);
+
+        // Extract metadata
+        let meta = {
+          title: path.basename(srcPath, ext),
+          artist: '',
+          album: '',
+          bpm: null,
+          key_raw: '',
+          duration: 0,
+          bitrate: 0,
+        };
+        try {
+          const { ffprobe: runFfprobe } = await import('./audio/ffmpeg.js');
+          const data = await runFfprobe(srcPath);
+          const tags = data.format?.tags || {};
+          const stream = data.streams?.find((s) => s.codec_type === 'audio') || {};
+          const bpmTag = tags.bpm || tags.BPM || tags.TBPM || tags['tbpm'];
+          meta = {
+            title: tags.title || path.basename(srcPath, ext),
+            artist: tags.artist || '',
+            album: tags.album || '',
+            bpm: bpmTag ? parseFloat(bpmTag) || null : null,
+            key_raw: tags.key || tags.KEY || tags.initialkey || tags.INITIALKEY || '',
+            duration: parseFloat(data.format?.duration) || 0,
+            bitrate: parseInt(stream.bit_rate || data.format?.bit_rate || 0, 10) || 0,
+          };
+        } catch {}
+
+        // Copy to USB /music/
+        const rawBase =
+          [meta.artist, meta.title].filter(Boolean).join(' - ') || path.basename(srcPath, ext);
+        const safeBase = rawBase.replace(/[<>:"/\\|?*\x00-\x1f]/g, '_').trim();
+        let filename = `${safeBase}${ext}`;
+        let n = 1;
+        while (usedNames.has(filename.toLowerCase())) {
+          filename = `${safeBase} (${n++})${ext}`;
+        }
+        usedNames.set(filename.toLowerCase(), true);
+
+        const destDir = path.join(usbRoot, 'music');
+        fs.mkdirSync(destDir, { recursive: true });
+        const destPath = path.join(destDir, filename);
+        if (!fs.existsSync(destPath)) fs.copyFileSync(srcPath, destPath);
+        const usbFilePath = `/music/${filename}`;
+
+        // Write minimal ANLZ (path + beatgrid only, no waveform for speed).
+        // #258 — blind mode writes no ANLZ at all.
+        if (shouldWriteAnlz(blind)) {
+          try {
+            const anlzDat = await writeAnlz({
+              usbFilePath,
+              sourceFilePath: null,
+              beatgrid: null,
+              bpm: meta.bpm || 0,
+              beatgridOffset: 0,
+              usbRoot,
+              ffmpegPath: getFfmpegRuntimePath(),
+              cuePoints: [],
+            });
+            anlzPaths.set(i, anlzDat);
+          } catch {}
+        }
+
+        let fileSize = 0;
+        try {
+          fileSize = fs.statSync(destPath).size;
+        } catch {}
+
+        pdbTracks.push(
+          applyBlindMode(
+            {
+              id: i + 1,
+              title: meta.title,
+              artist: meta.artist,
+              album: meta.album,
+              duration: meta.duration,
+              bpm: meta.bpm || 0,
+              key_raw: meta.key_raw,
+              file_path: usbFilePath,
+              track_number: i + 1,
+              year: '',
+              label: '',
+              genres: [],
+              file_size: fileSize,
+              bitrate: meta.bitrate,
+              comments: '',
+              rating: 0,
+              analyzePath: anlzPaths.get(i) || '',
+            },
+            blind
+          )
+        );
+
+        const pct = Math.round(((i + 1) / total) * 90);
+        send('export-explorer-progress', { msg: `Copying ${i + 1}/${total}: ${filename}`, pct });
+      }
+
+      send('export-explorer-progress', { msg: 'Writing PDB database…', pct: 92 });
+
+      const pdbPlaylists = playlistName
+        ? [{ id: 1, name: playlistName, track_ids: pdbTracks.map((t) => t.id) }]
+        : [];
+
+      const outputPath = path.join(usbRoot, 'PIONEER', 'rekordbox', 'export.pdb');
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+      writePdb({ tracks: pdbTracks, playlists: pdbPlaylists }, outputPath);
+
+      send('export-explorer-progress', { msg: 'Writing settings files…', pct: 96 });
+      try {
+        await writeSettingFiles(usbRoot);
+      } catch {}
+
+      send('export-explorer-progress', null);
+      return { ok: true, trackCount: pdbTracks.length, usbRoot };
+    } catch (err) {
+      send('export-explorer-progress', null);
+      return { ok: false, error: err.message };
+    }
   }
-});
+);
 
 // ── File Explorer v2 IPC ───────────────────────────────────────────────────────
 
@@ -2309,8 +2322,11 @@ ipcMain.handle(
       useNormalized = false,
       targetDevice = null,
       forceMp3 = false,
+      blindMode = null,
     }
   ) => {
+    // #258 — "Real DJ mode": no waveforms/BPM on the exported USB
+    const blind = resolveBlindMode(blindMode, getSetting);
     try {
       const targetLufs = useNormalized ? Number(getSetting('normalize_target_lufs', '-9')) : null;
       const ids = playlistIds?.length ? playlistIds : playlistId ? [playlistId] : null;
@@ -2383,22 +2399,24 @@ ipcMain.handle(
         const t = tracks[i];
         const usbFilePath = usbPaths.get(t.id);
         if (!usbFilePath) continue;
-        const anlzFolder = getAnlzFolder(usbFilePath).replace(/\\/g, '/');
-        anlzPaths.set(t.id, `/${anlzFolder}/ANLZ0000.DAT`);
-        const sourceFilePath = t.file_path || null;
-        try {
-          await writeAnlz({
-            usbFilePath,
-            sourceFilePath,
-            beatgrid: t.beatgrid ?? null,
-            bpm: t.bpm_override ?? t.bpm ?? 0,
-            beatgridOffset: t.beatgrid_offset ?? 0,
-            usbRoot,
-            ffmpegPath: getFfmpegRuntimePath(),
-            cuePoints: getCuePoints(t.id).filter((c) => c.enabled !== 0),
-          });
-        } catch (err) {
-          console.warn(`ANLZ write failed for track ${t.id}:`, err.message);
+        if (shouldWriteAnlz(blind)) {
+          const anlzFolder = getAnlzFolder(usbFilePath).replace(/\\/g, '/');
+          anlzPaths.set(t.id, `/${anlzFolder}/ANLZ0000.DAT`);
+          const sourceFilePath = t.file_path || null;
+          try {
+            await writeAnlz({
+              usbFilePath,
+              sourceFilePath,
+              beatgrid: t.beatgrid ?? null,
+              bpm: t.bpm_override ?? t.bpm ?? 0,
+              beatgridOffset: t.beatgrid_offset ?? 0,
+              usbRoot,
+              ffmpegPath: getFfmpegRuntimePath(),
+              cuePoints: getCuePoints(t.id).filter((c) => c.enabled !== 0),
+            });
+          } catch (err) {
+            console.warn(`ANLZ write failed for track ${t.id}:`, err.message);
+          }
         }
         send('export-rekordbox-progress', {
           msg: `Beat grids & waveforms… ${i + 1}/${total}`,
@@ -2408,26 +2426,31 @@ ipcMain.handle(
 
       // 4. Build PDB tracks for the current export
       send('export-rekordbox-progress', { msg: 'Writing Rekordbox database…', pct: 70 });
-      const newPdbTracks = tracks.map((t) => ({
-        id: t.id,
-        title: t.title || '',
-        artist: t.artist || '',
-        album: t.album || '',
-        duration: t.duration || 0,
-        bpm: t.bpm_override ?? t.bpm ?? 0,
-        key_raw: t.key_raw || '',
-        file_path: usbPaths.get(t.id) || '',
-        track_number: t.track_number || 0,
-        year: t.year || '',
-        label: t.label || '',
-        genres: t.genres ? JSON.parse(t.genres) : [],
-        file_size: usbMeta.get(t.id)?.fileSize ?? t.file_size ?? 0,
-        bitrate: usbMeta.get(t.id)?.bitrate ?? t.bitrate ?? 0,
-        comments: t.comments || '',
-        rating: t.rating || 0,
-        replay_gain: t.replay_gain ?? null,
-        analyzePath: anlzPaths.get(t.id) || '',
-      }));
+      const newPdbTracks = tracks.map((t) =>
+        applyBlindMode(
+          {
+            id: t.id,
+            title: t.title || '',
+            artist: t.artist || '',
+            album: t.album || '',
+            duration: t.duration || 0,
+            bpm: t.bpm_override ?? t.bpm ?? 0,
+            key_raw: t.key_raw || '',
+            file_path: usbPaths.get(t.id) || '',
+            track_number: t.track_number || 0,
+            year: t.year || '',
+            label: t.label || '',
+            genres: t.genres ? JSON.parse(t.genres) : [],
+            file_size: usbMeta.get(t.id)?.fileSize ?? t.file_size ?? 0,
+            bitrate: usbMeta.get(t.id)?.bitrate ?? t.bitrate ?? 0,
+            comments: t.comments || '',
+            rating: t.rating || 0,
+            replay_gain: t.replay_gain ?? null,
+            analyzePath: anlzPaths.get(t.id) || '',
+          },
+          blind
+        )
+      );
 
       const newPdbPlaylists = allPlaylists.map((pl) => ({
         id: pl.id,
@@ -2472,8 +2495,11 @@ ipcMain.handle(
       useNormalized = false,
       targetDevice = null,
       forceMp3 = false,
+      blindMode = null,
     }
   ) => {
+    // #258 — "Real DJ mode": no waveforms/BPM on the exported USB
+    const blind = resolveBlindMode(blindMode, getSetting);
     try {
       const targetLufs = useNormalized ? Number(getSetting('normalize_target_lufs', '-9')) : null;
       const ids = playlistIds?.length ? playlistIds : playlistId ? [playlistId] : null;
@@ -2564,24 +2590,27 @@ ipcMain.handle(
       }
 
       // Write ANLZ beat grids + waveforms (only for tracks in the current export)
+      // #258 — blind mode writes no ANLZ at all.
       send('export-all-progress', { msg: 'Writing beat grids & waveforms…', pct: 50 });
       for (let i = 0; i < allTracks.length; i++) {
         const t = allTracks[i];
         const usbFilePath = usbPaths.get(t.id);
         if (!usbFilePath) continue;
-        try {
-          await writeAnlz({
-            usbFilePath,
-            sourceFilePath: t.file_path || null,
-            beatgrid: t.beatgrid ?? null,
-            bpm: t.bpm_override ?? t.bpm ?? 0,
-            beatgridOffset: t.beatgrid_offset ?? 0,
-            usbRoot,
-            ffmpegPath: getFfmpegRuntimePath(),
-            cuePoints: getCuePoints(t.id).filter((c) => c.enabled !== 0),
-          });
-        } catch (err) {
-          console.warn(`ANLZ write failed for track ${t.id}:`, err.message);
+        if (shouldWriteAnlz(blind)) {
+          try {
+            await writeAnlz({
+              usbFilePath,
+              sourceFilePath: t.file_path || null,
+              beatgrid: t.beatgrid ?? null,
+              bpm: t.bpm_override ?? t.bpm ?? 0,
+              beatgridOffset: t.beatgrid_offset ?? 0,
+              usbRoot,
+              ffmpegPath: getFfmpegRuntimePath(),
+              cuePoints: getCuePoints(t.id).filter((c) => c.enabled !== 0),
+            });
+          } catch (err) {
+            console.warn(`ANLZ write failed for track ${t.id}:`, err.message);
+          }
         }
         send('export-all-progress', {
           msg: `Beat grids & waveforms… ${i + 1}/${total}`,
@@ -2591,31 +2620,36 @@ ipcMain.handle(
 
       // Write PDB — merge with existing manifest
       send('export-all-progress', { msg: 'Writing Rekordbox database…', pct: 70 });
-      const newPdbTracks = allTracks.map((t) => ({
-        id: t.id,
-        title: t.title || '',
-        artist: t.artist || '',
-        album: t.album || '',
-        duration: t.duration || 0,
-        bpm: t.bpm_override ?? t.bpm ?? 0,
-        key_raw: t.key_raw || '',
-        file_path: usbPaths.get(t.id) || '',
-        track_number: t.track_number || 0,
-        year: t.year || '',
-        label: t.label || '',
-        genres: t.genres ? JSON.parse(t.genres) : [],
-        file_size: usbMeta.get(t.id)?.fileSize ?? t.file_size ?? 0,
-        bitrate: usbMeta.get(t.id)?.bitrate ?? t.bitrate ?? 0,
-        comments: t.comments || '',
-        rating: t.rating || 0,
-        replay_gain: t.replay_gain ?? null,
-        analyzePath: (() => {
-          const usbFP = usbPaths.get(t.id);
-          if (!usbFP) return '';
-          const folder = getAnlzFolder(usbFP).replace(/\\/g, '/');
-          return folder ? `/${folder}/ANLZ0000.DAT` : '';
-        })(),
-      }));
+      const newPdbTracks = allTracks.map((t) =>
+        applyBlindMode(
+          {
+            id: t.id,
+            title: t.title || '',
+            artist: t.artist || '',
+            album: t.album || '',
+            duration: t.duration || 0,
+            bpm: t.bpm_override ?? t.bpm ?? 0,
+            key_raw: t.key_raw || '',
+            file_path: usbPaths.get(t.id) || '',
+            track_number: t.track_number || 0,
+            year: t.year || '',
+            label: t.label || '',
+            genres: t.genres ? JSON.parse(t.genres) : [],
+            file_size: usbMeta.get(t.id)?.fileSize ?? t.file_size ?? 0,
+            bitrate: usbMeta.get(t.id)?.bitrate ?? t.bitrate ?? 0,
+            comments: t.comments || '',
+            rating: t.rating || 0,
+            replay_gain: t.replay_gain ?? null,
+            analyzePath: (() => {
+              const usbFP = usbPaths.get(t.id);
+              if (!usbFP) return '';
+              const folder = getAnlzFolder(usbFP).replace(/\\/g, '/');
+              return folder ? `/${folder}/ANLZ0000.DAT` : '';
+            })(),
+          },
+          blind
+        )
+      );
       const newPdbPlaylists = allPlaylists.map((pl) => ({
         id: pl.id,
         name: pl.name,

--- a/src/usb/blindMode.js
+++ b/src/usb/blindMode.js
@@ -1,0 +1,33 @@
+// #258 — "Real DJ mode": export a USB that behaves like a plain stick. The
+// standalone player shows no waveform and no BPM, so the set has to be mixed by
+// ear. This is purely an export-time transformation — the library keeps all
+// analysed data, nothing is deleted.
+
+export const BLIND_MODE_SETTING = 'export_blind_mode';
+
+/**
+ * Resolve the blind-mode flag: an explicit per-export value wins, otherwise the
+ * stored setting decides (default off).
+ * @param {boolean|null|undefined} explicit
+ * @param {(key: string, def?: any) => any} [getSettingFn]
+ */
+export function resolveBlindMode(explicit, getSettingFn) {
+  if (explicit === true) return true;
+  if (explicit === false) return false;
+  if (typeof getSettingFn !== 'function') return false;
+  return getSettingFn(BLIND_MODE_SETTING, 'false') === 'true';
+}
+
+/**
+ * Blank the beat information a standalone player reads out of the PDB.
+ * Keeps every other field untouched (title/artist/cues/key all still export).
+ */
+export function applyBlindMode(track, blindMode) {
+  if (!blindMode) return track;
+  return { ...track, bpm: 0, analyzePath: '' };
+}
+
+/** Blind mode writes no ANLZ files at all (grid + waveform live there). */
+export function shouldWriteAnlz(blindMode) {
+  return !blindMode;
+}

--- a/src/usb/blindMode.js
+++ b/src/usb/blindMode.js
@@ -1,33 +1,33 @@
-// #258 — "Real DJ mode": export a USB that behaves like a plain stick. The
-// standalone player shows no waveform and no BPM, so the set has to be mixed by
-// ear. This is purely an export-time transformation — the library keeps all
-// analysed data, nothing is deleted.
+// #258 — "Real DJ mode": export a stick that gives the player nothing to mix
+// with. The CDJ shows no waveform and no BPM, so the set has to be mixed by ear.
+//
+// Two halves, both needed:
+//   1. the PDB ships BPM 0 (see applyBlindMode) — no BPM in the browser or on
+//      the deck;
+//   2. the ANLZ is still written, but blind (see writeAnlz({ blind: true })) —
+//      no waveform sections and an empty beat grid.
+//
+// The ANLZ must EXIST. Without it the player treats the track as unanalysed and
+// generates its own waveform + grid, which is the opposite of the point. This is
+// also the state a failed export used to leave behind, confirmed on hardware to
+// play with nothing displayed. The library keeps everything either way: this is
+// purely an export-time transformation.
 
 export const BLIND_MODE_SETTING = 'export_blind_mode';
 
-/**
- * Resolve the blind-mode flag: an explicit per-export value wins, otherwise the
- * stored setting decides (default off).
- * @param {boolean|null|undefined} explicit
- * @param {(key: string, def?: any) => any} [getSettingFn]
- */
+/** Resolve the flag: explicit per-export value wins, else the stored setting. */
 export function resolveBlindMode(explicit, getSettingFn) {
   if (explicit === true) return true;
   if (explicit === false) return false;
-  if (typeof getSettingFn !== 'function') return false;
-  return getSettingFn(BLIND_MODE_SETTING, 'false') === 'true';
+  return typeof getSettingFn === 'function' && getSettingFn(BLIND_MODE_SETTING, 'false') === 'true';
 }
 
 /**
- * Blank the beat information a standalone player reads out of the PDB.
- * Keeps every other field untouched (title/artist/cues/key all still export).
+ * Strip the beat information a standalone player would display.
+ * `analyzePath` is deliberately kept: it points at the blind ANLZ, and clearing
+ * it would make the player think the track was never analysed.
  */
 export function applyBlindMode(track, blindMode) {
   if (!blindMode) return track;
-  return { ...track, bpm: 0, analyzePath: '' };
-}
-
-/** Blind mode writes no ANLZ files at all (grid + waveform live there). */
-export function shouldWriteAnlz(blindMode) {
-  return !blindMode;
+  return { ...track, bpm: 0 };
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -39,6 +39,7 @@ export default defineConfig({
             'src/__tests__/importManager.test.js',
             'src/__tests__/dbLocation.test.js',
             'src/__tests__/autoTagger.test.js',
+            'src/__tests__/blindMode.test.js',
             'src/__tests__/ytDlpManager.test.js',
             'src/__tests__/tidalDlManager.test.js',
             'src/__tests__/mediaServer.test.js',


### PR DESCRIPTION
Refs #258

An export that gives the player nothing to mix against: the CDJ shows a **blank waveform** and **no BPM**, so the set has to be mixed by ear. Everything stays in the library.

## Why the ANLZ is still written
The obvious implementation (skip the ANLZ) is wrong: with no analysis data the player treats the track as unanalysed and **generates its own waveform and grid**, which defeats the whole thing. So the stick carries an ANLZ that looks analysed but is empty — the same state a failed export used to leave behind, already confirmed on hardware to play with nothing displayed.

Per track the export therefore writes:
- **DAT**: `PPTH` + `PVBR` + **header-only `PQTZ`** (zero beat entries) + cues. No `PWAV`, no `PWV2`.
- **EXT**: cues + `PCO2` + **header-only `PQT2`** (zero beats). No `PWV3`, `PWV5`, `PWV4`.
- **no `.2EX`** at all (colour waveforms).
- **PDB**: `bpm = 0`. `analyzePath` is **kept** on purpose — it points at that blind ANLZ, and clearing it would make the player analyse the track itself.
- Waveform generation is skipped entirely, so blind exports are also faster (no ffmpeg pass per track).

## Scope
- Wired into all three export paths: `export-explorer-to-usb`, `export-rekordbox`, `export-all`.
- Re-exporting onto an existing stick overwrites that track's PDB row, so a previously normal export becomes blind too.
- Side-by-side verify after exporting: DAT has no `PWAV`/`PWV2`, EXT has no `PWV3`/`PWV5`/`PWV4`, `PQTZ` is 24 bytes (header only), `PQT2` 56 bytes, no `.2EX` file, and the PDB BPM reads 0.
- Toggle: **Real DJ mode - blank waveform, no BPM (mix blind)** in the export modal, persisted as `export_blind_mode` so explorer exports honour it too. Off = normal export, untouched.

## Open question
Cue points are still exported in blind mode (they are your workflow anyway, and #259 reads them back). Waiting on meiremax's answer before deciding whether that should change.

## Tests
- `anlzWriter.test.js` blind suite: no `generateWaveform` call, DAT+EXT only (no 2EX), every waveform section absent, both grids header-only, path tag and seek table kept, cues still written, and a normal export untouched by the option.
- `blindMode.test.js`: `analyzePath` preserved, BPM zeroed, no mutation of the input.
- Root suite 510/510, renderer 197/197, lint clean.