### PR TITLE
feat(explorer): follow USB drives across drive-letter changes

### DIFF
--- a/renderer/src/ExportModal.jsx
+++ b/renderer/src/ExportModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import FormatConfirmModal from './FormatConfirmModal.jsx';
+import { applyVolumeRenames } from './volumeRenames.js';
 import './ExportModal.css';
 
 const STEPS = {
@@ -60,6 +61,10 @@ function ExportModal({ onClose, playlistId, initialMode }) {
   const [mode, setMode] = useState(initialMode ?? null);
   const [usbInfo, setUsbInfo] = useState(null);
   const [usbRoot, setUsbRoot] = useState(null);
+  // Stable identity of the picked volume (#514). The letter alone is not enough:
+  // the drive can come back under a different one before the export starts, so we
+  // remember `{ id, root }` and let the main process resolve the current letter.
+  const [usbVolume, setUsbVolume] = useState(null);
   const [progress, setProgress] = useState(null); // { msg, pct }
   const [formatProgress, setFormatProgress] = useState(null);
   const [result, setResult] = useState(null);
@@ -91,11 +96,33 @@ function ExportModal({ onClose, playlistId, initialMode }) {
     };
   }, []);
 
+  // #514: if the picked drive comes back under another letter while this dialog
+  // is open, follow it so the shown path (and the export) stays on the right disk.
+  // The volume root captured at pick time is kept in sync too, otherwise the main
+  // process could no longer tie the updated path back to its volume.
+  useEffect(() => {
+    const unsub = window.api.onDrivesUpdated((payload) => {
+      const renames = payload?.letterChanged ?? [];
+      if (renames.length === 0) return;
+      setUsbRoot((prev) => applyVolumeRenames(prev, renames));
+      setUsbVolume((prev) => {
+        if (!prev?.root) return prev;
+        const root = applyVolumeRenames(prev.root, renames);
+        return root === prev.root ? prev : { ...prev, root };
+      });
+    });
+    return unsub;
+  }, []);
+
   const pickFolder = async (exportMode) => {
     setMode(exportMode);
     const dir = await window.api.openDirDialog();
     if (!dir) return;
     setUsbRoot(dir);
+    // Remember which volume was picked, not just its letter, so a swap between
+    // picking the drive and starting the export can still be resolved (#514).
+    const volume = await window.api.getVolumeForPath(dir);
+    setUsbVolume(volume ?? null);
     setStep(STEPS.checkingFormat);
     const info = await window.api.checkUsbFormat(dir);
     setUsbInfo(info);
@@ -106,7 +133,7 @@ function ExportModal({ onClose, playlistId, initialMode }) {
     } else if (info.needsFormat) {
       setStep(STEPS.needsFormat);
     } else {
-      startExport(exportMode, dir);
+      startExport(exportMode, dir, volume ?? null);
     }
   };
 
@@ -118,16 +145,18 @@ function ExportModal({ onClose, playlistId, initialMode }) {
       setStep(STEPS.error);
       return;
     }
-    startExport(mode, usbRoot);
+    startExport(mode, usbRoot, usbVolume);
   };
 
-  const startExport = async (exportMode, dir) => {
+  const startExport = async (exportMode, dir, volume = usbVolume) => {
     setStep(STEPS.exporting);
     setProgress({ msg: 'Starting…', pct: 0 });
     let res;
     if (exportMode === 'rekordbox') {
       res = await window.api.exportRekordbox({
         usbRoot: dir,
+        usbVolumeId: volume?.id ?? null,
+        usbVolumeRoot: volume?.root ?? null,
         playlistId: playlistId ?? null,
         useNormalized,
         targetDevice: targetDevice || null,
@@ -136,6 +165,8 @@ function ExportModal({ onClose, playlistId, initialMode }) {
     } else {
       res = await window.api.exportAll({
         usbRoot: dir,
+        usbVolumeId: volume?.id ?? null,
+        usbVolumeRoot: volume?.root ?? null,
         playlistId: playlistId ?? null,
         useNormalized,
         targetDevice: targetDevice || null,

--- a/renderer/src/FileExplorerView.jsx
+++ b/renderer/src/FileExplorerView.jsx
@@ -4,6 +4,7 @@ import { usePlayer } from './PlayerContext.jsx';
 import { artworkUrl } from './artworkUrl.js';
 import TrackDetails from './TrackDetails.jsx';
 import BeatGridEditor from './BeatGridEditor.jsx';
+import { applyVolumeRenames } from './volumeRenames.js';
 import './MusicLibrary.css';
 import './FileExplorerView.css';
 
@@ -360,6 +361,33 @@ export default function FileExplorerView({ style }) {
       setFavourites(Array.isArray(parsed) ? parsed : []);
     });
     const unsub = window.api.onPlaylistsUpdated(() => window.api.getPlaylists().then(setPlaylists));
+    return unsub;
+  }, []);
+
+  // Drive hot-swap (#514): the main process re-scans drives on focus and on a
+  // short poll. Refresh the drive list, and when the volume we are browsing came
+  // back under a different letter, follow it instead of showing a stale path.
+  useEffect(() => {
+    const unsub = window.api.onDrivesUpdated((payload) => {
+      setDrives(payload?.drives ?? []);
+      const renames = payload?.letterChanged ?? [];
+      if (renames.length === 0) return;
+      setCurrentPath((prev) => applyVolumeRenames(prev, renames));
+      // Favourites are remembered by path too, so re-point the ones that lived on
+      // the renamed drive and persist the rewrite (#514).
+      setFavourites((prev) => {
+        let changed = false;
+        const next = prev.map((fav) => {
+          const path = applyVolumeRenames(fav.path, renames);
+          if (path === fav.path) return fav;
+          changed = true;
+          return { path, name: basename(path) || path };
+        });
+        if (!changed) return prev;
+        window.api.setSetting('explorer_favourites', JSON.stringify(next));
+        return next;
+      });
+    });
     return unsub;
   }, []);
 

--- a/renderer/src/HelpView.jsx
+++ b/renderer/src/HelpView.jsx
@@ -87,20 +87,22 @@ const SECTIONS = [
   },
   {
     title: 'Explorer & linked files',
-    keywords: 'filesystem drives usb folder link reference unavailable',
+    keywords: 'filesystem drives usb folder link reference unavailable reconnect letter hot swap',
     items: [
       'Explorer browses the filesystem: select a folder or files with audio and Add to Library to link them (kept in place), or manage linked files and their availability.',
-      'Removable drives are listed separately, which keeps USB workflow quick. Linked tracks on a disconnected drive show as unavailable rather than disappearing.',
+      'Removable drives are listed separately, which keeps USB workflow quick. Linked tracks on a disconnected drive show as unavailable rather than disappearing, and when the drive returns under a different letter the linked paths are re-pointed automatically.',
+      'Drives are re-detected automatically when one is plugged in, unplugged or comes back under a different letter: the folder you are browsing follows the drive instead of pointing at a stale path.',
     ],
   },
   {
     title: 'USB export (Rekordbox)',
-    keywords: 'usb stick drive rekordbox cdj export playlist format pdb',
+    keywords: 'usb stick drive rekordbox cdj export playlist format pdb reconnect letter',
     items: [
       'Export a single playlist or the whole library to a Rekordbox-compatible USB drive from the playlist context menu or the Export dialog.',
       'Only removable drives are offered as targets, so internal disks can never be overwritten by accident. Drives must be FAT32/exFAT (Rekordbox format).',
       'The export writes cue points, beat grid, BPM and automatic gain so CDJs (e.g. CDJ-3000) load the track ready to mix.',
       'Exporting again to a drive that already has the playlist reuses the existing path/name instead of creating duplicates.',
+      'The destination is re-checked right before writing: if the stick was unplugged or came back under another letter, the export follows it, or stops with a clear message instead of writing to the wrong disk.',
       'A supported format action is available for USB sticks that need a fresh Rekordbox layout.',
     ],
   },

--- a/renderer/src/PlayerContext.jsx
+++ b/renderer/src/PlayerContext.jsx
@@ -76,8 +76,10 @@ export function PlayerProvider({ children }) {
 
   // Track availability for linked (Explorer-referenced) files, which point at
   // arbitrary — often removable — paths. Re-check on mount, whenever the window
-  // regains focus (e.g. the user just plugged a drive back in), and on a slow
-  // background interval so the "grayed out" state doesn't require an action.
+  // regains focus (e.g. the user just plugged a drive back in), whenever the
+  // drive list changes (#514: a stick that came back under a new letter makes the
+  // greyed-out rows stale), and on a slow background interval so the "grayed out"
+  // state doesn't require an action.
   const refreshAvailability = useCallback(() => {
     window.api
       .getUnavailableLinkedTracks()
@@ -88,9 +90,13 @@ export function PlayerProvider({ children }) {
     refreshAvailability();
     window.addEventListener('focus', refreshAvailability);
     const interval = setInterval(refreshAvailability, 20000);
+    // Re-request immediately after a drive was added, removed or re-lettered so
+    // linked tracks stop showing as unavailable once the stick is back.
+    const unsubDrives = window.api.onDrivesUpdated(refreshAvailability);
     return () => {
       window.removeEventListener('focus', refreshAvailability);
       clearInterval(interval);
+      unsubDrives();
     };
   }, [refreshAvailability]);
 

--- a/renderer/src/__tests__/ExportModal.test.jsx
+++ b/renderer/src/__tests__/ExportModal.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import ExportModal from '../ExportModal.jsx';
 
 describe('ExportModal', () => {
@@ -324,6 +324,117 @@ describe('ExportModal', () => {
     await waitFor(() => {
       expect(window.api.exportRekordbox).toHaveBeenCalledWith(
         expect.objectContaining({ targetDevice: 'xdj-rx2', forceMp3: true })
+      );
+    });
+  });
+
+  // #514: the picked drive is remembered by volume id, not just by letter, so the
+  // main process can follow it when Windows reassigns the letter before the export.
+  it('passes the picked volume id to exportRekordbox', async () => {
+    window.api.openDirDialog.mockResolvedValueOnce('E:\\');
+    window.api.getVolumeForPath.mockResolvedValueOnce({ id: 'win32:vol:1a2b3c4d', root: 'E:\\' });
+    window.api.checkUsbFormat.mockResolvedValueOnce({
+      needsFormat: false,
+      fs: 'fat32',
+      fsLabel: 'FAT32',
+      device: 'E:',
+    });
+
+    render(<ExportModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('Export Rekordbox USB'));
+
+    await waitFor(() => {
+      expect(window.api.getVolumeForPath).toHaveBeenCalledWith('E:\\');
+      expect(window.api.exportRekordbox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          usbRoot: 'E:\\',
+          usbVolumeId: 'win32:vol:1a2b3c4d',
+          usbVolumeRoot: 'E:\\',
+        })
+      );
+    });
+  });
+
+  // #514: the drive can be replugged while the dialog is open, so the shown mount
+  // point (and the eventual export) must follow it to the new letter.
+  it('follows the picked drive when it returns under a new letter', async () => {
+    const subscribers = [];
+    window.api.onDrivesUpdated.mockImplementation((cb) => {
+      subscribers.push(cb);
+      return () => {};
+    });
+    window.api.openDirDialog.mockResolvedValueOnce('E:\\Music');
+    window.api.getVolumeForPath.mockResolvedValueOnce({ id: 'win32:vol:1a2b3c4d', root: 'E:\\' });
+    window.api.checkUsbFormat.mockResolvedValueOnce({
+      needsFormat: true,
+      removable: true,
+      fs: 'btrfs',
+      fsLabel: 'btrfs',
+      device: 'E:',
+    });
+
+    render(<ExportModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('Export Rekordbox USB'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/E:\\Music/)).toBeInTheDocument();
+    });
+
+    act(() => {
+      subscribers.forEach((cb) =>
+        cb({ letterChanged: [{ id: 'win32:vol:1a2b3c4d', from: 'E:\\', to: 'D:\\' }] })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/D:\\Music/)).toBeInTheDocument();
+    });
+  });
+
+  it('sends the re-lettered volume root when the export starts after a swap', async () => {
+    const subscribers = [];
+    window.api.onDrivesUpdated.mockImplementation((cb) => {
+      subscribers.push(cb);
+      return () => {};
+    });
+    window.api.openDirDialog.mockResolvedValueOnce('E:\\Music');
+    window.api.getVolumeForPath.mockResolvedValueOnce({ id: 'win32:vol:1a2b3c4d', root: 'E:\\' });
+    window.api.checkUsbFormat.mockResolvedValueOnce({
+      needsFormat: true,
+      removable: true,
+      fs: 'btrfs',
+      fsLabel: 'btrfs',
+      device: 'E:',
+    });
+
+    render(<ExportModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('Export Rekordbox USB'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Export Anyway')).toBeInTheDocument();
+    });
+
+    act(() => {
+      subscribers.forEach((cb) =>
+        cb({ letterChanged: [{ id: 'win32:vol:1a2b3c4d', from: 'E:\\', to: 'D:\\' }] })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/D:\\Music/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Export Anyway'));
+
+    await waitFor(() => {
+      expect(window.api.exportRekordbox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          usbRoot: 'D:\\Music',
+          usbVolumeId: 'win32:vol:1a2b3c4d',
+          // The pick-time volume root must follow the rename too, or the main
+          // process can no longer tie the path back to its volume (#514).
+          usbVolumeRoot: 'D:\\',
+        })
       );
     });
   });

--- a/renderer/src/__tests__/FileExplorerView.hotswap.test.jsx
+++ b/renderer/src/__tests__/FileExplorerView.hotswap.test.jsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import FileExplorerView from '../FileExplorerView.jsx';
+import { PlayerProvider } from '../PlayerContext.jsx';
+
+// jsdom has no ResizeObserver; FileExplorerView uses one to size its virtualized list.
+globalThis.ResizeObserver =
+  globalThis.ResizeObserver ||
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+// Both FileExplorerView and PlayerContext subscribe to the drive event, so the
+// fake collects every subscriber and fires them all.
+function subscribeToDriveEvents() {
+  const callbacks = [];
+  window.api.onDrivesUpdated.mockImplementation((cb) => {
+    callbacks.push(cb);
+    return () => {
+      const index = callbacks.indexOf(cb);
+      if (index >= 0) callbacks.splice(index, 1);
+    };
+  });
+  return (payload) => act(() => callbacks.forEach((cb) => cb(payload)));
+}
+
+function renderExplorer() {
+  return render(
+    <PlayerProvider>
+      <FileExplorerView />
+    </PlayerProvider>
+  );
+}
+
+// #514: a USB stick that comes back under a different letter must not leave the
+// Explorer pointing at the old, now stale, path.
+describe('FileExplorerView - drive hot-swap (#514)', () => {
+  it('follows the browsed volume when it returns under a new drive letter', async () => {
+    window.api.getComputerRoot.mockResolvedValue({
+      root: 'C:\\',
+      home: 'E:\\Music',
+      drives: ['C:\\', 'E:\\'],
+      volumes: [],
+    });
+    const emitDrivesUpdated = subscribeToDriveEvents();
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(window.api.browseDirectory).toHaveBeenCalledWith('E:\\Music');
+    });
+
+    emitDrivesUpdated({
+      drives: ['C:\\', 'D:\\'],
+      volumes: [],
+      added: [],
+      removed: [],
+      letterChanged: [{ id: 'win32:vol:1', from: 'E:\\', to: 'D:\\', volume: { root: 'D:\\' } }],
+    });
+
+    await waitFor(() => {
+      expect(window.api.browseDirectory).toHaveBeenCalledWith('D:\\Music');
+    });
+  });
+
+  it('keeps the current folder when a different drive appears', async () => {
+    window.api.getComputerRoot.mockResolvedValue({
+      root: 'C:\\',
+      home: 'E:\\Music',
+      drives: ['C:\\', 'E:\\'],
+      volumes: [],
+    });
+    const emitDrivesUpdated = subscribeToDriveEvents();
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(window.api.browseDirectory).toHaveBeenCalledWith('E:\\Music');
+    });
+    window.api.browseDirectory.mockClear();
+
+    emitDrivesUpdated({
+      drives: ['C:\\', 'E:\\', 'F:\\'],
+      volumes: [],
+      added: [{ root: 'F:\\' }],
+      removed: [],
+      letterChanged: [],
+    });
+
+    await waitFor(() => {
+      expect(window.api.browseDirectory).toHaveBeenCalledWith('E:\\Music');
+    });
+    expect(window.api.browseDirectory).not.toHaveBeenCalledWith('F:\\');
+  });
+
+  it('unsubscribes from the drive event on unmount', async () => {
+    const unsubscribe = vi.fn();
+    window.api.onDrivesUpdated.mockImplementation(() => unsubscribe);
+
+    const { unmount } = renderExplorer();
+    await waitFor(() => {
+      expect(window.api.onDrivesUpdated).toHaveBeenCalled();
+    });
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('re-points favourites that lived on the renamed drive', async () => {
+    window.api.getComputerRoot.mockResolvedValue({
+      root: 'C:\\',
+      home: 'E:\\Music',
+      drives: ['C:\\', 'E:\\'],
+      volumes: [],
+    });
+    window.api.getSetting.mockImplementation((key, def) =>
+      Promise.resolve(
+        key === 'explorer_favourites'
+          ? JSON.stringify([{ path: 'E:\\Music', name: 'Music' }])
+          : (def ?? null)
+      )
+    );
+    const emitDrivesUpdated = subscribeToDriveEvents();
+
+    renderExplorer();
+
+    await waitFor(() => {
+      expect(window.api.getSetting).toHaveBeenCalledWith('explorer_favourites', []);
+    });
+
+    emitDrivesUpdated({
+      drives: ['C:\\', 'D:\\'],
+      volumes: [],
+      added: [],
+      removed: [],
+      letterChanged: [{ id: 'win32:vol:1', from: 'E:\\', to: 'D:\\', volume: { root: 'D:\\' } }],
+    });
+
+    await waitFor(() => {
+      expect(window.api.setSetting).toHaveBeenCalledWith(
+        'explorer_favourites',
+        JSON.stringify([{ path: 'D:\\Music', name: 'Music' }])
+      );
+    });
+  });
+});

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -131,6 +131,8 @@ window.api = {
   onTidalTrackUpdate: vi.fn().mockImplementation(() => () => {}),
   openExternal: vi.fn().mockResolvedValue(undefined),
   getComputerRoot: vi.fn().mockResolvedValue({ root: '/', home: '/home/user' }),
+  getVolumeForPath: vi.fn().mockResolvedValue(null),
+  onDrivesUpdated: vi.fn().mockImplementation(noop),
   browseDirectory: vi.fn().mockResolvedValue({ dirs: [], files: [] }),
   selectExplorerFolder: vi.fn().mockResolvedValue(null),
   getTracksByPaths: vi.fn().mockResolvedValue([]),

--- a/renderer/src/__tests__/volumeRenames.test.js
+++ b/renderer/src/__tests__/volumeRenames.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { applyVolumeRenames, isDriveRoot } from '../volumeRenames.js';
+
+describe('isDriveRoot', () => {
+  it('detects Windows drive roots only', () => {
+    expect(isDriveRoot('E:\\')).toBe(true);
+    expect(isDriveRoot('E:')).toBe(true);
+    expect(isDriveRoot('/run/media/u/USB')).toBe(false);
+  });
+});
+
+describe('applyVolumeRenames', () => {
+  it('rewrites a browsed folder when the drive letter changes', () => {
+    const renames = [{ from: 'E:\\', to: 'D:\\' }];
+    expect(applyVolumeRenames('E:\\music\\a.mp3', renames)).toBe('D:\\music\\a.mp3');
+    expect(applyVolumeRenames('E:\\', renames)).toBe('D:\\');
+    expect(applyVolumeRenames('E:', renames)).toBe('D:\\');
+  });
+
+  it('matches Windows roots case-insensitively', () => {
+    expect(applyVolumeRenames('e:\\music', [{ from: 'E:\\', to: 'D:\\' }])).toBe('D:\\music');
+  });
+
+  it('leaves paths on other drives alone', () => {
+    const renames = [{ from: 'E:\\', to: 'D:\\' }];
+    expect(applyVolumeRenames('C:\\music', renames)).toBe('C:\\music');
+    expect(applyVolumeRenames('F:\\music', renames)).toBe('F:\\music');
+  });
+
+  it('rewrites POSIX mount points without touching lookalikes', () => {
+    const renames = [{ from: '/run/media/u/USB', to: '/media/u/USB' }];
+    expect(applyVolumeRenames('/run/media/u/USB/music', renames)).toBe('/media/u/USB/music');
+    expect(applyVolumeRenames('/run/media/u/USB2/music', renames)).toBe('/run/media/u/USB2/music');
+  });
+
+  it('anchors a naked Windows root with a backslash, not a slash', () => {
+    // Detect-windows roots normally carry the separator, but a rename pair handed
+    // in without one must still match real Windows paths (backslashes).
+    expect(applyVolumeRenames('E:\\music', [{ from: 'E:', to: 'D:' }])).toBe('D:\\music');
+    expect(applyVolumeRenames('E:', [{ from: 'E:', to: 'D:' }])).toBe('D:');
+  });
+
+  it('applies chained renames in order', () => {
+    const renames = [
+      { from: 'E:\\', to: 'F:\\' },
+      { from: 'F:\\', to: 'G:\\' },
+    ];
+    expect(applyVolumeRenames('E:\\music', renames)).toBe('G:\\music');
+  });
+
+  it('returns the input untouched for empty or useless input', () => {
+    expect(applyVolumeRenames(null, [{ from: 'E:\\', to: 'D:\\' }])).toBeNull();
+    expect(applyVolumeRenames('E:\\music', [])).toBe('E:\\music');
+    expect(applyVolumeRenames('E:\\music', null)).toBe('E:\\music');
+    expect(applyVolumeRenames('E:\\music', [{ from: 'E:\\', to: 'E:\\' }])).toBe('E:\\music');
+    expect(applyVolumeRenames('E:\\music', [{ from: '', to: 'D:\\' }])).toBe('E:\\music');
+  });
+});

--- a/renderer/src/volumeRenames.js
+++ b/renderer/src/volumeRenames.js
@@ -1,0 +1,50 @@
+/**
+ * Follows a drive that came back under a different letter (#514).
+ *
+ * The main process watches the volume list and reports the volumes that moved
+ * (`letterChanged: [{ from: 'E:\\', to: 'D:\\' }]`). Everything the renderer
+ * remembers by drive letter - the browsed folder, the export target - is
+ * rewritten from the old root to the new one instead of pointing at a path that
+ * now belongs to a different device (or to nothing at all).
+ *
+ * Pure string logic so it can be unit tested without the main process.
+ */
+
+/** True for roots shaped like a Windows drive ("E:", "E:\", "E:/"). */
+export function isDriveRoot(root) {
+  return /^[a-zA-Z]:[\\/]?$/.test(String(root ?? ''));
+}
+
+/**
+ * Applies every rename that contains `targetPath`.
+ *
+ * @param {string|null} targetPath path to rewrite (Windows letter or POSIX mount)
+ * @param {{ from: string, to: string }[]} renames old root -> new root pairs
+ * @returns {string|null} the rewritten path, or the original when nothing matches
+ */
+export function applyVolumeRenames(targetPath, renames = []) {
+  if (!targetPath || !Array.isArray(renames) || renames.length === 0) return targetPath;
+
+  let path = String(targetPath);
+  for (const rename of renames) {
+    const from = rename?.from;
+    const to = rename?.to;
+    if (!from || !to || from === to) continue;
+
+    const caseInsensitive = isDriveRoot(from);
+    const candidate = caseInsensitive ? path.toLowerCase() : path;
+    const root = caseInsensitive ? String(from).toLowerCase() : String(from);
+
+    if (candidate === root || candidate === root.replace(/[\\/]+$/, '')) {
+      path = to;
+    } else {
+      // A naked root needs a separator before it can anchor a prefix match, and it
+      // has to be the separator of the platform the root belongs to: `E:` uses
+      // backslashes, a POSIX mount point uses forward slashes.
+      const endsWithSep = root.endsWith('\\') || root.endsWith('/');
+      const prefix = endsWithSep ? root : `${root}${caseInsensitive ? '\\' : '/'}`;
+      if (candidate.startsWith(prefix)) path = to + path.slice(String(from).length);
+    }
+  }
+  return path;
+}

--- a/src/__tests__/volumeIdentity.test.js
+++ b/src/__tests__/volumeIdentity.test.js
@@ -1,0 +1,401 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decodeMountField,
+  decideExportDestination,
+  diffVolumes,
+  findVolumeForPath,
+  isWindowsDriveRoot,
+  makeLinuxVolumeId,
+  makeWindowsVolumeId,
+  parseProcMounts,
+  pathHasRoot,
+  planLinkedTrackRekeys,
+  resolveVolumePath,
+} from '../explorer/volumeIdentity.js';
+import { detectVolumes } from '../explorer/drives.js';
+
+const winVolume = (root, serial) => ({
+  id: makeWindowsVolumeId({ root, serial }),
+  root,
+  label: root.replace(/[\\/]+$/, ''),
+  platform: 'win32',
+});
+
+const linVolume = (root, fileSystemType = 'vfat', totalBytes = 3_100_000_000) => ({
+  id: makeLinuxVolumeId({
+    fileSystemType,
+    label: root.split('/').filter(Boolean).pop() ?? '',
+    totalBytes,
+  }),
+  root,
+  label: root,
+  platform: 'linux',
+});
+
+describe('parseProcMounts', () => {
+  it('parses device, mount point and filesystem type', () => {
+    const text = [
+      '# comment line',
+      '',
+      '/dev/nvme0n1p2 / ext4 rw,relatime 0 0',
+      '/dev/sdb1 /run/media/radex/USB vfat rw,nosuid 0 0',
+    ].join('\n');
+
+    expect(parseProcMounts(text)).toEqual([
+      { device: '/dev/nvme0n1p2', mountPoint: '/', fileSystemType: 'ext4' },
+      { device: '/dev/sdb1', mountPoint: '/run/media/radex/USB', fileSystemType: 'vfat' },
+    ]);
+  });
+
+  it('decodes the octal escapes used for spaces in mount points', () => {
+    const text = '/dev/sdb1 /run/media/radex/My\\040Stick vfat rw 0 0';
+    const [entry] = parseProcMounts(text);
+    expect(entry.mountPoint).toBe('/run/media/radex/My Stick');
+    expect(decodeMountField('a\\011b')).toBe('a\tb');
+    expect(decodeMountField('plain')).toBe('plain');
+  });
+
+  it('ignores lines that do not have at least three fields', () => {
+    expect(parseProcMounts('garbage\n\n/dev/sdb1 /mnt vfat 0 0')).toHaveLength(1);
+    expect(parseProcMounts()).toEqual([]);
+  });
+});
+
+describe('pathHasRoot', () => {
+  it('matches Linux roots as a path prefix', () => {
+    expect(pathHasRoot('/run/media/u/USB/music/a.mp3', '/run/media/u/USB')).toBe(true);
+    expect(pathHasRoot('/run/media/u/USB', '/run/media/u/USB')).toBe(true);
+    expect(pathHasRoot('/run/media/u/USB2', '/run/media/u/USB')).toBe(false);
+  });
+
+  it('matches Windows drive roots case-insensitively and without the separator', () => {
+    expect(pathHasRoot('E:\\music\\a.mp3', 'E:\\')).toBe(true);
+    expect(pathHasRoot('e:\\music\\a.mp3', 'E:\\')).toBe(true);
+    expect(pathHasRoot('E:\\', 'E:\\')).toBe(true);
+    expect(pathHasRoot('E:', 'E:\\')).toBe(true);
+    expect(pathHasRoot('F:\\music', 'E:\\')).toBe(false);
+    expect(isWindowsDriveRoot('E:')).toBe(true);
+    expect(isWindowsDriveRoot('/mnt/usb')).toBe(false);
+  });
+
+  it('returns false for empty inputs', () => {
+    expect(pathHasRoot('', 'E:\\')).toBe(false);
+    expect(pathHasRoot('E:\\', '')).toBe(false);
+  });
+});
+
+describe('findVolumeForPath', () => {
+  it('returns the longest matching root', () => {
+    const root = linVolume('/');
+    const usb = linVolume('/run/media/u/USB');
+    expect(findVolumeForPath('/run/media/u/USB/music/a.mp3', [root, usb])).toBe(usb);
+    expect(findVolumeForPath('/home/radex/a.mp3', [root, usb])).toBe(root);
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(findVolumeForPath('/media/u/USB/a.mp3', [])).toBeNull();
+    expect(findVolumeForPath(null, [linVolume('/')])).toBeNull();
+  });
+});
+
+describe('resolveVolumePath', () => {
+  const oldVolume = winVolume('E:\\', 0x1a2b3c4d);
+  const newRootVolume = winVolume('D:\\', 0x1a2b3c4d);
+  const otherVolume = winVolume('E:\\', 0xdeadbeef);
+
+  it('keeps the path when the volume is still at the same root', () => {
+    const res = resolveVolumePath('E:\\music\\a.mp3', [oldVolume], [oldVolume]);
+    expect(res).toEqual({
+      ok: true,
+      path: 'E:\\music\\a.mp3',
+      volumeId: oldVolume.id,
+      root: 'E:\\',
+      changed: false,
+    });
+  });
+
+  it('follows the volume to a new letter', () => {
+    const res = resolveVolumePath('E:\\music\\a.mp3', [newRootVolume, otherVolume], [oldVolume]);
+    expect(res.ok).toBe(true);
+    expect(res.path).toBe('D:\\music\\a.mp3');
+    expect(res.changed).toBe(true);
+    expect(res.root).toBe('D:\\');
+  });
+
+  it('rewrites a bare drive root', () => {
+    const res = resolveVolumePath('E:\\', [newRootVolume], [oldVolume]);
+    expect(res.path).toBe('D:\\');
+  });
+
+  it('fails when the volume is gone instead of reusing a stale path', () => {
+    const res = resolveVolumePath('E:\\music', [otherVolume], [oldVolume]);
+    expect(res).toEqual({ ok: false, reason: 'volume-missing', volumeId: oldVolume.id });
+  });
+
+  it('supports the export form where the pick-time volume is passed explicitly', () => {
+    const picked = [{ id: oldVolume.id, root: 'E:\\' }];
+    expect(resolveVolumePath('E:\\music\\a.mp3', [newRootVolume], picked).path).toBe(
+      'D:\\music\\a.mp3'
+    );
+  });
+
+  it('keeps a picked subfolder when only the volume root moved', () => {
+    // The export flow passes the volume root captured at pick time, so re-rooting
+    // must preserve the subfolder the user actually selected (#514).
+    const picked = [{ id: oldVolume.id, root: 'E:\\' }];
+    expect(resolveVolumePath('E:\\Music', [newRootVolume], picked)).toMatchObject({
+      ok: true,
+      path: 'D:\\Music',
+      changed: true,
+    });
+  });
+
+  it('reports no-volume when the path belongs to no known volume', () => {
+    expect(resolveVolumePath('Z:\\music', [oldVolume], [oldVolume])).toEqual({
+      ok: false,
+      reason: 'no-volume',
+    });
+  });
+
+  it('reports no-path for an empty destination', () => {
+    expect(resolveVolumePath(null, [oldVolume])).toEqual({ ok: false, reason: 'no-path' });
+  });
+});
+
+describe('diffVolumes', () => {
+  it('reports no change for identical snapshots', () => {
+    const volumes = [winVolume('C:\\', 1), winVolume('E:\\', 2)];
+    const diff = diffVolumes(
+      volumes,
+      volumes.map((v) => ({ ...v }))
+    );
+    expect(diff.changed).toBe(false);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.letterChanged).toEqual([]);
+    expect(diff.unchanged).toHaveLength(2);
+  });
+
+  it('detects added, removed and letter-changed volumes by stable id', () => {
+    const c = winVolume('C:\\', 1);
+    const stick = winVolume('E:\\', 2);
+    const previous = [c, stick];
+    const next = [c, winVolume('D:\\', 2), winVolume('F:\\', 3)];
+
+    const diff = diffVolumes(previous, next);
+    expect(diff.changed).toBe(true);
+    expect(diff.added.map((v) => v.root)).toEqual(['F:\\']);
+    expect(diff.removed).toEqual([]);
+    expect(diff.letterChanged).toEqual([
+      { id: stick.id, from: 'E:\\', to: 'D:\\', volume: next[1] },
+    ]);
+    expect(diff.unchanged.map((v) => v.root)).toEqual(['C:\\']);
+  });
+
+  it('treats a removed volume as removed, not as renamed', () => {
+    const stick = winVolume('E:\\', 2);
+    const diff = diffVolumes([stick], []);
+    expect(diff.removed).toEqual([stick]);
+    expect(diff.letterChanged).toEqual([]);
+    expect(diff.changed).toBe(true);
+  });
+});
+
+describe('planLinkedTrackRekeys', () => {
+  it('appends the platform separator to naked roots', () => {
+    expect(planLinkedTrackRekeys([{ from: 'E:\\', to: 'D:\\' }], '\\')).toEqual([
+      { from: 'E:\\', to: 'D:\\', fromPrefix: 'E:\\', toPrefix: 'D:\\' },
+    ]);
+    expect(planLinkedTrackRekeys([{ from: '/run/media/u/USB', to: '/media/u/USB' }], '/')).toEqual([
+      {
+        from: '/run/media/u/USB',
+        to: '/media/u/USB',
+        fromPrefix: '/run/media/u/USB/',
+        toPrefix: '/media/u/USB/',
+      },
+    ]);
+  });
+
+  it('keeps a separator that is already there', () => {
+    const [plan] = planLinkedTrackRekeys([{ from: '/mnt/usb/', to: 'E:/' }], '/');
+    expect(plan).toMatchObject({ fromPrefix: '/mnt/usb/', toPrefix: 'E:/' });
+  });
+
+  it('skips empty, identical and duplicate renames', () => {
+    const plans = planLinkedTrackRekeys(
+      [
+        { from: 'E:\\', to: 'D:\\' },
+        { from: 'E:\\', to: 'D:\\' },
+        { from: '', to: 'D:\\' },
+        { from: 'F:\\', to: 'F:\\' },
+      ],
+      '\\'
+    );
+    expect(plans).toHaveLength(1);
+  });
+
+  it('returns an empty list for no changes', () => {
+    expect(planLinkedTrackRekeys([], '\\')).toEqual([]);
+    expect(planLinkedTrackRekeys(undefined, '\\')).toEqual([]);
+  });
+});
+
+describe('decideExportDestination', () => {
+  const oldVolume = winVolume('E:\\', 0x1a2b3c4d);
+  const reLettered = winVolume('D:\\', 0x1a2b3c4d);
+  const otherVolume = winVolume('E:\\', 0xdeadbeef);
+
+  it('refuses an empty destination with a clear message', () => {
+    const decision = decideExportDestination({ usbRoot: null }, [oldVolume]);
+    expect(decision.ok).toBe(false);
+    expect(decision.error).toBe('No export destination selected.');
+  });
+
+  it('follows the picked volume to its new letter', () => {
+    const decision = decideExportDestination(
+      { usbRoot: 'E:\\Music', usbVolumeId: oldVolume.id, usbVolumeRoot: 'E:\\' },
+      [reLettered],
+      { exists: () => true }
+    );
+    expect(decision).toEqual({
+      ok: true,
+      path: 'D:\\Music',
+      changed: true,
+      volumeId: reLettered.id,
+    });
+  });
+
+  it('reports an unchanged path when the drive is still there', () => {
+    const decision = decideExportDestination(
+      { usbRoot: 'E:\\Music', usbVolumeId: oldVolume.id, usbVolumeRoot: 'E:\\' },
+      [oldVolume]
+    );
+    expect(decision).toMatchObject({ ok: true, path: 'E:\\Music', changed: false });
+  });
+
+  it('fails loudly when the picked volume is gone, even if the old path still resolves', () => {
+    // Another device took over E:\ in the meantime: writing there would export to
+    // the wrong disk, so the existence check must NOT rescue this case (#514).
+    const decision = decideExportDestination(
+      { usbRoot: 'E:\\Music', usbVolumeId: oldVolume.id, usbVolumeRoot: 'E:\\' },
+      [otherVolume],
+      { exists: () => true }
+    );
+    expect(decision.ok).toBe(false);
+    expect(decision.error).toMatch(/disconnected or reconnected under a different letter/);
+  });
+
+  it('falls back to the existence check when no volume identity is available', () => {
+    const exists = (p) => p === '\\\\server\\share\\music';
+    const atShare = decideExportDestination({ usbRoot: '\\\\server\\share\\music' }, [], {
+      exists,
+    });
+    expect(atShare).toEqual({
+      ok: true,
+      path: '\\\\server\\share\\music',
+      changed: false,
+      volumeId: null,
+    });
+
+    const gone = decideExportDestination({ usbRoot: '\\\\server\\share\\music' }, [], {
+      exists: () => false,
+    });
+    expect(gone.ok).toBe(false);
+    expect(gone.error).toMatch(/destination drive is not available/);
+  });
+
+  it('falls back to the existence check for a path outside every known volume', () => {
+    const decision = decideExportDestination({ usbRoot: 'Z:\\Music' }, [oldVolume], {
+      exists: () => true,
+    });
+    expect(decision).toMatchObject({ ok: true, path: 'Z:\\Music', changed: false });
+  });
+
+  it('works without an existence probe for a remaining volume', () => {
+    const decision = decideExportDestination(
+      { usbRoot: 'E:\\', usbVolumeId: oldVolume.id, usbVolumeRoot: 'E:\\' },
+      [oldVolume]
+    );
+    expect(decision).toMatchObject({ ok: true, path: 'E:\\' });
+  });
+});
+
+describe('detectVolumes (real platform)', () => {
+  it('returns an array of absolute mounts on this machine without throwing', () => {
+    const volumes = detectVolumes();
+    expect(Array.isArray(volumes)).toBe(true);
+    for (const volume of volumes) {
+      expect(volume.root.startsWith('/')).toBe(true);
+      expect(typeof volume.id).toBe('string');
+      expect(volume.id.length).toBeGreaterThan(0);
+    }
+    expect(findVolumeForPath(process.cwd(), volumes)).not.toBeNull();
+  });
+});
+
+describe('volume ids', () => {
+  it('uses the volume serial in hex on Windows', () => {
+    expect(makeWindowsVolumeId({ root: 'E:\\', serial: 0x1a2b3c4d })).toBe('win32:vol:1a2b3c4d');
+    expect(makeWindowsVolumeId({ root: 'E:\\', serial: 0 })).toBe('win32:root:E:\\');
+    expect(makeWindowsVolumeId({ root: 'e:\\' })).toBe('win32:root:E:\\');
+  });
+
+  it('keeps the Linux id stable across mount points', () => {
+    const a = makeLinuxVolumeId({ fileSystemType: 'VFAT', label: 'USB', totalBytes: 1000 });
+    const b = makeLinuxVolumeId({ fileSystemType: 'vfat', label: 'USB', totalBytes: 1000 });
+    expect(a).toBe(b);
+    expect(a).toBe('linux:vfat:USB:1000');
+    expect(makeLinuxVolumeId({})).toBe('linux:unknown::0');
+  });
+});
+
+describe('detectVolumes', () => {
+  it('returns [] on platforms without identity support', () => {
+    expect(detectVolumes({ platform: 'darwin' })).toEqual([]);
+  });
+
+  it('builds Windows volumes from the detected roots and their serials', () => {
+    const existsSync = (p) => p === 'C:\\' || p === 'E:\\';
+    const statSync = (p) => ({ dev: p === 'E:\\' ? 4242 : 1 });
+    const volumes = detectVolumes({ platform: 'win32', existsSync, statSync });
+
+    expect(volumes.map((v) => v.root)).toEqual(['C:\\', 'E:\\']);
+    expect(volumes[1]).toMatchObject({ id: 'win32:vol:1092', label: 'E:' });
+  });
+
+  it('falls back to a letter id when the volume cannot be stat-ed', () => {
+    const existsSync = (p) => p === 'E:\\';
+    const statSync = () => {
+      throw new Error('access denied');
+    };
+    expect(detectVolumes({ platform: 'win32', existsSync, statSync })[0].id).toBe(
+      'win32:root:E:\\'
+    );
+  });
+
+  it('parses Linux mounts, filters pseudo filesystems and reads sizes via statfs', () => {
+    const mountsText = [
+      'proc /proc proc rw 0 0',
+      'tmpfs /run tmpfs rw 0 0',
+      '/dev/nvme0n1p2 / ext4 rw 0 0',
+      '/dev/sdb1 /run/media/radex/USB vfat rw 0 0',
+    ].join('\n');
+    const statfsSync = () => ({ bsize: 512, blocks: 1000 });
+
+    const volumes = detectVolumes({ platform: 'linux', mountsText, statfsSync });
+    expect(volumes.map((v) => v.root)).toEqual(['/', '/run/media/radex/USB']);
+    expect(volumes[1]).toMatchObject({
+      id: 'linux:vfat:USB:512000',
+      device: '/dev/sdb1',
+      fileSystemType: 'vfat',
+      platform: 'linux',
+    });
+  });
+
+  it('keeps working when /proc/mounts cannot be read', () => {
+    const readMounts = () => {
+      throw new Error('ENOENT');
+    };
+    expect(detectVolumes({ platform: 'linux', readMounts })).toEqual([]);
+  });
+});

--- a/src/explorer/drives.js
+++ b/src/explorer/drives.js
@@ -1,4 +1,11 @@
 import fs from 'node:fs';
+import path from 'node:path';
+import {
+  VIRTUAL_FS_TYPES,
+  makeLinuxVolumeId,
+  makeWindowsVolumeId,
+  parseProcMounts,
+} from './volumeIdentity.js';
 
 /**
  * Enumerate present Windows drive roots ("C:\", "D:\", ...) without spawning
@@ -24,4 +31,105 @@ export function detectWindowsDrives({
     }
   }
   return roots;
+}
+
+/**
+ * Reads the volume serial number of a Windows drive root. Node reports it as
+ * `dev` on Windows (`ino` is the file index), and it stays the same when the
+ * letter changes — exactly the identity we need for hot-swap (#514).
+ */
+function readWindowsVolumeSerial(root, statSync) {
+  try {
+    const stats = statSync(root);
+    const serial = Number(stats?.dev);
+    return Number.isFinite(serial) && serial > 0 ? serial : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Windows volumes with a stable id: `[{ id, root, label, platform }]`.
+ * Falls back to a letter-based id when the drive cannot be stat'ed, so the
+ * drive still shows up (it just cannot be followed across a letter change).
+ */
+export function detectWindowsVolumes({
+  platform = process.platform,
+  existsSync = fs.existsSync,
+  statSync = fs.statSync,
+} = {}) {
+  if (platform !== 'win32') return [];
+  return detectWindowsDrives({ platform, existsSync }).map((root) => ({
+    id: makeWindowsVolumeId({ root, serial: readWindowsVolumeSerial(root, statSync) }),
+    root,
+    label: root.replace(/[\\/]+$/, ''),
+    platform,
+  }));
+}
+
+/**
+ * Linux volumes with a stable id: `[{ id, root, label, platform }]`.
+ * Mounts are read from /proc/mounts (no blkid / no shell) and pseudo
+ * filesystems are filtered out via `VIRTUAL_FS_TYPES`.
+ *
+ * @param {{mountsText?: string, readMounts?: () => string, statfsSync?: Function}} [opts]
+ */
+export function detectLinuxVolumes({
+  mountsText,
+  readMounts = () => fs.readFileSync('/proc/mounts', 'utf8'),
+  statfsSync = fs.statfsSync,
+} = {}) {
+  let text = mountsText;
+  if (text === undefined) {
+    try {
+      text = readMounts();
+    } catch {
+      // No /proc/mounts (non-Linux kernel or restricted sandbox) — no volumes.
+      return [];
+    }
+  }
+
+  const volumes = [];
+  const seen = new Set();
+  for (const entry of parseProcMounts(text)) {
+    if (VIRTUAL_FS_TYPES.has(entry.fileSystemType)) continue;
+    if (!entry.mountPoint.startsWith('/')) continue;
+
+    let totalBytes = 0;
+    try {
+      const stats = statfsSync(entry.mountPoint);
+      totalBytes = Number(stats?.bsize) * Number(stats?.blocks);
+    } catch {
+      // Unreadable mount (permissions, stale entry) — size stays 0.
+    }
+
+    const id = makeLinuxVolumeId({
+      fileSystemType: entry.fileSystemType,
+      label: path.basename(entry.mountPoint),
+      totalBytes,
+    });
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    volumes.push({
+      id,
+      root: entry.mountPoint,
+      label: entry.device || entry.mountPoint,
+      device: entry.device,
+      fileSystemType: entry.fileSystemType,
+      platform: 'linux',
+    });
+  }
+  return volumes;
+}
+
+/**
+ * Every volume we can identify on this platform, as `[{ id, root, label, ... }]`.
+ * Unknown platforms return an empty list — callers must keep working without it.
+ */
+export function detectVolumes(opts = {}) {
+  const { platform = process.platform, ...rest } = opts;
+  if (platform === 'win32') return detectWindowsVolumes({ platform, ...rest });
+  if (platform === 'linux') return detectLinuxVolumes(rest);
+  return [];
 }

--- a/src/explorer/volumeIdentity.js
+++ b/src/explorer/volumeIdentity.js
@@ -1,0 +1,337 @@
+/**
+ * Pure helpers for stable volume identity and drive-list diffing (#514).
+ *
+ * Windows hands out drive letters dynamically, so a USB stick that is unplugged
+ * and plugged back in (or plugged in after another stick) can come back under a
+ * different letter. Anything that remembers a path by letter goes stale: the
+ * Explorer shows a dead folder, linked tracks grey out and an export writes to
+ * whatever device now owns the old letter.
+ *
+ * Volumes are keyed here by a stable id instead, and paths are translated
+ * between the previous and the current root on demand.
+ *
+ * Plain string logic on purpose: no Node or Electron imports, so it is unit
+ * testable without touching the filesystem and safe to import anywhere.
+ */
+
+/**
+ * Filesystem types that carry no removable-volume identity: kernel pseudo
+ * filesystems, container overlays and snap/squashfs images. Kept in sync with
+ * the filtering in `detectLinuxVolumes()`.
+ */
+export const VIRTUAL_FS_TYPES = new Set([
+  'autofs',
+  'binfmt_misc',
+  'bpf',
+  'cgroup',
+  'cgroup2',
+  'configfs',
+  'debugfs',
+  'devpts',
+  'devtmpfs',
+  'efivarfs',
+  'fusectl',
+  'hugetlbfs',
+  'mqueue',
+  'nsfs',
+  'overlay',
+  'proc',
+  'pstore',
+  'ramfs',
+  'rpc_pipefs',
+  'securityfs',
+  'squashfs',
+  'sysfs',
+  'tmpfs',
+  'tracefs',
+]);
+
+const MOUNT_FIELD_ESCAPES = { '011': '\t', '012': '\n', '040': ' ', 134: '\\' };
+
+/** Decodes the octal escapes /proc/mounts uses for spaces, tabs and backslashes. */
+export function decodeMountField(field) {
+  return String(field ?? '').replace(
+    /\\([0-7]{3})/g,
+    (match, octal) => MOUNT_FIELD_ESCAPES[octal] ?? match
+  );
+}
+
+/**
+ * Parses /proc/mounts (or an /etc/mtab copy) into plain entries.
+ * Returns `[{ device, mountPoint, fileSystemType }]`.
+ */
+export function parseProcMounts(text) {
+  const entries = [];
+  if (!text) return entries;
+  for (const rawLine of String(text).split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 3) continue;
+    entries.push({
+      device: decodeMountField(parts[0]),
+      mountPoint: decodeMountField(parts[1]),
+      fileSystemType: parts[2],
+    });
+  }
+  return entries;
+}
+
+/** True for roots shaped like a Windows drive ("E:", "E:\", "E:/"). */
+export function isWindowsDriveRoot(root) {
+  return /^[a-zA-Z]:[\\/]?$/.test(String(root ?? ''));
+}
+
+/**
+ * True when `targetPath` is the root itself or lives below it. Windows roots are
+ * compared case-insensitively (and with or without the trailing separator).
+ */
+export function pathHasRoot(targetPath, root) {
+  if (!targetPath || !root) return false;
+  const caseInsensitive = isWindowsDriveRoot(root);
+  const path = caseInsensitive ? String(targetPath).toLowerCase() : String(targetPath);
+  const normalizedRoot = caseInsensitive ? String(root).toLowerCase() : String(root);
+
+  if (path === normalizedRoot) return true;
+  if (path === normalizedRoot.replace(/[\\/]+$/, '')) return true;
+
+  const prefix =
+    normalizedRoot.endsWith('/') || normalizedRoot.endsWith('\\')
+      ? normalizedRoot
+      : `${normalizedRoot}${caseInsensitive ? '\\' : '/'}`;
+  return path.startsWith(prefix);
+}
+
+/**
+ * Finds the volume whose root contains `targetPath`. The longest matching root
+ * wins, so a USB mount point beats the filesystem root on Linux.
+ */
+export function findVolumeForPath(targetPath, volumes = []) {
+  if (!targetPath) return null;
+  let best = null;
+  for (const volume of volumes) {
+    if (!volume || !volume.root) continue;
+    if (!pathHasRoot(targetPath, volume.root)) continue;
+    if (!best || String(volume.root).length > String(best.root).length) best = volume;
+  }
+  return best;
+}
+
+function reRootPath(targetPath, fromRoot, toRoot) {
+  if (fromRoot === toRoot) return targetPath;
+  return String(toRoot) + String(targetPath).slice(String(fromRoot).length);
+}
+
+/**
+ * Re-resolves a path against the volumes that are present right now.
+ *
+ * `previousVolumes` describes how the path was picked (for the export flow this
+ * is `[{ id: usbVolumeId, root: usbRoot }]`); the matching volume is looked up by
+ * stable id so it can be followed to its current root.
+ *
+ * @returns {{ ok: true, path: string, volumeId: string, root: string, changed: boolean }
+ *   | { ok: false, reason: 'no-path' | 'no-volume' | 'volume-missing', volumeId?: string }}
+ */
+export function resolveVolumePath(
+  targetPath,
+  currentVolumes = [],
+  previousVolumes = currentVolumes
+) {
+  if (!targetPath) return { ok: false, reason: 'no-path' };
+
+  const previous = findVolumeForPath(targetPath, previousVolumes);
+  if (previous) {
+    const current = currentVolumes.find((volume) => volume && volume.id === previous.id) ?? null;
+    if (!current) {
+      // The volume that owned the path is not present any more. Callers must not
+      // fall back to the raw path: another device may occupy it by now.
+      return { ok: false, reason: 'volume-missing', volumeId: previous.id };
+    }
+    const path = reRootPath(targetPath, previous.root, current.root);
+    return {
+      ok: true,
+      path,
+      volumeId: current.id,
+      root: current.root,
+      changed: path !== targetPath,
+    };
+  }
+
+  const match = findVolumeForPath(targetPath, currentVolumes);
+  if (!match) return { ok: false, reason: 'no-volume' };
+  return { ok: true, path: targetPath, volumeId: match.id, root: match.root, changed: false };
+}
+
+/**
+ * Decides which directory an export may write to right now (#514).
+ *
+ * The dialog picks a folder and remembers the volume it lived on; by the time the
+ * export starts the drive may have been replugged under another letter. This
+ * returns the resolved path, or a refusal with a user-facing message.
+ *
+ * @param {{usbRoot?: string, usbVolumeId?: string|null, usbVolumeRoot?: string|null}} target
+ *   the destination as the renderer remembers it
+ * @param {object[]} currentVolumes volumes present right now (`detectVolumes()`)
+ * @param {{exists?: (p: string) => boolean}} [opts] existence probe used when the
+ *   path cannot be tied to a known volume
+ * @returns {{ ok: true, path: string, changed: boolean, volumeId: string|null }
+ *   | { ok: false, error: string }}
+ */
+export function decideExportDestination(
+  { usbRoot, usbVolumeId = null, usbVolumeRoot = null } = {},
+  currentVolumes = [],
+  { exists } = {}
+) {
+  if (!usbRoot) return { ok: false, error: 'No export destination selected.' };
+
+  // The volume root captured at pick time matters because the stored path can
+  // point at a subfolder: re-rooting must start from the volume root, otherwise
+  // `E:\Music` would collapse to `D:\` instead of becoming `D:\Music`.
+  const previousVolumes = usbVolumeId
+    ? [{ id: usbVolumeId, root: usbVolumeRoot || usbRoot }]
+    : currentVolumes;
+  const resolved = resolveVolumePath(usbRoot, currentVolumes, previousVolumes);
+
+  if (resolved.ok) {
+    return {
+      ok: true,
+      path: resolved.path,
+      changed: resolved.changed,
+      volumeId: resolved.volumeId ?? null,
+    };
+  }
+
+  if (resolved.reason === 'volume-missing') {
+    // The volume that owned this path is gone. Never fall back to the raw path:
+    // another device may already have taken the old letter.
+    return {
+      ok: false,
+      error:
+        'Export failed: the drive was disconnected or reconnected under a different letter. ' +
+        'Re-select the destination drive and try again.',
+    };
+  }
+
+  // `no-volume`: the path could not be tied to a volume at all (volume identity
+  // is unavailable on this platform, or the folder is a UNC/network share). There
+  // is nothing to follow, so keep the plain existence check exports used before.
+  if (typeof exists === 'function' && exists(usbRoot)) {
+    return { ok: true, path: usbRoot, changed: false, volumeId: null };
+  }
+
+  return {
+    ok: false,
+    error: 'Export failed: the destination drive is not available. Re-connect it and try again.',
+  };
+}
+
+/**
+ * Compares two volume snapshots (matched by stable id).
+ *
+ * @returns {{
+ *   added: object[], removed: object[], unchanged: object[],
+ *   letterChanged: { id: string, from: string, to: string, volume: object }[],
+ *   changed: boolean
+ * }}
+ */
+export function diffVolumes(previousVolumes = [], nextVolumes = []) {
+  const previousById = new Map(previousVolumes.map((volume) => [volume.id, volume]));
+  const nextById = new Map(nextVolumes.map((volume) => [volume.id, volume]));
+
+  const added = [];
+  const removed = [];
+  const unchanged = [];
+  const letterChanged = [];
+
+  for (const volume of nextVolumes) {
+    if (!previousById.has(volume.id)) added.push(volume);
+  }
+
+  for (const previous of previousVolumes) {
+    const current = nextById.get(previous.id);
+    if (!current) {
+      removed.push(previous);
+    } else if (current.root !== previous.root) {
+      letterChanged.push({
+        id: previous.id,
+        from: previous.root,
+        to: current.root,
+        volume: current,
+      });
+    } else {
+      unchanged.push(current);
+    }
+  }
+
+  return {
+    added,
+    removed,
+    unchanged,
+    letterChanged,
+    changed: added.length > 0 || removed.length > 0 || letterChanged.length > 0,
+  };
+}
+
+/**
+ * Turns the letter changes reported by `diffVolumes()` into concrete prefixes
+ * for re-keying stored linked-track paths (#514).
+ *
+ * A linked track keeps its absolute path, so when its drive comes back under a
+ * different letter every stored row is stale. The prefixes carry a trailing
+ * separator so a root like `E:\` cannot swallow `E:\Extra\...` — matching the
+ * naked root would corrupt paths that live beside the volume.
+ *
+ * @param {{from: string, to: string}[]} letterChanged entries from `diffVolumes()`
+ * @param {string} [separator] platform path separator (`path.sep`)
+ * @returns {{ from: string, to: string, fromPrefix: string, toPrefix: string }[]}
+ */
+export function planLinkedTrackRekeys(letterChanged = [], separator = '/') {
+  const sep = String(separator || '/');
+  const endsWithSep = (value) => value.endsWith('/') || value.endsWith('\\');
+  const plans = [];
+  const seen = new Set();
+
+  for (const change of letterChanged) {
+    const from = String(change?.from ?? '');
+    const to = String(change?.to ?? '');
+    if (!from || !to || from === to) continue;
+    const key = `${from}\u0000${to}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    plans.push({
+      from,
+      to,
+      fromPrefix: endsWithSep(from) ? from : from + sep,
+      toPrefix: endsWithSep(to) ? to : to + sep,
+    });
+  }
+
+  return plans;
+}
+
+/**
+ * Stable id for a Windows volume. The volume serial number survives a letter
+ * change; the raw root is only a fallback for volumes we cannot stat (e.g. an
+ * inaccessible card reader), which then cannot be followed across a swap.
+ */
+export function makeWindowsVolumeId({ root, serial } = {}) {
+  const value = Number(serial);
+  if (serial !== null && serial !== undefined && Number.isFinite(value) && value > 0) {
+    return `win32:vol:${value.toString(16)}`;
+  }
+  return `win32:root:${String(root ?? '').toUpperCase()}`;
+}
+
+/**
+ * Stable id for a Linux volume. Derived from the filesystem type, the label
+ * (mount point basename, which udev usually takes from the stick itself) and the
+ * total size, so the same stick keeps its id when it is remounted elsewhere.
+ * Two identical sticks mounted at the same time are indistinguishable - a
+ * documented limitation, not a crash.
+ */
+export function makeLinuxVolumeId({ fileSystemType, label, totalBytes } = {}) {
+  const type = String(fileSystemType ?? 'unknown').toLowerCase();
+  const size = Number(totalBytes) > 0 ? Number(totalBytes) : 0;
+  return `linux:${type}:${String(label ?? '')}:${size}`;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -137,7 +137,13 @@ import {
 } from './deps.js';
 import { initLogger, getLogDir, initRendererLogger, logRendererMessage } from './logger.js';
 import { detectFilesystem, formatDrive, describeFilesystem } from './usb/usbUtils.js';
-import { detectWindowsDrives } from './explorer/drives.js';
+import { detectWindowsDrives, detectVolumes } from './explorer/drives.js';
+import {
+  decideExportDestination,
+  diffVolumes,
+  findVolumeForPath,
+  planLinkedTrackRekeys,
+} from './explorer/volumeIdentity.js';
 import { writeAnlz, getAnlzFolder } from './audio/anlzWriter.js';
 import { writeSettingFiles } from './usb/settingWriter.js';
 import { writePdb } from './usb/pdbWriter.js';
@@ -286,6 +292,11 @@ function createWindow() {
 
   global.mainWindow = mainWindow; // make accessible to workers
   mainWindow.maximize();
+
+  // Drives are usually swapped while the app is in the background, so make the
+  // common "plug the stick in and come back" case instant instead of waiting for
+  // the next poll tick (#514).
+  mainWindow.on('focus', () => checkDrivesChanged());
 
   // Native right-click context menu for editable inputs and text selections
   mainWindow.webContents.on('context-menu', (_e, params) => {
@@ -469,6 +480,7 @@ async function initApp() {
   await startMediaServer();
   console.log('Creating window.');
   createWindow();
+  startDriveWatcher();
 
   // Skip dep download in E2E tests — binary not needed for UI tests and the
   // pending download blocks app.close(), causing afterEach timeouts.
@@ -1844,146 +1856,253 @@ ipcMain.handle('get-explorer-track-metadata', async (_, filePath) => {
   }
 });
 
-ipcMain.handle('export-explorer-to-usb', async (_, { filePaths, usbRoot, playlistName }) => {
-  try {
-    const total = filePaths.length;
-    send('export-explorer-progress', { msg: `Exporting ${total} tracks to USB…`, pct: 0 });
-
-    const usedNames = new Map();
-    const pdbTracks = [];
-    const anlzPaths = new Map();
-
-    for (let i = 0; i < filePaths.length; i++) {
-      const srcPath = filePaths[i];
-      const ext = path.extname(srcPath);
-
-      // Extract metadata
-      let meta = {
-        title: path.basename(srcPath, ext),
-        artist: '',
-        album: '',
-        bpm: null,
-        key_raw: '',
-        duration: 0,
-        bitrate: 0,
-      };
-      try {
-        const { ffprobe: runFfprobe } = await import('./audio/ffmpeg.js');
-        const data = await runFfprobe(srcPath);
-        const tags = data.format?.tags || {};
-        const stream = data.streams?.find((s) => s.codec_type === 'audio') || {};
-        const bpmTag = tags.bpm || tags.BPM || tags.TBPM || tags['tbpm'];
-        meta = {
-          title: tags.title || path.basename(srcPath, ext),
-          artist: tags.artist || '',
-          album: tags.album || '',
-          bpm: bpmTag ? parseFloat(bpmTag) || null : null,
-          key_raw: tags.key || tags.KEY || tags.initialkey || tags.INITIALKEY || '',
-          duration: parseFloat(data.format?.duration) || 0,
-          bitrate: parseInt(stream.bit_rate || data.format?.bit_rate || 0, 10) || 0,
-        };
-      } catch {}
-
-      // Copy to USB /music/
-      const rawBase =
-        [meta.artist, meta.title].filter(Boolean).join(' - ') || path.basename(srcPath, ext);
-      const safeBase = rawBase.replace(/[<>:"/\\|?*\x00-\x1f]/g, '_').trim();
-      let filename = `${safeBase}${ext}`;
-      let n = 1;
-      while (usedNames.has(filename.toLowerCase())) {
-        filename = `${safeBase} (${n++})${ext}`;
-      }
-      usedNames.set(filename.toLowerCase(), true);
-
-      const destDir = path.join(usbRoot, 'music');
-      fs.mkdirSync(destDir, { recursive: true });
-      const destPath = path.join(destDir, filename);
-      if (!fs.existsSync(destPath)) fs.copyFileSync(srcPath, destPath);
-      const usbFilePath = `/music/${filename}`;
-
-      // Write minimal ANLZ (path + beatgrid only, no waveform for speed)
-      try {
-        const anlzDat = await writeAnlz({
-          usbFilePath,
-          sourceFilePath: null,
-          beatgrid: null,
-          bpm: meta.bpm || 0,
-          beatgridOffset: 0,
-          usbRoot,
-          ffmpegPath: getFfmpegRuntimePath(),
-          cuePoints: [],
-        });
-        anlzPaths.set(i, anlzDat);
-      } catch {}
-
-      let fileSize = 0;
-      try {
-        fileSize = fs.statSync(destPath).size;
-      } catch {}
-
-      pdbTracks.push({
-        id: i + 1,
-        title: meta.title,
-        artist: meta.artist,
-        album: meta.album,
-        duration: meta.duration,
-        bpm: meta.bpm || 0,
-        key_raw: meta.key_raw,
-        file_path: usbFilePath,
-        track_number: i + 1,
-        year: '',
-        label: '',
-        genres: [],
-        file_size: fileSize,
-        bitrate: meta.bitrate,
-        comments: '',
-        rating: 0,
-        analyzePath: anlzPaths.get(i) || '',
-      });
-
-      const pct = Math.round(((i + 1) / total) * 90);
-      send('export-explorer-progress', { msg: `Copying ${i + 1}/${total}: ${filename}`, pct });
-    }
-
-    send('export-explorer-progress', { msg: 'Writing PDB database…', pct: 92 });
-
-    const pdbPlaylists = playlistName
-      ? [{ id: 1, name: playlistName, track_ids: pdbTracks.map((t) => t.id) }]
-      : [];
-
-    const outputPath = path.join(usbRoot, 'PIONEER', 'rekordbox', 'export.pdb');
-    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-    writePdb({ tracks: pdbTracks, playlists: pdbPlaylists }, outputPath);
-
-    send('export-explorer-progress', { msg: 'Writing settings files…', pct: 96 });
+ipcMain.handle(
+  'export-explorer-to-usb',
+  async (_, { filePaths, usbRoot, usbVolumeId = null, usbVolumeRoot = null, playlistName }) => {
     try {
-      await writeSettingFiles(usbRoot);
-    } catch {}
+      // Resolve the drive's CURRENT root first: the user may have replugged the
+      // stick between picking it and pressing export (#514).
+      usbRoot = resolveExportRoot(usbRoot, usbVolumeId, usbVolumeRoot);
+      const total = filePaths.length;
+      send('export-explorer-progress', { msg: `Exporting ${total} tracks to USB…`, pct: 0 });
 
-    send('export-explorer-progress', null);
-    return { ok: true, trackCount: pdbTracks.length, usbRoot };
-  } catch (err) {
-    send('export-explorer-progress', null);
-    return { ok: false, error: err.message };
+      const usedNames = new Map();
+      const pdbTracks = [];
+      const anlzPaths = new Map();
+
+      for (let i = 0; i < filePaths.length; i++) {
+        const srcPath = filePaths[i];
+        const ext = path.extname(srcPath);
+
+        // Extract metadata
+        let meta = {
+          title: path.basename(srcPath, ext),
+          artist: '',
+          album: '',
+          bpm: null,
+          key_raw: '',
+          duration: 0,
+          bitrate: 0,
+        };
+        try {
+          const { ffprobe: runFfprobe } = await import('./audio/ffmpeg.js');
+          const data = await runFfprobe(srcPath);
+          const tags = data.format?.tags || {};
+          const stream = data.streams?.find((s) => s.codec_type === 'audio') || {};
+          const bpmTag = tags.bpm || tags.BPM || tags.TBPM || tags['tbpm'];
+          meta = {
+            title: tags.title || path.basename(srcPath, ext),
+            artist: tags.artist || '',
+            album: tags.album || '',
+            bpm: bpmTag ? parseFloat(bpmTag) || null : null,
+            key_raw: tags.key || tags.KEY || tags.initialkey || tags.INITIALKEY || '',
+            duration: parseFloat(data.format?.duration) || 0,
+            bitrate: parseInt(stream.bit_rate || data.format?.bit_rate || 0, 10) || 0,
+          };
+        } catch {}
+
+        // Copy to USB /music/
+        const rawBase =
+          [meta.artist, meta.title].filter(Boolean).join(' - ') || path.basename(srcPath, ext);
+        const safeBase = rawBase.replace(/[<>:"/\\|?*\x00-\x1f]/g, '_').trim();
+        let filename = `${safeBase}${ext}`;
+        let n = 1;
+        while (usedNames.has(filename.toLowerCase())) {
+          filename = `${safeBase} (${n++})${ext}`;
+        }
+        usedNames.set(filename.toLowerCase(), true);
+
+        const destDir = path.join(usbRoot, 'music');
+        fs.mkdirSync(destDir, { recursive: true });
+        const destPath = path.join(destDir, filename);
+        if (!fs.existsSync(destPath)) fs.copyFileSync(srcPath, destPath);
+        const usbFilePath = `/music/${filename}`;
+
+        // Write minimal ANLZ (path + beatgrid only, no waveform for speed)
+        try {
+          const anlzDat = await writeAnlz({
+            usbFilePath,
+            sourceFilePath: null,
+            beatgrid: null,
+            bpm: meta.bpm || 0,
+            beatgridOffset: 0,
+            usbRoot,
+            ffmpegPath: getFfmpegRuntimePath(),
+            cuePoints: [],
+          });
+          anlzPaths.set(i, anlzDat);
+        } catch {}
+
+        let fileSize = 0;
+        try {
+          fileSize = fs.statSync(destPath).size;
+        } catch {}
+
+        pdbTracks.push({
+          id: i + 1,
+          title: meta.title,
+          artist: meta.artist,
+          album: meta.album,
+          duration: meta.duration,
+          bpm: meta.bpm || 0,
+          key_raw: meta.key_raw,
+          file_path: usbFilePath,
+          track_number: i + 1,
+          year: '',
+          label: '',
+          genres: [],
+          file_size: fileSize,
+          bitrate: meta.bitrate,
+          comments: '',
+          rating: 0,
+          analyzePath: anlzPaths.get(i) || '',
+        });
+
+        const pct = Math.round(((i + 1) / total) * 90);
+        send('export-explorer-progress', { msg: `Copying ${i + 1}/${total}: ${filename}`, pct });
+      }
+
+      send('export-explorer-progress', { msg: 'Writing PDB database…', pct: 92 });
+
+      const pdbPlaylists = playlistName
+        ? [{ id: 1, name: playlistName, track_ids: pdbTracks.map((t) => t.id) }]
+        : [];
+
+      const outputPath = path.join(usbRoot, 'PIONEER', 'rekordbox', 'export.pdb');
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+      writePdb({ tracks: pdbTracks, playlists: pdbPlaylists }, outputPath);
+
+      send('export-explorer-progress', { msg: 'Writing settings files…', pct: 96 });
+      try {
+        await writeSettingFiles(usbRoot);
+      } catch {}
+
+      send('export-explorer-progress', null);
+      return { ok: true, trackCount: pdbTracks.length, usbRoot };
+    } catch (err) {
+      send('export-explorer-progress', null);
+      return { ok: false, error: err.message };
+    }
   }
-});
+);
 
-// ── File Explorer v2 IPC ───────────────────────────────────────────────────────
+// ── Drive hot-swap detection (#514) ────────────────────────────────────────────
+// Windows can hand a replugged USB stick a different letter, which makes every
+// path the UI remembered stale. Poll the volume list (and re-check on window
+// focus), diff it against the previous snapshot by stable volume id and push the
+// result to the renderer so the drive picker, the open folder and the export
+// target follow the stick instead of the letter.
 
-ipcMain.handle('get-computer-root', () => {
+const DRIVE_POLL_INTERVAL_MS = 7000;
+
+let driveWatcher = null; // { timer, volumes }
+
+/**
+ * Current drive roots, home directory and identified volumes. Shared by the
+ * IPC handlers and the watcher so both always agree on the same snapshot.
+ */
+function scanDrives() {
+  const platform = process.platform;
   const home = os.homedir();
   let root;
   let drives = [];
-  if (process.platform === 'win32') {
+  if (platform === 'win32') {
     root = path.parse(home).root || 'C:\\';
-    // #473: enumerate ALL present drives so the Explorer can switch from C:
+    // #473: enumerate ALL present drives so the Explorer can switch from C:\
     // to any other volume (D:, E:, ...).
-    drives = detectWindowsDrives();
+    drives = detectWindowsDrives({ platform });
     if (!drives.includes(root)) drives.unshift(root);
   } else {
     root = '/';
   }
-  return { root, home, drives };
+  return { root, home, drives, volumes: detectVolumes({ platform }) };
+}
+
+/** Re-scans and notifies the renderer when the drive landscape changed. */
+function checkDrivesChanged() {
+  if (!driveWatcher) return null;
+  let snapshot;
+  try {
+    snapshot = scanDrives();
+  } catch (err) {
+    console.error('[drives] rescan failed:', err.message);
+    return null;
+  }
+  const diff = diffVolumes(driveWatcher.volumes, snapshot.volumes);
+  if (!diff.changed) return null;
+  driveWatcher.volumes = snapshot.volumes;
+
+  // A stick that came back under another letter leaves every linked-track path
+  // stale, so re-point the stored rows before the renderer refreshes (#514). The
+  // new root is pre-allowed too, so the media server can serve from it without
+  // the user having to reopen the Explorer.
+  const rekeys = planLinkedTrackRekeys(diff.letterChanged, path.sep);
+  let rekeyedTracks = 0;
+  for (const rekey of rekeys) {
+    rekeyedTracks += remapTracksByPrefix(rekey.fromPrefix, rekey.toPrefix);
+    if (!explorerAllowedBases.includes(rekey.to)) explorerAllowedBases.push(rekey.to);
+  }
+  if (rekeyedTracks > 0) {
+    console.log(`[drives] re-pointed ${rekeyedTracks} linked track path(s) after a letter change`);
+    send('library-updated');
+  }
+
+  const payload = {
+    drives: snapshot.drives,
+    volumes: snapshot.volumes,
+    added: diff.added,
+    removed: diff.removed,
+    letterChanged: diff.letterChanged,
+  };
+  console.log(
+    `[drives] change: +${diff.added.length} -${diff.removed.length} ` +
+      `renamed=${diff.letterChanged.map((c) => `${c.from}->${c.to}`).join(',') || 'none'}`
+  );
+  if (global.mainWindow) global.mainWindow.webContents.send('drives-updated', payload);
+  return payload;
+}
+
+function startDriveWatcher() {
+  if (driveWatcher) return;
+  driveWatcher = { timer: null, volumes: scanDrives().volumes };
+  // A poll keeps working when the app is unfocused (exports keep running there);
+  // the window focus hook below makes the common plug-in case instant.
+  driveWatcher.timer = setInterval(checkDrivesChanged, DRIVE_POLL_INTERVAL_MS);
+  if (typeof driveWatcher.timer.unref === 'function') driveWatcher.timer.unref();
+}
+
+/**
+ * Resolves an export destination right before anything is written (#514).
+ * `usbRoot` is the path the user picked (it may still carry the old letter) and
+ * `usbVolumeId` is the stable id captured at pick time, so the drive can be
+ * followed across a letter change. Throws when the volume is gone rather than
+ * writing into a path some other device may own by now.
+ */
+function resolveExportRoot(usbRoot, usbVolumeId = null, usbVolumeRoot = null) {
+  const { volumes } = scanDrives();
+  const decision = decideExportDestination({ usbRoot, usbVolumeId, usbVolumeRoot }, volumes, {
+    exists: fs.existsSync,
+  });
+
+  if (decision.ok) {
+    if (decision.changed) {
+      console.log(`[export] drive letter changed, using ${decision.path} instead of ${usbRoot}`);
+    }
+    return decision.path;
+  }
+
+  throw new Error(decision.error);
+}
+
+// ── File Explorer v2 IPC ───────────────────────────────────────────────────────
+
+ipcMain.handle('get-computer-root', () => scanDrives());
+
+// Stable volume id of the drive that holds `targetPath`, so the export flow can
+// follow a volume instead of the letter it had when the folder was picked (#514).
+ipcMain.handle('get-volume-for-path', (_, targetPath) => {
+  const volume = findVolumeForPath(targetPath, scanDrives().volumes);
+  return volume ? { id: volume.id, root: volume.root } : null;
 });
 
 ipcMain.handle('get-tracks-by-paths', (_, filePaths) => {
@@ -2309,9 +2428,15 @@ ipcMain.handle(
       useNormalized = false,
       targetDevice = null,
       forceMp3 = false,
+      usbVolumeId = null,
+      usbVolumeRoot = null,
     }
   ) => {
     try {
+      // Follow the volume, not the letter it had when it was picked: the drive
+      // may have come back under a different letter, and a missing drive must
+      // fail loudly instead of writing to a stale path (#514).
+      usbRoot = resolveExportRoot(usbRoot, usbVolumeId, usbVolumeRoot);
       const targetLufs = useNormalized ? Number(getSetting('normalize_target_lufs', '-9')) : null;
       const ids = playlistIds?.length ? playlistIds : playlistId ? [playlistId] : null;
       const allPlaylists = ids?.length
@@ -2472,9 +2597,14 @@ ipcMain.handle(
       useNormalized = false,
       targetDevice = null,
       forceMp3 = false,
+      usbVolumeId = null,
+      usbVolumeRoot = null,
     }
   ) => {
     try {
+      // Re-resolve the destination from the volume id before writing anything, so
+      // a letter change is followed and a disconnected drive fails loudly (#514).
+      usbRoot = resolveExportRoot(usbRoot, usbVolumeId, usbVolumeRoot);
       const targetLufs = useNormalized ? Number(getSetting('normalize_target_lufs', '-9')) : null;
       const ids = playlistIds?.length ? playlistIds : playlistId ? [playlistId] : null;
       const allPlaylists = ids?.length

--- a/src/preload.js
+++ b/src/preload.js
@@ -256,6 +256,15 @@ contextBridge.exposeInMainWorld('api', {
 
   // File Explorer
   getComputerRoot: () => ipcRenderer.invoke('get-computer-root'),
+  // Stable volume id of the drive holding a path (#514) — lets the export flow
+  // follow the volume when Windows reassigns its letter.
+  getVolumeForPath: (targetPath) => ipcRenderer.invoke('get-volume-for-path', targetPath),
+  // Fired when a drive is added, removed or comes back under another letter.
+  onDrivesUpdated: (cb) => {
+    const handler = (_, data) => cb(data);
+    ipcRenderer.on('drives-updated', handler);
+    return () => ipcRenderer.removeListener('drives-updated', handler);
+  },
   browseDirectory: (dirPath) => ipcRenderer.invoke('browse-directory', dirPath),
   selectExplorerFolder: () => ipcRenderer.invoke('select-explorer-folder'),
   getTracksByPaths: (filePaths) => ipcRenderer.invoke('get-tracks-by-paths', filePaths),

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -50,6 +50,7 @@ export default defineConfig({
             'src/__tests__/pdbWriter.test.js',
             'src/__tests__/deviceFormats.test.js',
             'src/__tests__/drives.test.js',
+            'src/__tests__/volumeIdentity.test.js',
             'src/__tests__/ffmpegConvert.test.js',
             'src/__tests__/exportReuse.test.js',
           ],


### PR DESCRIPTION
Closes #514

## What changed
- **Stable volume identity** (`src/explorer/volumeIdentity.js`, new): pure helpers `makeWindowsVolumeId` / `makeLinuxVolumeId` / `parseProcMounts` / `diffVolumes` / `findVolumeForPath` / `resolveVolumePath` / `planLinkedTrackRekeys` / `decideExportDestination`. Windows id = volume serial (`fs.statSync(root).dev`, survives a letter change, letter-root fallback); Linux id = `fstype:mount-label:size`, re-parsed from `/proc/mounts` with pseudo filesystems filtered out.
- `src/explorer/drives.js`: `detectVolumes()` returns `[{id, root, label, platform}]` for both platforms.
- `src/main.js`: 7 s poll (`startDriveWatcher`, unref'd) plus a window `focus` re-check. On change it diffs by volume id, re-points linked track paths through `remapTracksByPrefix`, pre-allows the new root for the media server and pushes a new `drives-updated` event (added / removed / letterChanged). New invokes `get-volume-for-path` and `get-computer-root` now also returns `volumes`.
- Export safety: `ExportModal` captures `{id, root}` and passes `usbVolumeId` / `usbVolumeRoot`; `resolveExportRoot()` re-resolves the volume's current letter right before writing and throws a clear "drive disconnected / reconnected under a different letter" error instead of writing to a stale path. The dialog also follows a rename while it is open.
- Renderer: `FileExplorerView` rewrites the open folder + favourites via `applyVolumeRenames`; `PlayerContext` re-requests unavailable linked tracks on `drives-updated`. `HelpView` documents it (grep-verified).

## Verification
- root `npx vitest run`: 21 files, 533 tests passed
- renderer `npx vitest run src/__tests__`: 19 files, 212 tests passed
- root `npm run lint` and renderer `npm run lint`: 0 errors (renderer keeps its 6 pre-existing warnings)

## Limits (stated, not hidden)
Windows-only paths (volume serial, real letter change) are covered by unit tests with injected fakes only; confirming the serial behaviour and a real swap needs a Windows machine. Two identical Linux sticks (same fs type + label + size) are indistinguishable, documented in the code. No `WM_DEVICECHANGE` hook: a poll + focus re-check was the approach the issue allowed.