### PR TITLE
feat(tidal): browse and download account collections

### DIFF
--- a/renderer/src/HelpView.jsx
+++ b/renderer/src/HelpView.jsx
@@ -81,6 +81,9 @@ const SECTIONS = [
     items: [
       'Cloud Search looks up tracks on YouTube and TIDAL: pick the source and type (track, album, playlist, ...), search, select the results and download them into the library - progress is shown for every entry.',
       'TIDAL downloads need a one-time login: the TIDAL view starts a device-login flow (URL to open and confirm in your browser); the session is stored locally afterwards.',
+      'The TIDAL view also lists your own account collections in the "My collections" panel: Playlists, Mixes & Radio (including My Daily Discovery and the video mixes) and Favorites (tracks, albums, artists, videos). The ↓ button next to a collection downloads it in one go.',
+      'Downloading a collection saves its tracks to a playlist of the same name. Video items are skipped - DjManager imports audio tracks only.',
+      'Paste a TIDAL URL instead when you want to pick individual tracks first: albums and playlists open a selection step, single tracks and mixes start downloading straight away.',
       'The Download view lists supported sites (YouTube, SoundCloud, Bandcamp, Mixcloud, Vimeo, Twitch): paste a link to download that video, album or playlist through yt-dlp into the library.',
       'When a site requires a login or blocks downloads (403), set the yt-dlp cookies to your logged-in browser profile in Settings.',
     ],

--- a/renderer/src/TidalCollectionsPanel.css
+++ b/renderer/src/TidalCollectionsPanel.css
@@ -1,0 +1,183 @@
+/* ── Account collections tree (TIDAL view) ───────────────────────────────── */
+
+.tidal-collections {
+  flex: 0 0 300px;
+  max-width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 6px;
+  background: var(--bg-secondary, #1a1a1a);
+  overflow-y: auto;
+  max-height: min(520px, 60vh);
+}
+
+.tidal-collections-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border, #2a2a2a);
+  position: sticky;
+  top: 0;
+  background: var(--bg-secondary, #1a1a1a);
+  z-index: 1;
+}
+
+.tidal-collections-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary, #ddd);
+}
+
+.tidal-collections-reload {
+  background: none;
+  border: none;
+  color: var(--text-secondary, #666);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.tidal-collections-reload:hover:not(:disabled) {
+  color: var(--text-secondary, #999);
+}
+
+.tidal-collections-reload:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.tidal-collections-status {
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+}
+
+.tidal-tree {
+  padding-bottom: 6px;
+}
+
+.tidal-tree-group-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 5px 10px;
+  background: none;
+  border: none;
+  color: var(--text-primary, #ddd);
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tidal-tree-group-head:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.tidal-tree-caret,
+.tidal-tree-toggle {
+  flex: 0 0 12px;
+  width: 12px;
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-secondary, #777);
+  font-size: 10px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.tidal-tree-toggle:disabled {
+  cursor: default;
+  color: var(--text-secondary, #444);
+}
+
+.tidal-tree-group-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tidal-tree-node {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+}
+
+.tidal-tree-node:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.tidal-tree-label {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+}
+
+.tidal-tree-title {
+  font-size: 12px;
+  color: var(--text-primary, #ddd);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tidal-tree-subtitle {
+  font-size: 10px;
+  color: var(--text-secondary, #888);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tidal-tree-count {
+  font-size: 10px;
+  color: var(--text-secondary, #666);
+  white-space: nowrap;
+}
+
+.tidal-tree-download {
+  flex: 0 0 auto;
+  background: none;
+  border: 1px solid var(--border, #333);
+  border-radius: 4px;
+  color: var(--text-secondary, #999);
+  font-size: 12px;
+  line-height: 1;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+
+.tidal-tree-download:hover:not(:disabled) {
+  color: #fff;
+  border-color: var(--accent, #7c5cfc);
+}
+
+.tidal-tree-download:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.tidal-collections-note {
+  padding: 6px 12px 8px;
+  border-top: 1px solid var(--border, #2a2a2a);
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--text-secondary, #777);
+}

--- a/renderer/src/TidalCollectionsPanel.jsx
+++ b/renderer/src/TidalCollectionsPanel.jsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import './TidalCollectionsPanel.css';
+
+// Group order mirrors tidal-dl-ng's own collection tree.
+const GROUP_ORDER = ['playlists', 'mixes', 'favorites'];
+
+const GROUP_LABELS = {
+  playlists: 'Playlists',
+  mixes: 'Mixes & Radio',
+  favorites: 'Favorites',
+};
+
+function groupRank(group) {
+  const idx = GROUP_ORDER.indexOf(group);
+  return idx === -1 ? GROUP_ORDER.length : idx;
+}
+
+/** Stable key for one collection row (ids are only unique per type). */
+function collectionKey(col) {
+  return `${col.type}:${col.id}`;
+}
+
+/**
+ * Tree panel listing the logged-in TIDAL account's collections (playlists,
+ * mixes & radio including My Daily Discovery and video mixes, favorites) with
+ * a download action per collection. Loads through window.api.tidalListCollections.
+ *
+ * Branches start expanded: the user asked for the account tree, and collapsing
+ * is remembered per branch in the local `collapsed` set.
+ */
+export default function TidalCollectionsPanel({ onDownload, busyKey, disabled = false }) {
+  const [collections, setCollections] = useState(null);
+  const [warnings, setWarnings] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [collapsed, setCollapsed] = useState(() => new Set());
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await window.api.tidalListCollections();
+      if (!res?.ok) {
+        setError(res?.error ?? 'Could not load your TIDAL collections.');
+        setCollections([]);
+        setWarnings([]);
+      } else {
+        setCollections(res.collections ?? []);
+        setWarnings(res.warnings ?? []);
+      }
+    } catch (err) {
+      setError(err?.message ?? 'Could not load your TIDAL collections.');
+      setCollections([]);
+      setWarnings([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const groups = useMemo(() => {
+    const byGroup = new Map();
+    for (const col of collections ?? []) {
+      const list = byGroup.get(col.group) ?? [];
+      list.push(col);
+      byGroup.set(col.group, list);
+    }
+    return [...byGroup.entries()]
+      .sort((a, b) => groupRank(a[0]) - groupRank(b[0]))
+      .map(([key, items]) => ({
+        key,
+        label: GROUP_LABELS[key] ?? key,
+        items,
+      }));
+  }, [collections]);
+
+  const isOpen = useCallback((key) => !collapsed.has(key), [collapsed]);
+
+  const toggle = useCallback((key) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const renderNode = (col, depth) => {
+    const key = collectionKey(col);
+    const children = (collections ?? []).filter((c) => c.parentId === col.id);
+    const open = isOpen(key);
+    const busy = busyKey === key;
+
+    return (
+      <div key={key} className="tidal-tree-branch">
+        <div
+          className={`tidal-tree-node${depth > 0 ? ' tidal-tree-node--child' : ''}`}
+          style={{ paddingLeft: 8 + depth * 14 }}
+        >
+          <button
+            type="button"
+            className="tidal-tree-toggle"
+            onClick={() => children.length > 0 && toggle(key)}
+            disabled={children.length === 0}
+            aria-expanded={children.length > 0 ? open : undefined}
+            aria-label={open ? `Collapse ${col.title}` : `Expand ${col.title}`}
+          >
+            {children.length === 0 ? '·' : open ? '▾' : '▸'}
+          </button>
+          <button
+            type="button"
+            className="tidal-tree-label"
+            onClick={() => children.length > 0 && toggle(key)}
+            title={col.subtitle || col.title}
+          >
+            <span className="tidal-tree-title">{col.title}</span>
+            {col.subtitle ? <span className="tidal-tree-subtitle">{col.subtitle}</span> : null}
+          </button>
+          {col.count > 0 ? <span className="tidal-tree-count">{col.count}</span> : null}
+          <button
+            type="button"
+            className="tidal-tree-download"
+            onClick={() => onDownload(col)}
+            disabled={disabled || busy}
+            title={`Download ${col.title}`}
+            aria-label={`Download ${col.title}`}
+          >
+            {busy ? '…' : '↓'}
+          </button>
+        </div>
+        {children.length > 0 && open ? (
+          <div className="tidal-tree-children">
+            {children.map((child) => renderNode(child, depth + 1))}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
+  return (
+    <div className="tidal-collections">
+      <div className="tidal-collections-head">
+        <span className="tidal-collections-title">My collections</span>
+        <button
+          type="button"
+          className="tidal-collections-reload"
+          onClick={load}
+          disabled={loading}
+        >
+          Reload
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="tidal-collections-status">Loading collections…</div>
+      ) : error ? (
+        <div className="dl-fetch-error" style={{ padding: '4px 12px 8px' }}>
+          ✗ {error}
+        </div>
+      ) : groups.length === 0 ? (
+        <div className="tidal-collections-status">No collections found on this account.</div>
+      ) : (
+        <div className="tidal-tree" role="tree">
+          {groups.map((group) => {
+            const groupKey = `group:${group.key}`;
+            const groupOpen = !collapsed.has(groupKey);
+            return (
+              <div key={group.key} className="tidal-tree-group">
+                <button
+                  type="button"
+                  className="tidal-tree-group-head"
+                  onClick={() => toggle(groupKey)}
+                  aria-expanded={groupOpen}
+                >
+                  <span className="tidal-tree-caret">{groupOpen ? '▾' : '▸'}</span>
+                  <span className="tidal-tree-group-title">{group.label}</span>
+                  <span className="tidal-tree-count">{group.items.length}</span>
+                </button>
+                {groupOpen ? (
+                  <div className="tidal-tree-children">
+                    {group.items.filter((col) => !col.parentId).map((col) => renderNode(col, 0))}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!loading && !error && warnings.length > 0 && (
+        <div className="tidal-collections-status" title={warnings.join('\n')}>
+          Some collections could not be loaded ({warnings.length}).
+        </div>
+      )}
+
+      {!loading && !error && groups.length > 0 && (
+        <div className="tidal-collections-note">
+          Downloading a collection adds its tracks to a playlist of the same name.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/renderer/src/TidalDownloadView.css
+++ b/renderer/src/TidalDownloadView.css
@@ -392,6 +392,45 @@
   white-space: nowrap;
 }
 
+/* ── Account collections browser layout ─────────────────────────────────── */
+
+.tidal-browse-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.tidal-url-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 900px) {
+  .tidal-browse-layout {
+    flex-direction: column;
+  }
+
+  .tidal-collections {
+    flex: 0 0 auto;
+    max-width: none;
+    width: 100%;
+  }
+}
+
+/* Video items inside a collection cannot be imported as audio tracks. */
+
+.tidal-skip-note {
+  margin-top: 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 4px;
+  background: var(--bg-secondary, #1a1a1a);
+  font-size: 11px;
+  color: var(--text-secondary, #999);
+}
+
 /* ── Progress bar fill (deterministic) ──────────────────────────────────── */
 
 .dl-progress-fill {

--- a/renderer/src/TidalDownloadView.jsx
+++ b/renderer/src/TidalDownloadView.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTidalDownload } from './TidalDownloadContext.jsx';
+import TidalCollectionsPanel from './TidalCollectionsPanel.jsx';
 import './DownloadView.css';
 import './TidalDownloadView.css';
 
@@ -56,6 +57,7 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
     loading,
     setLoading,
     trackStatuses,
+    setTrackStatuses,
     result,
     setResult,
     resetToUrl,
@@ -69,6 +71,7 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
   const [installing, setInstalling] = useState(false);
   const [installLog, setInstallLog] = useState([]);
   const [installError, setInstallError] = useState(null);
+  const [collectionBusy, setCollectionBusy] = useState(null); // `${type}:${id}` being downloaded
 
   const inputRef = useRef(null);
 
@@ -353,6 +356,53 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
     }
   }
 
+  // ── collection download (account playlists / mixes / favorites) ────────────
+  // Resolution and download happen in main (tidal-download-collection); the UI
+  // only mirrors the progress events into the regular download step.
+  const handleDownloadCollection = useCallback(
+    async (col) => {
+      if (collectionBusy) return;
+      const key = `${col.type}:${col.id}`;
+      setCollectionBusy(key);
+      setFetchError(null);
+      setResult(null);
+      setTrackStatuses([]);
+      setPlaylistInfo({ type: col.type, title: col.title, entries: [] });
+      setStep('download');
+      setLoading(true);
+
+      try {
+        const res = await window.api.tidalDownloadCollection({
+          type: col.type,
+          id: col.id,
+          title: col.title,
+        });
+        setResult(res);
+        if (res?.ok) {
+          await window.api
+            .getPlaylists()
+            .then(setPlaylists)
+            .catch(() => {});
+        }
+      } catch (err) {
+        setResult({ ok: false, error: err?.message ?? 'Collection download failed' });
+      } finally {
+        setLoading(false);
+        setCollectionBusy(null);
+      }
+    },
+    [
+      collectionBusy,
+      setFetchError,
+      setLoading,
+      setPlaylistInfo,
+      setPlaylists,
+      setResult,
+      setStep,
+      setTrackStatuses,
+    ]
+  );
+
   // ── toggle selection ────────────────────────────────────────────────────────
   const handleToggleEntry = useCallback(
     (index, entry) => {
@@ -552,65 +602,81 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
           <p className="dl-subtitle">Paste a TIDAL URL to import tracks into your library.</p>
         </div>
 
-        <form className="dl-form" onSubmit={handleLoad}>
-          <div className="dl-input-row">
-            <input
-              ref={inputRef}
-              className="dl-input"
-              type="url"
-              placeholder="https://tidal.com/browse/album/…"
-              value={url}
-              onChange={(e) => {
-                setUrl(e.target.value);
-                setFetchError(null);
-              }}
-              onPaste={(e) => {
-                const text = e.clipboardData?.getData('text')?.trim();
-                if (text) {
-                  e.preventDefault();
-                  setUrl(text);
-                  setFetchError(null);
-                }
-              }}
-              disabled={fetching}
-              autoComplete="off"
-              spellCheck={false}
-            />
-            <button className="dl-btn" type="submit" disabled={fetching || !url.trim()}>
-              {fetching ? (
-                <span className="dl-fetch-spinner">
-                  <svg className="dl-spinner-svg" viewBox="0 0 16 16" fill="none">
-                    <circle cx="8" cy="8" r="6" stroke="rgba(255,255,255,0.3)" strokeWidth="2" />
-                    <path
-                      d="M8 2a6 6 0 0 1 6 6"
-                      stroke="#fff"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                    />
-                  </svg>
-                  Fetching…
-                </span>
-              ) : (
-                'Get tracks →'
-              )}
-            </button>
-          </div>
-          {fetchError && (
-            <div className="dl-fetch-error" style={{ marginTop: 8 }}>
-              ✗ {fetchError}
-            </div>
-          )}
-        </form>
+        <div className="tidal-browse-layout">
+          <TidalCollectionsPanel
+            onDownload={handleDownloadCollection}
+            busyKey={collectionBusy}
+            disabled={collectionBusy !== null}
+          />
 
-        <div className="dl-sources" style={{ marginTop: 32 }}>
-          <div className="dl-sources-title">Supported URL types</div>
-          <div className="dl-sources-grid">
-            {TIDAL_URL_TYPES.map((t) => (
-              <div key={t.label} className="dl-source-chip">
-                <span className="dl-source-icon">♫</span>
-                <span>{t.label}</span>
+          <div className="tidal-url-main">
+            <form className="dl-form" onSubmit={handleLoad}>
+              <div className="dl-input-row">
+                <input
+                  ref={inputRef}
+                  className="dl-input"
+                  type="url"
+                  placeholder="https://tidal.com/browse/album/…"
+                  value={url}
+                  onChange={(e) => {
+                    setUrl(e.target.value);
+                    setFetchError(null);
+                  }}
+                  onPaste={(e) => {
+                    const text = e.clipboardData?.getData('text')?.trim();
+                    if (text) {
+                      e.preventDefault();
+                      setUrl(text);
+                      setFetchError(null);
+                    }
+                  }}
+                  disabled={fetching}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <button className="dl-btn" type="submit" disabled={fetching || !url.trim()}>
+                  {fetching ? (
+                    <span className="dl-fetch-spinner">
+                      <svg className="dl-spinner-svg" viewBox="0 0 16 16" fill="none">
+                        <circle
+                          cx="8"
+                          cy="8"
+                          r="6"
+                          stroke="rgba(255,255,255,0.3)"
+                          strokeWidth="2"
+                        />
+                        <path
+                          d="M8 2a6 6 0 0 1 6 6"
+                          stroke="#fff"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                        />
+                      </svg>
+                      Fetching…
+                    </span>
+                  ) : (
+                    'Get tracks →'
+                  )}
+                </button>
               </div>
-            ))}
+              {fetchError && (
+                <div className="dl-fetch-error" style={{ marginTop: 8 }}>
+                  ✗ {fetchError}
+                </div>
+              )}
+            </form>
+
+            <div className="dl-sources" style={{ marginTop: 32 }}>
+              <div className="dl-sources-title">Supported URL types</div>
+              <div className="dl-sources-grid">
+                {TIDAL_URL_TYPES.map((t) => (
+                  <div key={t.label} className="dl-source-chip">
+                    <span className="dl-source-icon">♫</span>
+                    <span>{t.label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
 
@@ -813,6 +879,14 @@ export default function TidalDownloadView({ onGoToLibrary, onGoToPlaylist, style
               </div>
             );
           })}
+        </div>
+      )}
+
+      {/* Video items of a collection are skipped by the audio importer */}
+      {result?.videoCount > 0 && (
+        <div className="tidal-skip-note">
+          Skipped {result.videoCount} video item{result.videoCount !== 1 ? 's' : ''} - DjManager
+          imports audio tracks only.
         </div>
       )}
 

--- a/renderer/src/__tests__/TidalDownloadView.collections.test.jsx
+++ b/renderer/src/__tests__/TidalDownloadView.collections.test.jsx
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import TidalDownloadView from '../TidalDownloadView.jsx';
+import { TidalDownloadProvider } from '../TidalDownloadContext.jsx';
+
+// Mirrors the account tree the tdn GUI shows: playlists, mixes & radio
+// (incl. My Daily Discovery and video mixes) and the favorites collections.
+const COLLECTIONS = [
+  {
+    id: 'pl-1',
+    type: 'playlist',
+    title: 'Uptempo',
+    group: 'playlists',
+    parentId: null,
+    subtitle: '',
+    count: 12,
+  },
+  {
+    id: 'mix-1',
+    type: 'mix',
+    title: 'My Daily Discovery',
+    group: 'mixes',
+    parentId: null,
+    subtitle: 'Daily',
+    count: 0,
+  },
+  {
+    id: 'mix-2',
+    type: 'mix',
+    title: 'My Video Mix 1',
+    group: 'mixes',
+    parentId: null,
+    subtitle: '',
+    count: 0,
+  },
+  {
+    id: 'tracks',
+    type: 'favorites',
+    title: 'Favorite tracks',
+    group: 'favorites',
+    parentId: null,
+    subtitle: '',
+    count: 3,
+  },
+  {
+    id: 'albums',
+    type: 'favorites',
+    title: 'Favorite albums',
+    group: 'favorites',
+    parentId: null,
+    subtitle: '',
+    count: 1,
+  },
+  {
+    id: 'artists',
+    type: 'favorites',
+    title: 'Favorite artists',
+    group: 'favorites',
+    parentId: null,
+    subtitle: '',
+    count: 1,
+  },
+  {
+    id: 'videos',
+    type: 'favorites',
+    title: 'Favorite videos',
+    group: 'favorites',
+    parentId: null,
+    subtitle: '',
+    count: 0,
+  },
+  {
+    id: '521',
+    type: 'artist',
+    title: 'Doja Cat',
+    group: 'favorites',
+    parentId: 'artists',
+    subtitle: '',
+    count: 0,
+  },
+];
+
+function renderView() {
+  return render(
+    <TidalDownloadProvider>
+      <TidalDownloadView />
+    </TidalDownloadProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.api.tidalCheck.mockResolvedValue({ installed: true, loggedIn: true });
+  window.api.getPlaylists.mockResolvedValue([]);
+  window.api.tidalListCollections.mockResolvedValue({
+    ok: true,
+    collections: COLLECTIONS,
+    warnings: [],
+  });
+  window.api.tidalDownloadCollection.mockResolvedValue({
+    ok: true,
+    trackIds: ['t1'],
+    playlistId: null,
+  });
+});
+
+describe('TidalDownloadView - account collections browser', () => {
+  it('lists playlists, mixes & radio and the favorites collections', async () => {
+    renderView();
+
+    expect(await screen.findByText('Uptempo')).toBeInTheDocument();
+    expect(screen.getByText('My Daily Discovery')).toBeInTheDocument();
+    expect(screen.getByText('My Video Mix 1')).toBeInTheDocument();
+    expect(screen.getByText('Favorite tracks')).toBeInTheDocument();
+    expect(screen.getByText('Favorite albums')).toBeInTheDocument();
+    expect(screen.getByText('Favorite artists')).toBeInTheDocument();
+    expect(screen.getByText('Favorite videos')).toBeInTheDocument();
+    // Group headers
+    expect(screen.getByText('Playlists')).toBeInTheDocument();
+    expect(screen.getByText('Mixes & Radio')).toBeInTheDocument();
+    expect(screen.getByText('Favorites')).toBeInTheDocument();
+    // Favorite artists are nested under their collection
+    expect(screen.getByText('Doja Cat')).toBeInTheDocument();
+    expect(window.api.tidalListCollections).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error state when collections cannot be listed', async () => {
+    window.api.tidalListCollections.mockResolvedValue({
+      ok: false,
+      error: 'Not logged in to TIDAL. Please connect your account first.',
+      collections: [],
+    });
+    renderView();
+
+    expect(
+      await screen.findByText(/Not logged in to TIDAL. Please connect your account first./)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Uptempo')).not.toBeInTheDocument();
+  });
+
+  it('downloads a single collection by type and id and shows the download step', async () => {
+    renderView();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Download Uptempo' }));
+
+    await waitFor(() =>
+      expect(window.api.tidalDownloadCollection).toHaveBeenCalledWith({
+        type: 'playlist',
+        id: 'pl-1',
+        title: 'Uptempo',
+      })
+    );
+    // The view switches to the download step, titled after the collection.
+    expect(await screen.findByRole('heading', { level: 2, name: 'Uptempo' })).toBeInTheDocument();
+  });
+
+  it('downloads a favorites collection with its kind as id', async () => {
+    renderView();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Download Favorite videos' }));
+
+    await waitFor(() =>
+      expect(window.api.tidalDownloadCollection).toHaveBeenCalledWith({
+        type: 'favorites',
+        id: 'videos',
+        title: 'Favorite videos',
+      })
+    );
+  });
+
+  it('downloads a nested favorite artist by its artist id', async () => {
+    renderView();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Download Doja Cat' }));
+
+    await waitFor(() =>
+      expect(window.api.tidalDownloadCollection).toHaveBeenCalledWith({
+        type: 'artist',
+        id: '521',
+        title: 'Doja Cat',
+      })
+    );
+  });
+
+  it('surfaces the download error without leaving the download step', async () => {
+    window.api.tidalDownloadCollection.mockResolvedValue({
+      ok: false,
+      error: 'This collection has no downloadable tracks.',
+    });
+    renderView();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Download My Daily Discovery' }));
+
+    expect(
+      await screen.findByText('✗ This collection has no downloadable tracks.')
+    ).toBeInTheDocument();
+  });
+
+  it('notes how many video items were skipped by the audio importer', async () => {
+    window.api.tidalDownloadCollection.mockResolvedValue({
+      ok: true,
+      trackIds: ['t1'],
+      playlistId: 'pl-uuid',
+      videoCount: 2,
+    });
+    renderView();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Download My Video Mix 1' }));
+
+    expect(await screen.findByText(/Skipped 2 video items/)).toBeInTheDocument();
+    expect(screen.getByText(/DjManager imports audio tracks only/)).toBeInTheDocument();
+  });
+
+  it('does not show the skip note for audio-only collections', async () => {
+    renderView();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Download Uptempo' }));
+
+    await waitFor(() => expect(window.api.tidalDownloadCollection).toHaveBeenCalled());
+    expect(screen.queryByText(/video item/)).not.toBeInTheDocument();
+  });
+
+  it('collapses and expands a collection group', async () => {
+    renderView();
+
+    expect(await screen.findByText('Uptempo')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Playlists/ }));
+    expect(screen.queryByText('Uptempo')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Playlists/ }));
+    expect(await screen.findByText('Uptempo')).toBeInTheDocument();
+  });
+
+  it('collapses the nested favorite artists branch', async () => {
+    renderView();
+
+    expect(await screen.findByText('Doja Cat')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse Favorite artists' }));
+    expect(screen.queryByText('Doja Cat')).not.toBeInTheDocument();
+  });
+
+  it('reloads the collection list on demand', async () => {
+    renderView();
+
+    await screen.findByText('Uptempo');
+    expect(window.api.tidalListCollections).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload' }));
+
+    await waitFor(() => expect(window.api.tidalListCollections).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows an empty state when the account has no collections', async () => {
+    window.api.tidalListCollections.mockResolvedValue({
+      ok: true,
+      collections: [],
+      warnings: [],
+    });
+    renderView();
+
+    expect(await screen.findByText('No collections found on this account.')).toBeInTheDocument();
+  });
+
+  it('flags collections that could not be loaded', async () => {
+    window.api.tidalListCollections.mockResolvedValue({
+      ok: true,
+      collections: COLLECTIONS,
+      warnings: ['mixes: unavailable'],
+    });
+    renderView();
+
+    expect(
+      await screen.findByText(/Some collections could not be loaded \(1\)/)
+    ).toBeInTheDocument();
+  });
+});

--- a/renderer/src/__tests__/setup.js
+++ b/renderer/src/__tests__/setup.js
@@ -120,6 +120,8 @@ window.api = {
   tidalInstall: vi.fn().mockResolvedValue({ ok: true }),
   tidalFetchInfo: vi.fn().mockResolvedValue({ ok: false, error: 'not configured' }),
   tidalLogin: vi.fn().mockResolvedValue({ ok: true }),
+  tidalListCollections: vi.fn().mockResolvedValue({ ok: true, collections: [], warnings: [] }),
+  tidalDownloadCollection: vi.fn().mockResolvedValue({ ok: true, trackIds: [], playlistId: null }),
   tidalDownloadUrl: vi.fn().mockResolvedValue({ ok: true, trackIds: [], playlistId: null }),
   cloudSearch: vi.fn().mockResolvedValue({ ok: true, results: [] }),
   cloudSearchPreview: vi

--- a/src/__tests__/tidalCollections.test.js
+++ b/src/__tests__/tidalCollections.test.js
@@ -1,0 +1,426 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('os', () => ({
+  default: { homedir: () => '/home/test', tmpdir: () => '/tmp' },
+  homedir: () => '/home/test',
+  tmpdir: () => '/tmp',
+}));
+
+const mockExistsSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+const mockReadFileSync = vi.fn();
+vi.mock('fs', () => ({
+  default: {
+    existsSync: (...args) => mockExistsSync(...args),
+    writeFileSync: (...args) => mockWriteFileSync(...args),
+    readFileSync: (...args) => mockReadFileSync(...args),
+  },
+  existsSync: (...args) => mockExistsSync(...args),
+  writeFileSync: (...args) => mockWriteFileSync(...args),
+  readFileSync: (...args) => mockReadFileSync(...args),
+}));
+
+let lastSpawnBin = null;
+let lastSpawnArgs = null;
+let fakeProc;
+vi.mock('child_process', () => ({
+  spawn: vi.fn((bin, args) => {
+    lastSpawnBin = bin;
+    lastSpawnArgs = args;
+    return fakeProc;
+  }),
+  execSync: vi.fn(() => {
+    throw new Error('not found');
+  }),
+}));
+
+function makeFakeProc() {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  return proc;
+}
+
+import {
+  buildCollectionsArgs,
+  buildCollectionTracksArgs,
+  parseTidalScriptOutput,
+  normalizeTidalCollections,
+  normalizeTidalCollectionTracks,
+  splitTidalCollectionEntries,
+  reindexTidalEntries,
+  fetchTidalCollections,
+  fetchTidalCollectionTracks,
+} from '../audio/tidalDlManager.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fakeProc = makeFakeProc();
+  lastSpawnBin = null;
+  lastSpawnArgs = null;
+});
+
+describe('TIDAL collection script builders', () => {
+  it('builds the collections-list argument vector', () => {
+    expect(buildCollectionsArgs('/tmp/collections.py', '/home/u/token.json')).toEqual([
+      '/tmp/collections.py',
+      '/home/u/token.json',
+    ]);
+  });
+
+  it('builds the collection-tracks argument vector with type, id and limit', () => {
+    expect(
+      buildCollectionTracksArgs('/tmp/tracks.py', 'favorites', 'tracks', '/home/u/token.json', 250)
+    ).toEqual(['/tmp/tracks.py', 'favorites', 'tracks', '/home/u/token.json', '250']);
+  });
+
+  it('defaults the collection-tracks limit to 500', () => {
+    const args = buildCollectionTracksArgs('/tmp/tracks.py', 'mix', 'mix-1', '/home/u/token.json');
+    expect(args[4]).toBe('500');
+  });
+});
+
+describe('parseTidalScriptOutput', () => {
+  it('parses the JSON payload printed by the script', () => {
+    expect(parseTidalScriptOutput('{"ok": true, "collections": []}', '')).toEqual({
+      ok: true,
+      collections: [],
+    });
+  });
+
+  it('falls back to stderr when stdout is not JSON', () => {
+    const res = parseTidalScriptOutput('Traceback: boom', 'Session error: expired');
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('Session error: expired');
+  });
+
+  it('falls back to stdout when stderr is empty', () => {
+    const res = parseTidalScriptOutput('not json', '');
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('not json');
+  });
+});
+
+describe('normalizeTidalCollections', () => {
+  it('keeps id/type/title/group metadata and drops malformed rows', () => {
+    const res = normalizeTidalCollections({
+      ok: true,
+      collections: [
+        { id: 'pl-1', type: 'playlist', title: 'Uptempo', group: 'playlists', count: 12 },
+        { id: '', type: 'playlist', title: 'no id' },
+        { id: '   ', type: 'playlist', title: 'blank id' },
+        { id: 'x', type: '', title: 'no type' },
+        null,
+        { id: 'mix-1', type: 'mix', title: 'My Daily Discovery', group: 'mixes' },
+        { id: '521', type: 'artist', title: 'Doja Cat', group: 'favorites', parentId: 'artists' },
+      ],
+      warnings: ['mixes: unavailable'],
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.warnings).toEqual(['mixes: unavailable']);
+    expect(res.collections.map((c) => c.id)).toEqual(['pl-1', 'mix-1', '521']);
+    expect(res.collections[0].count).toBe(12);
+    expect(res.collections[1].group).toBe('mixes');
+    expect(res.collections[1].count).toBe(0); // missing count defaults to 0
+    expect(res.collections[2].parentId).toBe('artists');
+  });
+
+  it('stringifies numeric ids and falls back to the id as title', () => {
+    const res = normalizeTidalCollections({
+      ok: true,
+      collections: [{ id: 987, type: 'playlist' }],
+    });
+    expect(res.collections).toEqual([
+      {
+        id: '987',
+        type: 'playlist',
+        title: '987',
+        group: 'other',
+        parentId: null,
+        subtitle: '',
+        mixType: '',
+        count: 0,
+      },
+    ]);
+  });
+
+  it('returns an error result when the payload reports failure', () => {
+    const res = normalizeTidalCollections({ ok: false, error: 'Not logged in to TIDAL' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('Not logged in to TIDAL');
+    expect(res.collections).toEqual([]);
+    expect(res.warnings).toEqual([]);
+  });
+
+  it('tolerates a null payload', () => {
+    const res = normalizeTidalCollections(null);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/Failed to list TIDAL collections/);
+  });
+});
+
+describe('normalizeTidalCollectionTracks', () => {
+  it('normalizes entries, defaults mediaType to track and drops rows without an id', () => {
+    const res = normalizeTidalCollectionTracks({
+      ok: true,
+      type: 'playlist',
+      title: 'Uptempo',
+      total: 3,
+      truncated: true,
+      entries: [
+        { index: 0, id: 111, title: 'One', artist: 'A', duration: 200, url: 'u1' },
+        { index: 1, title: 'no id' },
+        { index: 2, id: '222', title: 'Two', artist: 'B', mediaType: 'video' },
+      ],
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.title).toBe('Uptempo');
+    expect(res.type).toBe('playlist');
+    expect(res.truncated).toBe(true);
+    expect(res.entries).toEqual([
+      {
+        index: 0,
+        id: '111',
+        title: 'One',
+        artist: 'A',
+        duration: 200,
+        url: 'u1',
+        mediaType: 'track',
+      },
+      { index: 2, id: '222', title: 'Two', artist: 'B', duration: 0, url: '', mediaType: 'video' },
+    ]);
+    expect(res.videoCount).toBe(1);
+  });
+
+  it('trusts an explicit videoCount from the script', () => {
+    const res = normalizeTidalCollectionTracks({
+      ok: true,
+      entries: [{ id: '1', mediaType: 'video' }],
+      videoCount: 7,
+    });
+    expect(res.videoCount).toBe(7);
+  });
+
+  it('returns an error result when the payload reports failure', () => {
+    const res = normalizeTidalCollectionTracks({ ok: false, error: 'Mix not found' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('Mix not found');
+    expect(res.entries).toEqual([]);
+    expect(res.videoCount).toBe(0);
+  });
+});
+
+describe('reindexTidalEntries', () => {
+  it('rewrites sparse indices into a contiguous 0-based order', () => {
+    const out = reindexTidalEntries([
+      { index: 0, id: 'a' },
+      { index: 4, id: 'b' },
+      { index: 7, id: 'c' },
+    ]);
+    expect(out).toEqual([
+      { index: 0, id: 'a' },
+      { index: 1, id: 'b' },
+      { index: 2, id: 'c' },
+    ]);
+  });
+
+  it('does not mutate the input entries', () => {
+    const input = [{ index: 9, id: 'a' }];
+    reindexTidalEntries(input);
+    expect(input[0].index).toBe(9);
+  });
+
+  it('handles a missing list', () => {
+    expect(reindexTidalEntries(undefined)).toEqual([]);
+  });
+});
+
+describe('splitTidalCollectionEntries', () => {
+  it('keeps audio entries, re-indexes them from 0 and counts the videos', () => {
+    const { tracks, videoCount } = splitTidalCollectionEntries([
+      { index: 0, id: 'a', mediaType: 'track' },
+      { index: 1, id: 'v', mediaType: 'video' },
+      { index: 2, id: 'b', mediaType: 'track' },
+      { index: 3, id: 'v2', mediaType: 'video' },
+    ]);
+
+    expect(videoCount).toBe(2);
+    expect(tracks.map((t) => [t.id, t.index])).toEqual([
+      ['a', 0],
+      ['b', 1],
+    ]);
+  });
+
+  it('treats entries without a mediaType as audio tracks', () => {
+    const { tracks, videoCount } = splitTidalCollectionEntries([{ index: 4, id: 'x' }]);
+    expect(videoCount).toBe(0);
+    expect(tracks).toEqual([{ index: 0, id: 'x' }]);
+  });
+
+  it('handles an empty or missing list', () => {
+    expect(splitTidalCollectionEntries([])).toEqual({ tracks: [], videoCount: 0 });
+    expect(splitTidalCollectionEntries(undefined)).toEqual({ tracks: [], videoCount: 0 });
+  });
+});
+
+describe('fetchTidalCollections', () => {
+  it('errors when no Python interpreter can be found', async () => {
+    mockExistsSync.mockReturnValue(false);
+    const res = await fetchTidalCollections();
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/Python interpreter not found/);
+  });
+
+  it('errors when not logged in to TIDAL', async () => {
+    mockExistsSync.mockImplementation((p) => p.includes('python'));
+    const res = await fetchTidalCollections();
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/Not logged in/);
+  });
+
+  it('spawns the collections script with the token path and parses its output', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const resultPromise = fetchTidalCollections();
+
+    fakeProc.stdout.emit(
+      'data',
+      JSON.stringify({
+        ok: true,
+        collections: [
+          { id: 'pl-1', type: 'playlist', title: 'Uptempo', group: 'playlists', count: 12 },
+          { id: 'tracks', type: 'favorites', title: 'Favorite tracks', group: 'favorites' },
+        ],
+      })
+    );
+    fakeProc.emit('close', 0);
+
+    const res = await resultPromise;
+
+    expect(lastSpawnBin).toMatch(/python/);
+    expect(lastSpawnArgs[0]).toMatch(/dj_manager_tidal_collections\.py$/);
+    expect(lastSpawnArgs[1]).toMatch(/token\.json$/);
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    expect(res.ok).toBe(true);
+    expect(res.collections).toHaveLength(2);
+    expect(res.collections[0].title).toBe('Uptempo');
+  });
+
+  it('resolves with an error when the script prints unparseable output', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const resultPromise = fetchTidalCollections();
+    fakeProc.stderr.emit('data', 'Traceback: something went wrong');
+    fakeProc.emit('close', 1);
+
+    const res = await resultPromise;
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/something went wrong/);
+    expect(res.collections).toEqual([]);
+  });
+
+  it('resolves with an error when spawning the interpreter fails', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const resultPromise = fetchTidalCollections();
+    fakeProc.emit('error', new Error('ENOENT'));
+
+    const res = await resultPromise;
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('ENOENT');
+  });
+});
+
+describe('fetchTidalCollectionTracks', () => {
+  it('rejects a missing type or id without spawning python', async () => {
+    const noType = await fetchTidalCollectionTracks('', 'pl-1');
+    expect(noType.ok).toBe(false);
+    expect(noType.error).toMatch(/Missing collection type or id/);
+
+    const noId = await fetchTidalCollectionTracks('playlist', '');
+    expect(noId.ok).toBe(false);
+    expect(noId.error).toMatch(/Missing collection type or id/);
+    expect(lastSpawnBin).toBeNull();
+  });
+
+  it('errors when no Python interpreter can be found', async () => {
+    mockExistsSync.mockReturnValue(false);
+    const res = await fetchTidalCollectionTracks('playlist', 'pl-1');
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/Python interpreter not found/);
+  });
+
+  it('errors when not logged in to TIDAL', async () => {
+    mockExistsSync.mockImplementation((p) => p.includes('python'));
+    const res = await fetchTidalCollectionTracks('favorites', 'tracks');
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/Not logged in/);
+  });
+
+  it('spawns the resolver with type, id and limit and parses the entries', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const resultPromise = fetchTidalCollectionTracks('favorites', 'videos', { limit: 25 });
+
+    fakeProc.stdout.emit(
+      'data',
+      JSON.stringify({
+        ok: true,
+        type: 'favorites',
+        id: 'videos',
+        title: 'Favorite videos',
+        total: 1,
+        truncated: false,
+        entries: [
+          {
+            index: 0,
+            id: '77',
+            title: 'Video One',
+            artist: 'Somebody',
+            duration: 180,
+            url: 'https://tidal.com/browse/video/77',
+            mediaType: 'video',
+          },
+        ],
+      })
+    );
+    fakeProc.emit('close', 0);
+
+    const res = await resultPromise;
+
+    expect(lastSpawnArgs[0]).toMatch(/dj_manager_tidal_collection_tracks\.py$/);
+    expect(lastSpawnArgs[1]).toBe('favorites');
+    expect(lastSpawnArgs[2]).toBe('videos');
+    expect(lastSpawnArgs[3]).toMatch(/token\.json$/);
+    expect(lastSpawnArgs[4]).toBe('25');
+    expect(res.ok).toBe(true);
+    expect(res.title).toBe('Favorite videos');
+    expect(res.entries).toHaveLength(1);
+    expect(res.entries[0].mediaType).toBe('video');
+    expect(res.entries[0].url).toBe('https://tidal.com/browse/video/77');
+    expect(res.videoCount).toBe(1);
+  });
+
+  it('propagates a script-level error payload', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const resultPromise = fetchTidalCollectionTracks('mix', 'mix-404');
+
+    fakeProc.stdout.emit('data', JSON.stringify({ ok: false, error: 'Mix not found' }));
+    fakeProc.emit('close', 0);
+
+    const res = await resultPromise;
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('Mix not found');
+    expect(res.entries).toEqual([]);
+  });
+
+  it('resolves with an error when spawning the interpreter fails', async () => {
+    mockExistsSync.mockReturnValue(true);
+    const resultPromise = fetchTidalCollectionTracks('playlist', 'pl-1');
+    fakeProc.emit('error', new Error('ENOENT'));
+
+    const res = await resultPromise;
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('ENOENT');
+    expect(res.entries).toEqual([]);
+  });
+});

--- a/src/__tests__/tidalCollectionsScript.test.js
+++ b/src/__tests__/tidalCollectionsScript.test.js
@@ -1,0 +1,423 @@
+/**
+ * Runs the embedded TIDAL collection Python scripts against a stub `tidalapi`
+ * module, with a fake token file. No network and no real TIDAL account: the
+ * stub stands in for tidalapi and records what the script asks of it.
+ *
+ * Skipped when no usable Python interpreter exists on the machine.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync, execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { COLLECTIONS_SCRIPT, COLLECTION_TRACKS_SCRIPT } from '../audio/tidalDlManager.js';
+
+function findPython() {
+  for (const bin of ['python3', 'python']) {
+    try {
+      const out = execSync(`${bin} -c "import sys; print(sys.version_info[0])"`, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 15000,
+      }).trim();
+      if (out === '3') return bin;
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return null;
+}
+
+const PYTHON = findPython();
+
+const STUB_TIDALAPI = `
+class _Artist:
+    def __init__(self, id, name, top=None):
+        self.id = id
+        self.name = name
+        self._top = top or []
+
+    def get_top_tracks(self, limit=None, offset=0):
+        return self._top[offset:offset + (limit or len(self._top))]
+
+
+class Track:
+    def __init__(self, id, name, artist='Artist', duration=200):
+        self.id = id
+        self.name = name
+        self.artist = _Artist('900', artist)
+        self.duration = duration
+        self.share_url = 'https://tidal.com/browse/track/' + str(id)
+
+
+class Video:
+    def __init__(self, id, name, artist='VidArtist', duration=120):
+        self.id = id
+        self.name = name
+        self.artist = _Artist('901', artist)
+        self.duration = duration
+        self.share_url = 'https://tidal.com/browse/video/' + str(id)
+
+
+class Playlist:
+    def __init__(self, id, name, items=None):
+        self.id = id
+        self.name = name
+        self._items = items or []
+        self.num_tracks = len([i for i in self._items if not isinstance(i, Video)])
+        self.num_videos = len([i for i in self._items if isinstance(i, Video)])
+        self.share_url = 'https://tidal.com/browse/playlist/' + str(id)
+
+    def items(self, limit=100, offset=0):
+        return self._items[offset:offset + limit]
+
+    def tracks(self, limit=None, offset=0):
+        tracks = [i for i in self._items if not isinstance(i, Video)]
+        return tracks[offset:offset + (limit or len(tracks))]
+
+
+class Album:
+    def __init__(self, id, name, tracks):
+        self.id = id
+        self.name = name
+        self._tracks = tracks
+
+    def tracks(self, limit=None, offset=0):
+        return self._tracks[offset:offset + (limit or len(self._tracks))]
+
+
+class Mix:
+    def __init__(self, id, title, items):
+        self.id = id
+        self.title = title
+        self.sub_title = 'Daily'
+        self._items = items
+
+    def items(self):
+        return self._items
+
+
+class MixV2:
+    """Shape returned by Session.mixes().categories[0].items."""
+
+    def __init__(self, id, title, sub_title='', items=None):
+        self.id = id
+        self.title = title
+        self.sub_title = sub_title
+        self.short_subtitle = sub_title
+        self.mix_type = None
+        self._items = items
+
+
+class _Category:
+    def __init__(self, items):
+        self.items = items
+
+
+class Page:
+    def __init__(self, items):
+        self.categories = [_Category(items)]
+
+
+_TRACKS = [Track('111', 'One', 'A'), Track('222', 'Two', 'B')]
+_VIDEOS = [Video('777', 'Video One')]
+_ALBUM = Album('555', 'Album One', [Track('333', 'Album Track')])
+_ARTIST = _Artist('521', 'Doja Cat', top=[Track('444', 'Top Track')])
+
+
+class Favorites:
+    def __init__(self):
+        self._mixes = [Mix('mix-9', 'Favorite mix', [Track('666', 'Mix Track')])]
+
+    def playlists_paginated(self, order=None, order_direction=None):
+        return [Playlist('pl-1', 'Uptempo', _TRACKS)]
+
+    def tracks_paginated(self, order=None, order_direction=None):
+        return list(_TRACKS)
+
+    def videos_paginated(self, order=None, order_direction=None):
+        return list(_VIDEOS)
+
+    def albums_paginated(self, order=None, order_direction=None):
+        return [_ALBUM]
+
+    def artists_paginated(self, order=None, order_direction=None):
+        return [_ARTIST]
+
+    def mixes(self, limit=50, offset=0):
+        return list(self._mixes)
+
+    def _count(self, items):
+        return len(items)
+
+    def get_tracks_count(self):
+        return len(_TRACKS)
+
+    def get_albums_count(self):
+        return 1
+
+    def get_artists_count(self):
+        return 1
+
+    def get_videos_count(self):
+        return len(_VIDEOS)
+
+
+class _User:
+    def __init__(self):
+        self.favorites = Favorites()
+
+    def playlist_and_favorite_playlists(self, offset=0, limit=50):
+        if offset > 0:
+            return []
+        return [Playlist('pl-2', 'Created by me', [Track('888', 'Own Track')])]
+
+
+class Session:
+    def __init__(self):
+        self.user = _User()
+
+    def load_oauth_session(self, token_type, access_token, refresh_token=None):
+        assert access_token == 'stub-token', 'script must pass the token from the token file'
+        return True
+
+    def check_login(self):
+        return True
+
+    def mixes(self):
+        return Page([
+            MixV2('mix-1', 'My Mix 1', 'Mix'),
+            MixV2('mix-2', 'My Daily Discovery', 'Daily'),
+            MixV2('mix-3', 'My Video Mix 1', 'Video', items=_VIDEOS),
+        ])
+
+    def playlist(self, playlist_id):
+        return Playlist(str(playlist_id), 'Playlist ' + str(playlist_id), _TRACKS + _VIDEOS)
+
+    def mix(self, mix_id):
+        items = {'mix-9': [Track('666', 'Mix Track')]}.get(str(mix_id), _TRACKS)
+        return Mix(str(mix_id), 'Mix ' + str(mix_id), items)
+
+    def album(self, album_id):
+        return _ALBUM
+
+    def artist(self, artist_id):
+        return _ARTIST
+
+    def track(self, track_id):
+        return Track(str(track_id), 'Single Track', 'Solo')
+
+    def video(self, video_id):
+        return Video(str(video_id), 'Single Video')
+`;
+
+const TOKEN = { token_type: 'Bearer', access_token: 'stub-token', refresh_token: 'r' };
+
+let tmpDir = null;
+let collectionsScript = null;
+let tracksScript = null;
+
+const runScript = (script, args) => {
+  const stdout = execFileSync(PYTHON ?? 'python3', [script, ...args], {
+    cwd: tmpDir,
+    encoding: 'utf8',
+    timeout: 30000,
+    env: {
+      ...process.env,
+      PYTHONPATH: tmpDir + path.delimiter + (process.env.PYTHONPATH ?? ''),
+      PYTHONIOENCODING: 'utf-8',
+    },
+  });
+  return JSON.parse(stdout.trim());
+};
+
+describe.skipIf(!PYTHON)('embedded TIDAL collection scripts (stub tidalapi)', () => {
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'djm-tidal-stub-'));
+    fs.writeFileSync(path.join(tmpDir, 'tidalapi.py'), STUB_TIDALAPI.trimStart());
+    fs.writeFileSync(path.join(tmpDir, 'token.json'), JSON.stringify(TOKEN));
+    // NOTE: never name these 'collections.py' - the script dir is on sys.path and
+    // would shadow the stdlib collections module.
+    collectionsScript = path.join(tmpDir, 'djm_collections.py');
+    tracksScript = path.join(tmpDir, 'djm_collection_tracks.py');
+    fs.writeFileSync(collectionsScript, COLLECTIONS_SCRIPT.trimStart());
+    fs.writeFileSync(tracksScript, COLLECTION_TRACKS_SCRIPT.trimStart());
+  });
+
+  afterAll(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('collections listing', () => {
+    it('lists playlists (created + favorited), mixes & radio and every favorites node', () => {
+      const res = runScript(collectionsScript, ['token.json']);
+
+      expect(res.ok).toBe(true);
+      expect(res.warnings).toEqual([]);
+
+      const byType = {};
+      for (const c of res.collections) {
+        byType[c.type] = byType[c.type] ?? [];
+        byType[c.type].push(c);
+      }
+
+      // Favorited playlists and the user's own playlists, deduplicated.
+      expect(byType.playlist.map((c) => c.id)).toEqual(['pl-1', 'pl-2']);
+      expect(byType.playlist[0].group).toBe('playlists');
+      expect(byType.playlist[0].count).toBe(2);
+
+      // My Mix 1-8 / My Daily Discovery / video mixes from session.mixes().
+      expect(byType.mix.map((c) => c.id)).toEqual(['mix-1', 'mix-2', 'mix-3']);
+      expect(byType.mix.map((c) => c.title)).toEqual([
+        'My Mix 1',
+        'My Daily Discovery',
+        'My Video Mix 1',
+      ]);
+      expect(byType.mix[1].subtitle).toBe('Daily');
+
+      // Favorites: tracks / albums / artists / videos / mixes.
+      expect(byType.favorites.map((c) => c.id)).toEqual([
+        'tracks',
+        'albums',
+        'artists',
+        'videos',
+        'mixes',
+      ]);
+      expect(byType.favorites[0].count).toBe(2);
+      expect(byType.favorites[3].title).toBe('Favorite videos');
+
+      // Favorite artists are nested under the "artists" node.
+      expect(byType.artist).toEqual([
+        expect.objectContaining({ id: '521', title: 'Doja Cat', parentId: 'artists' }),
+      ]);
+    });
+
+    it('reports a session error instead of a collection list', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'bad-token.json'),
+        JSON.stringify({ token_type: 'Bearer' })
+      );
+      let res;
+      try {
+        runScript(collectionsScript, ['bad-token.json']);
+        throw new Error('script should have exited non-zero');
+      } catch (err) {
+        res = JSON.parse((err.stdout ?? '').toString().trim());
+      }
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/Session error/);
+    });
+  });
+
+  describe('collection track resolution', () => {
+    it('resolves favorited tracks as audio entries', () => {
+      const res = runScript(tracksScript, ['favorites', 'tracks', 'token.json', '500']);
+
+      expect(res.ok).toBe(true);
+      expect(res.title).toBe('Favorite tracks');
+      expect(res.total).toBe(2);
+      expect(res.truncated).toBe(false);
+      expect(res.videoCount).toBe(0);
+      expect(res.entries).toEqual([
+        {
+          index: 0,
+          id: '111',
+          title: 'One',
+          artist: 'A',
+          duration: 200,
+          url: 'https://tidal.com/browse/track/111',
+          mediaType: 'track',
+        },
+        {
+          index: 1,
+          id: '222',
+          title: 'Two',
+          artist: 'B',
+          duration: 200,
+          url: 'https://tidal.com/browse/track/222',
+          mediaType: 'track',
+        },
+      ]);
+    });
+
+    it('marks favorite videos as video entries', () => {
+      const res = runScript(tracksScript, ['favorites', 'videos', 'token.json']);
+
+      expect(res.ok).toBe(true);
+      expect(res.videoCount).toBe(1);
+      expect(res.entries[0].mediaType).toBe('video');
+      expect(res.entries[0].url).toBe('https://tidal.com/browse/video/777');
+    });
+
+    it('flattens favorite albums and favorite artists into tracks', () => {
+      const albums = runScript(tracksScript, ['favorites', 'albums', 'token.json']);
+      expect(albums.entries.map((e) => e.id)).toEqual(['333']);
+
+      const artists = runScript(tracksScript, ['favorites', 'artists', 'token.json']);
+      expect(artists.entries.map((e) => e.id)).toEqual(['444']);
+      expect(artists.title).toBe('Favorite artists');
+    });
+
+    it('resolves a playlist, keeping its videos flagged', () => {
+      const res = runScript(tracksScript, ['playlist', 'pl-1', 'token.json']);
+
+      expect(res.ok).toBe(true);
+      expect(res.type).toBe('playlist');
+      expect(res.entries.map((e) => e.mediaType)).toEqual(['track', 'track', 'video']);
+      expect(res.videoCount).toBe(1);
+    });
+
+    it('resolves a mix through session.mix()', () => {
+      const res = runScript(tracksScript, ['mix', 'mix-1', 'token.json']);
+
+      expect(res.ok).toBe(true);
+      expect(res.title).toBe('Mix mix-1');
+      expect(res.entries.map((e) => e.id)).toEqual(['111', '222']);
+    });
+
+    it('resolves a nested favorite artist by id', () => {
+      const res = runScript(tracksScript, ['artist', '521', 'token.json']);
+      expect(res.ok).toBe(true);
+      expect(res.title).toBe('Doja Cat');
+      expect(res.entries.map((e) => e.id)).toEqual(['444']);
+    });
+
+    it('resolves favorite mixes & radio', () => {
+      const res = runScript(tracksScript, ['favorites', 'mixes', 'token.json']);
+      expect(res.ok).toBe(true);
+      expect(res.title).toBe('Favorite mixes & radio');
+      expect(res.entries.map((e) => e.id)).toEqual(['666']);
+    });
+
+    it('honours the limit argument and flags truncation', () => {
+      const res = runScript(tracksScript, ['favorites', 'tracks', 'token.json', '1']);
+      expect(res.total).toBe(2);
+      expect(res.truncated).toBe(true);
+      expect(res.entries).toHaveLength(1);
+    });
+
+    it('reports unsupported collection types instead of crashing', () => {
+      let res;
+      try {
+        runScript(tracksScript, ['nonsense', 'x', 'token.json']);
+        throw new Error('script should have exited non-zero');
+      } catch (err) {
+        res = JSON.parse((err.stdout ?? '').toString().trim());
+      }
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/Unsupported collection type/);
+    });
+
+    it('reports an unknown favorites kind instead of crashing', () => {
+      let res;
+      try {
+        runScript(tracksScript, ['favorites', 'boom', 'token.json']);
+        throw new Error('script should have exited non-zero');
+      } catch (err) {
+        res = JSON.parse((err.stdout ?? '').toString().trim());
+      }
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/Unknown favorites collection/);
+    });
+  });
+});

--- a/src/audio/tidalDlManager.js
+++ b/src/audio/tidalDlManager.js
@@ -251,6 +251,330 @@ except Exception as e:
     sys.exit(1)
 `;
 
+// Embedded Python script for listing the logged-in account's collections
+// (playlists, mixes & radio, favorites) via tidalapi. Uses the same OAuth
+// session/token as every other script here, so no second login is needed.
+export const COLLECTIONS_SCRIPT = `
+import sys, json
+try:
+    import tidalapi
+except ImportError:
+    print(json.dumps({'ok': False, 'error': 'tidalapi not installed'}))
+    sys.exit(1)
+
+if len(sys.argv) < 2:
+    print(json.dumps({'ok': False, 'error': 'Usage: script.py <token_path>'}))
+    sys.exit(1)
+
+token_path = sys.argv[1]
+
+try:
+    with open(token_path) as f:
+        token = json.load(f)
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': 'Token error: ' + str(e)}))
+    sys.exit(1)
+
+try:
+    session = tidalapi.Session()
+    session.load_oauth_session(
+        token.get('token_type', 'Bearer'),
+        token['access_token'],
+        token.get('refresh_token')
+    )
+    if not session.check_login():
+        print(json.dumps({'ok': False, 'error': 'Not logged in to TIDAL'}))
+        sys.exit(1)
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': 'Session error: ' + str(e)}))
+    sys.exit(1)
+
+collections = []
+warnings = []
+
+def add(cid, ctype, title, group, parent_id='', subtitle='', count=0, mix_type=''):
+    cid = str(cid or '')
+    if not cid or not ctype:
+        return
+    collections.append({
+        'id': cid,
+        'type': ctype,
+        'title': title or cid,
+        'group': group,
+        'parentId': parent_id or '',
+        'subtitle': subtitle or '',
+        'count': int(count or 0),
+        'mixType': mix_type or '',
+    })
+
+def safe(label, func, fallback):
+    try:
+        return func()
+    except Exception as e:
+        warnings.append(label + ': ' + str(e))
+        return fallback
+
+def paginate(func, page=100, cap=2000):
+    out = []
+    offset = 0
+    while len(out) < cap:
+        batch = func(limit=page, offset=offset)
+        if not batch:
+            break
+        out.extend(batch)
+        if len(batch) < page:
+            break
+        offset += page
+    return out
+
+# -- Playlists: created and favorited, mirroring the tdn GUI "Playlists" node --
+def load_playlists():
+    found = {}
+
+    def absorb(func):
+        for pl in safe('playlists', func, []) or []:
+            pid = str(getattr(pl, 'id', '') or '')
+            if pid and pid not in found:
+                found[pid] = pl
+
+    absorb(lambda: session.user.favorites.playlists_paginated())
+    absorb(lambda: paginate(session.user.playlist_and_favorite_playlists, page=50))
+    return list(found.values())
+
+for pl in load_playlists():
+    count = (getattr(pl, 'num_tracks', 0) or 0) + (getattr(pl, 'num_videos', 0) or 0)
+    add(
+        getattr(pl, 'id', ''),
+        'playlist',
+        getattr(pl, 'name', ''),
+        'playlists',
+        count=count,
+    )
+
+# -- Mixes & radio: My Mix 1-8, My Daily Discovery, My Video Mix 1-6 ----------
+def load_mixes():
+    out = []
+    page = session.mixes()
+    for category in getattr(page, 'categories', None) or []:
+        out.extend(list(getattr(category, 'items', None) or []))
+    if out:
+        return out
+    return list(session.user.favorites.mixes() or [])
+
+seen_mixes = set()
+for mx in safe('mixes', load_mixes, []) or []:
+    mix_id = str(getattr(mx, 'id', '') or '')
+    if not mix_id or mix_id in seen_mixes:
+        continue
+    seen_mixes.add(mix_id)
+    mix_type = getattr(mx, 'mix_type', None)
+    if mix_type is not None and hasattr(mix_type, 'value'):
+        mix_type = mix_type.value
+    subtitle = getattr(mx, 'sub_title', '') or getattr(mx, 'short_subtitle', '') or ''
+    add(mix_id, 'mix', getattr(mx, 'title', ''), 'mixes', subtitle=subtitle, mix_type=mix_type or '')
+
+# -- Favorites: tracks / albums / artists / videos / mixes -------------------
+fav = getattr(session.user, 'favorites', None)
+
+FAVORITE_KINDS = [
+    ('tracks', 'Favorite tracks', 'get_tracks_count'),
+    ('albums', 'Favorite albums', 'get_albums_count'),
+    ('artists', 'Favorite artists', 'get_artists_count'),
+    ('videos', 'Favorite videos', 'get_videos_count'),
+    ('mixes', 'Favorite mixes & radio', ''),
+]
+
+def favorite_count(method_name):
+    if fav is None or not method_name:
+        return 0
+    count_method = getattr(fav, method_name, None)
+    if count_method is None:
+        return 0
+    return safe('favorites', count_method, 0) or 0
+
+if fav is not None:
+    for kind, label, count_method in FAVORITE_KINDS:
+        add(kind, 'favorites', label, 'favorites', count=favorite_count(count_method))
+
+    # Individual favorite artists, nested under the "Favorite artists" node.
+    fav_artists = safe('favorite artists', lambda: fav.artists_paginated(), []) or []
+    for artist in fav_artists[:200]:
+        add(
+            getattr(artist, 'id', ''),
+            'artist',
+            getattr(artist, 'name', ''),
+            'favorites',
+            parent_id='artists',
+        )
+
+print(json.dumps({'ok': True, 'collections': collections, 'warnings': warnings}))
+`;
+
+// Embedded Python script that resolves one collection (by type + id) into the
+// individual track/video entries the download path needs. Same session/token
+// handling as every other script in this file.
+export const COLLECTION_TRACKS_SCRIPT = `
+import sys, json
+try:
+    import tidalapi
+except ImportError:
+    print(json.dumps({'ok': False, 'error': 'tidalapi not installed'}))
+    sys.exit(1)
+
+if len(sys.argv) < 4:
+    print(json.dumps({'ok': False, 'error': 'Usage: script.py <type> <id> <token_path> [limit]'}))
+    sys.exit(1)
+
+ctype = sys.argv[1]
+cid = sys.argv[2]
+token_path = sys.argv[3]
+limit = int(sys.argv[4]) if len(sys.argv) > 4 else 500
+
+try:
+    with open(token_path) as f:
+        token = json.load(f)
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': 'Token error: ' + str(e)}))
+    sys.exit(1)
+
+try:
+    session = tidalapi.Session()
+    session.load_oauth_session(
+        token.get('token_type', 'Bearer'),
+        token['access_token'],
+        token.get('refresh_token')
+    )
+    if not session.check_login():
+        print(json.dumps({'ok': False, 'error': 'Not logged in to TIDAL'}))
+        sys.exit(1)
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': 'Session error: ' + str(e)}))
+    sys.exit(1)
+
+def is_video(media):
+    video_class = getattr(tidalapi, 'Video', None)
+    return isinstance(media, video_class) if isinstance(video_class, type) else False
+
+def paginate(func, page=100, cap=5000):
+    out = []
+    offset = 0
+    while len(out) < cap:
+        batch = func(limit=page, offset=offset)
+        if not batch:
+            break
+        out.extend(batch)
+        if len(batch) < page:
+            break
+        offset += page
+    return out
+
+def media_title(media):
+    return getattr(media, 'name', None) or getattr(media, 'title', None) or str(getattr(media, 'id', ''))
+
+def media_artist(media):
+    artist = getattr(media, 'artist', None)
+    name = getattr(artist, 'name', '') if artist is not None else ''
+    if name:
+        return name
+    artists = getattr(media, 'artists', None) or []
+    names = [n for n in (getattr(a, 'name', '') for a in artists) if n]
+    return ', '.join(names)
+
+def media_url(media):
+    url = getattr(media, 'share_url', '') or ''
+    if url:
+        return url
+    mid = str(getattr(media, 'id', ''))
+    if is_video(media):
+        return 'https://tidal.com/browse/video/' + mid
+    return 'https://tidal.com/browse/track/' + mid
+
+def to_entry(media, idx):
+    return {
+        'index': idx,
+        'id': str(getattr(media, 'id', '')),
+        'title': media_title(media),
+        'artist': media_artist(media),
+        'duration': int(getattr(media, 'duration', 0) or 0),
+        'url': media_url(media),
+        'mediaType': 'video' if is_video(media) else 'track',
+    }
+
+def resolve():
+    if ctype == 'track':
+        media = session.track(int(cid))
+        artist = media_artist(media)
+        title = (artist + ' - ' + media_title(media)) if artist else media_title(media)
+        return title, [media]
+    if ctype == 'video':
+        media = session.video(int(cid))
+        return media_title(media), [media]
+    if ctype == 'album':
+        media = session.album(int(cid))
+        return media.name, list(media.tracks())
+    if ctype == 'playlist':
+        media = session.playlist(cid)
+        return media.name, paginate(media.items)
+    if ctype == 'mix':
+        media = session.mix(cid)
+        return (getattr(media, 'title', '') or 'TIDAL Mix'), list(media.items())
+    if ctype == 'artist':
+        media = session.artist(int(cid))
+        return media.name, list(media.get_top_tracks(limit=50))
+    if ctype == 'favorites':
+        fav = session.user.favorites
+        if cid == 'tracks':
+            return 'Favorite tracks', list(fav.tracks_paginated())
+        if cid == 'videos':
+            return 'Favorite videos', list(fav.videos_paginated())
+        if cid == 'albums':
+            out = []
+            for album in fav.albums_paginated():
+                out.extend(list(album.tracks()))
+            return 'Favorite albums', out
+        if cid == 'artists':
+            out = []
+            for artist in fav.artists_paginated():
+                out.extend(list(artist.get_top_tracks(limit=10)))
+            return 'Favorite artists', out
+        if cid == 'mixes':
+            out = []
+            for mix in fav.mixes():
+                mix_id = str(getattr(mix, 'id', '') or '')
+                if not mix_id:
+                    continue
+                try:
+                    # Favorite mixes come back as MixV2 placeholders without
+                    # their items - resolve each one through session.mix().
+                    out.extend(list(session.mix(mix_id).items()))
+                except Exception:
+                    continue
+            return 'Favorite mixes & radio', out
+        raise ValueError('Unknown favorites collection: ' + cid)
+    raise ValueError('Unsupported collection type: ' + ctype)
+
+try:
+    title, media_items = resolve()
+except Exception as e:
+    print(json.dumps({'ok': False, 'error': str(e)}))
+    sys.exit(1)
+
+total = len(media_items)
+truncated = total > limit
+entries = [to_entry(m, i) for i, m in enumerate(media_items[:limit])]
+
+print(json.dumps({
+    'ok': True,
+    'type': ctype,
+    'id': cid,
+    'title': title,
+    'entries': entries,
+    'total': total,
+    'truncated': truncated,
+    'videoCount': sum(1 for e in entries if e['mediaType'] == 'video'),
+}))
+`;
+
 // Strip ANSI escape codes from terminal output
 function stripAnsi(str) {
   return str.replace(/\x1B\[[0-9;]*[mGKHFABCDST]/g, '');
@@ -505,6 +829,296 @@ export async function getTidalPreviewUrl(url) {
     });
     proc.on('error', (err) => {
       resolve({ ok: false, error: err.message });
+    });
+  });
+}
+
+/**
+ * Argument vector for the collections-list script.
+ * Exported so the argument building can be unit tested without spawning python.
+ * @param {string} scriptPath
+ * @param {string} tokenPath
+ * @returns {string[]}
+ */
+export function buildCollectionsArgs(scriptPath, tokenPath) {
+  return [scriptPath, tokenPath];
+}
+
+/**
+ * Argument vector for the collection-tracks resolver script.
+ * @param {string} scriptPath
+ * @param {string} type  Collection type: playlist | mix | album | artist | favorites | track | video
+ * @param {string} id    Collection id (for `favorites`: tracks | albums | artists | videos)
+ * @param {string} tokenPath
+ * @param {number} [limit]  Maximum number of entries to return (default 500)
+ * @returns {string[]}
+ */
+export function buildCollectionTracksArgs(scriptPath, type, id, tokenPath, limit = 500) {
+  return [scriptPath, String(type), String(id), tokenPath, String(limit)];
+}
+
+/**
+ * Parse the JSON payload an embedded TIDAL script printed to stdout.
+ * Falls back to an error object carrying stderr/stdout so callers never throw.
+ * @param {string} stdout
+ * @param {string} stderr
+ * @returns {object}
+ */
+export function parseTidalScriptOutput(stdout, stderr) {
+  const out = (stdout ?? '').trim();
+  try {
+    return JSON.parse(out);
+  } catch {
+    return { ok: false, error: (stderr ?? '').trim() || out || 'Failed to parse response' };
+  }
+}
+
+/**
+ * Normalize the raw collections payload into a stable shape for the renderer.
+ * @param {object} raw
+ * @returns {{ ok: boolean, collections: Array, warnings: string[], error?: string }}
+ */
+export function normalizeTidalCollections(raw) {
+  if (!raw || raw.ok !== true) {
+    return {
+      ok: false,
+      error: raw?.error ?? 'Failed to list TIDAL collections',
+      collections: [],
+      warnings: [],
+    };
+  }
+  const collections = (Array.isArray(raw.collections) ? raw.collections : [])
+    .map((c) => ({
+      id: c?.id !== undefined && c?.id !== null ? String(c.id).trim() : '',
+      type: c?.type ? String(c.type).trim() : '',
+      title: c?.title ? String(c.title) : '',
+      group: c?.group ? String(c.group) : 'other',
+      parentId: c?.parentId ? String(c.parentId) : null,
+      subtitle: c?.subtitle ? String(c.subtitle) : '',
+      mixType: c?.mixType ? String(c.mixType) : '',
+      count: Number.isFinite(c?.count) ? c.count : 0,
+    }))
+    // A collection without an id or a type cannot be resolved for download.
+    .filter((c) => c.id && c.type)
+    .map((c) => ({ ...c, title: c.title || c.id }));
+  return {
+    ok: true,
+    collections,
+    warnings: Array.isArray(raw.warnings) ? raw.warnings : [],
+  };
+}
+
+/**
+ * Normalize the raw collection-tracks payload into download entries.
+ * `mediaType` is 'track' or 'video' - tdn saves videos as .mp4/.ts, which the
+ * DjManager audio importer cannot read, so the download path must drop them.
+ * @param {object} raw
+ * @returns {{ ok: boolean, entries: Array, title: string, type: string, truncated: boolean, total: number, error?: string }}
+ */
+export function normalizeTidalCollectionTracks(raw) {
+  if (!raw || raw.ok !== true) {
+    return {
+      ok: false,
+      error: raw?.error ?? 'Failed to load the TIDAL collection',
+      entries: [],
+      title: '',
+      type: '',
+      truncated: false,
+      total: 0,
+      videoCount: 0,
+    };
+  }
+  const entries = (Array.isArray(raw.entries) ? raw.entries : [])
+    .map((e, i) => ({
+      index: Number.isInteger(e?.index) ? e.index : i,
+      id: e?.id !== undefined && e?.id !== null ? String(e.id) : '',
+      title: e?.title ? String(e.title) : '',
+      artist: e?.artist ? String(e.artist) : '',
+      duration: Number.isFinite(e?.duration) ? e.duration : 0,
+      url: e?.url ? String(e.url) : '',
+      mediaType: e?.mediaType === 'video' ? 'video' : 'track',
+    }))
+    .filter((e) => e.id);
+  return {
+    ok: true,
+    entries,
+    title: raw.title ? String(raw.title) : '',
+    type: raw.type ? String(raw.type) : '',
+    truncated: raw.truncated === true,
+    total: Number.isFinite(raw.total) ? raw.total : entries.length,
+    videoCount: Number.isFinite(raw.videoCount)
+      ? raw.videoCount
+      : entries.filter((e) => e.mediaType === 'video').length,
+  };
+}
+
+/**
+ * Re-index entries from 0 in their current order.
+ *
+ * The download path reports progress positionally: the file reported by
+ * `onFileReady` is matched to the entry at the same position, and the renderer
+ * writes the Nth update into the Nth status row. Entry indices therefore must
+ * be contiguous - a user-deselected selection (0, 2, 5) would otherwise leave
+ * rows stuck on "pending" and overwrite the wrong titles.
+ *
+ * @param {Array} entries
+ * @returns {Array}
+ */
+export function reindexTidalEntries(entries) {
+  return (entries ?? []).map((entry, i) => ({ ...entry, index: i }));
+}
+
+/**
+ * Split resolved collection entries into the audio tracks DjManager can import
+ * and the video items it cannot (tdn saves videos as .mp4/.ts).
+ *
+ * The audio entries are RE-INDEXED from 0 for the same positional-mapping
+ * reason as `reindexTidalEntries`.
+ *
+ * @param {Array} entries
+ * @returns {{ tracks: Array, videoCount: number }}
+ */
+export function splitTidalCollectionEntries(entries) {
+  const audio = [];
+  let videoCount = 0;
+  for (const entry of entries ?? []) {
+    if (entry?.mediaType === 'video') videoCount += 1;
+    else audio.push(entry);
+  }
+  return { tracks: reindexTidalEntries(audio), videoCount };
+}
+
+/**
+ * List the logged-in TIDAL account's collections (playlists, mixes & radio,
+ * favorites) using the existing tdn OAuth session/token.
+ * @returns {Promise<{ ok: boolean, collections: Array, warnings: string[], error?: string }>}
+ */
+export async function fetchTidalCollections() {
+  const pythonPath = findTidalPython();
+  if (!pythonPath) {
+    return {
+      ok: false,
+      error: 'Python interpreter not found. Ensure tidal-dl-ng is installed.',
+      collections: [],
+      warnings: [],
+    };
+  }
+
+  const tokenPath = getTokenPath();
+  if (!fs.existsSync(tokenPath)) {
+    return {
+      ok: false,
+      error: 'Not logged in to TIDAL. Please connect your account first.',
+      collections: [],
+      warnings: [],
+    };
+  }
+
+  const scriptPath = path.join(os.tmpdir(), 'dj_manager_tidal_collections.py');
+  try {
+    fs.writeFileSync(scriptPath, COLLECTIONS_SCRIPT.trimStart());
+  } catch (e) {
+    return {
+      ok: false,
+      error: `Failed to write collections script: ${e.message}`,
+      collections: [],
+      warnings: [],
+    };
+  }
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+
+    const proc = spawn(pythonPath, buildCollectionsArgs(scriptPath, tokenPath), {
+      env: { ...process.env, PYTHONUNBUFFERED: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on('close', () => {
+      resolve(normalizeTidalCollections(parseTidalScriptOutput(stdout, stderr)));
+    });
+
+    proc.on('error', (err) => {
+      resolve({ ok: false, error: err.message, collections: [], warnings: [] });
+    });
+  });
+}
+
+/**
+ * Resolve one TIDAL collection into individual track/video entries.
+ * @param {string} type   playlist | mix | album | artist | favorites | track | video
+ * @param {string} id     Collection id (for `favorites`: tracks | albums | artists | videos)
+ * @param {{ limit?: number }} [opts]
+ * @returns {Promise<{ ok: boolean, entries: Array, title: string, truncated: boolean, error?: string }>}
+ */
+export async function fetchTidalCollectionTracks(type, id, opts = {}) {
+  const fallback = { entries: [], title: '', type: '', truncated: false, total: 0 };
+
+  if (!type || id === undefined || id === null || id === '') {
+    return { ok: false, error: 'Missing collection type or id', ...fallback };
+  }
+
+  const pythonPath = findTidalPython();
+  if (!pythonPath) {
+    return {
+      ok: false,
+      error: 'Python interpreter not found. Ensure tidal-dl-ng is installed.',
+      ...fallback,
+    };
+  }
+
+  const tokenPath = getTokenPath();
+  if (!fs.existsSync(tokenPath)) {
+    return {
+      ok: false,
+      error: 'Not logged in to TIDAL. Please connect your account first.',
+      ...fallback,
+    };
+  }
+
+  const scriptPath = path.join(os.tmpdir(), 'dj_manager_tidal_collection_tracks.py');
+  try {
+    fs.writeFileSync(scriptPath, COLLECTION_TRACKS_SCRIPT.trimStart());
+  } catch (e) {
+    return { ok: false, error: `Failed to write collection script: ${e.message}`, ...fallback };
+  }
+
+  const limit = opts.limit ?? 500;
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+
+    const proc = spawn(
+      pythonPath,
+      buildCollectionTracksArgs(scriptPath, type, id, tokenPath, limit),
+      {
+        env: { ...process.env, PYTHONUNBUFFERED: '1' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on('close', () => {
+      resolve(normalizeTidalCollectionTracks(parseTidalScriptOutput(stdout, stderr)));
+    });
+
+    proc.on('error', (err) => {
+      resolve({ ok: false, error: err.message, ...fallback });
     });
   });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -121,6 +121,10 @@ import {
   startLogin as tidalStartLogin,
   downloadTidal,
   fetchTidalInfo,
+  fetchTidalCollections,
+  fetchTidalCollectionTracks,
+  splitTidalCollectionEntries,
+  reindexTidalEntries,
   searchTidal,
   getTidalPreviewUrl,
 } from './audio/tidalDlManager.js';
@@ -1605,131 +1609,228 @@ ipcMain.handle('tidal-login', async () => {
   }
 });
 
-ipcMain.handle(
-  'tidal-download-url',
-  async (_event, { url, selectedEntries, linkTrackIds, existingPlaylistId, newPlaylistName }) => {
-    const send = (ch, data) => {
-      if (global.mainWindow) global.mainWindow.webContents.send(ch, data);
+// Build the TIDAL URL handed to tdn for one entry. Entries resolved from an
+// account collection carry their own URL (tracks and videos), so prefer it and
+// only fall back to the conventional track URL for search/single-track entries.
+function tidalEntryUrl(entry) {
+  if (entry?.url) return entry.url;
+  if (entry?.id) return `https://tidal.com/browse/track/${entry.id}`;
+  return null;
+}
+
+// Share URL of an account collection, used for provenance and as the default
+// playlist name source when a collection is downloaded without a URL.
+function tidalCollectionUrl(type, id) {
+  switch (type) {
+    case 'playlist':
+      return `https://tidal.com/browse/playlist/${id}`;
+    case 'mix':
+      return `https://tidal.com/browse/mix/${id}`;
+    case 'album':
+      return `https://tidal.com/browse/album/${id}`;
+    case 'artist':
+      return `https://tidal.com/browse/artist/${id}`;
+    default:
+      return 'https://tidal.com/my-collection';
+  }
+}
+
+/**
+ * Shared TIDAL download routine: resolves the URLs handed to tdn, imports every
+ * downloaded file into the library and reports per-track progress.
+ * Used by both `tidal-download-url` and `tidal-download-collection`.
+ */
+async function runTidalDownload({
+  url,
+  selectedEntries,
+  linkTrackIds,
+  existingPlaylistId,
+  newPlaylistName,
+}) {
+  const send = (ch, data) => {
+    if (global.mainWindow) global.mainWindow.webContents.send(ch, data);
+  };
+  const sendTrackUpdate = (data) => send('tidal-track-update', data);
+  const sendProgress = (msg) => send('tidal-progress', { msg });
+
+  try {
+    const tmpDir = path.join(app.getPath('userData'), 'tidal_tmp');
+
+    // Contiguous indices: progress is reported positionally (Nth file -> Nth
+    // entry), so a selection with gaps would desync the per-track status list.
+    const entries = reindexTidalEntries(selectedEntries);
+
+    // Resolve the download URLs: individual entries when selectedEntries are provided,
+    // otherwise the raw URL (for mixes and direct single-URL downloads).
+    const downloadUrls =
+      entries.length > 0 ? entries.map((e) => tidalEntryUrl(e)).filter(Boolean) : [url];
+
+    // Create playlist before starting download so tracks can be added progressively.
+    let playlistId = null;
+    if (existingPlaylistId) {
+      playlistId = existingPlaylistId;
+    } else if (newPlaylistName?.trim()) {
+      try {
+        const { id } = findOrCreatePlaylist(newPlaylistName.trim(), null, url);
+        playlistId = id;
+        send('playlists-updated');
+      } catch (err) {
+        console.error('[tidal] findOrCreatePlaylist failed:', err.message);
+      }
+    }
+
+    // Emit init event so the UI can render the full track list immediately.
+    if (entries.length > 0) {
+      sendTrackUpdate({ type: 'init', tracks: entries });
+    }
+
+    const trackIds = [];
+    // fileIndex tracks which entry corresponds to the next file reported by onFileReady.
+    // tdn downloads in the order we pass URLs, so positional matching is reliable.
+    let fileIndex = 0;
+
+    const onFileReady = async (filePath) => {
+      const entry = entries[fileIndex] ?? null;
+      const idx = fileIndex;
+      fileIndex++;
+
+      if (entry) {
+        sendTrackUpdate({
+          index: idx,
+          title: entry.title,
+          artist: entry.artist,
+          status: 'importing',
+        });
+      } else {
+        // No entry info (e.g. mix download) — emit a generic update
+        sendTrackUpdate({
+          index: idx,
+          title: path.basename(filePath),
+          artist: '',
+          status: 'importing',
+        });
+      }
+
+      try {
+        const trackSourceUrl = tidalEntryUrl(entry) ?? url;
+        const trackId = await importAudioFile(filePath, {
+          source_url: trackSourceUrl,
+          source_link: url !== trackSourceUrl ? url : null,
+          source_platform: 'tidal',
+        });
+        trackIds.push(trackId);
+        if (playlistId) {
+          addTrackToPlaylist(playlistId, trackId);
+          send('playlists-updated');
+        }
+        send('library-updated');
+        sendTrackUpdate({
+          index: idx,
+          title: entry?.title ?? path.basename(filePath),
+          artist: entry?.artist ?? '',
+          status: 'done',
+          trackId,
+        });
+      } catch (err) {
+        console.error('[tidal] importAudioFile failed:', err.message);
+        sendTrackUpdate({
+          index: idx,
+          title: entry?.title ?? path.basename(filePath),
+          artist: entry?.artist ?? '',
+          status: 'failed',
+          error: err.message,
+        });
+      }
     };
-    const sendTrackUpdate = (data) => send('tidal-track-update', data);
-    const sendProgress = (msg) => send('tidal-progress', { msg });
+
+    sendProgress('Starting download…');
+
+    // Only call tdn if there are new tracks to download
+    const hasDownloads = entries.length > 0 || !selectedEntries;
+    if (hasDownloads) {
+      const files = await downloadTidal(downloadUrls, tmpDir, sendProgress, { onFileReady });
+      if (files.length === 0 && trackIds.length === 0 && (linkTrackIds?.length ?? 0) === 0) {
+        send('tidal-progress', null);
+        return { ok: false, error: 'Download finished but no audio files were found.' };
+      }
+    }
+
+    // Link already-in-library tracks to the playlist (no re-download needed)
+    if (linkTrackIds?.length > 0 && playlistId) {
+      for (const tid of linkTrackIds) {
+        try {
+          addTrackToPlaylist(playlistId, tid);
+        } catch {
+          // ignore duplicate playlist entry errors
+        }
+      }
+      send('playlists-updated');
+    }
+
+    send('tidal-progress', null);
+    return { ok: true, trackIds, playlistId: playlistId ?? null };
+  } catch (err) {
+    send('tidal-progress', null);
+    return { ok: false, error: err.message };
+  }
+}
+
+ipcMain.handle('tidal-download-url', async (_event, opts) => runTidalDownload(opts ?? {}));
+
+ipcMain.handle('tidal-list-collections', async () => {
+  try {
+    const res = await fetchTidalCollections();
+    console.log(`[tidal-list-collections] ok=${res.ok} count=${res.collections?.length ?? 0}`);
+    return res;
+  } catch (err) {
+    console.error('[tidal-list-collections] error:', err.message);
+    return { ok: false, error: err.message, collections: [], warnings: [] };
+  }
+});
+
+ipcMain.handle(
+  'tidal-download-collection',
+  async (_event, { type, id, title, existingPlaylistId, newPlaylistName } = {}) => {
+    if (!type || !id) return { ok: false, error: 'Missing collection type or id' };
 
     try {
-      const tmpDir = path.join(app.getPath('userData'), 'tidal_tmp');
+      // Resolve the collection into individual track/video entries, then reuse
+      // the shared download path (same tdn invocation, same progressive import).
+      const resolved = await fetchTidalCollectionTracks(type, id);
+      if (!resolved.ok) return resolved;
 
-      // Resolve the download URLs: individual track URLs when selectedEntries are provided,
-      // otherwise the raw URL (for mixes and direct single-URL downloads).
-      const downloadUrls =
-        selectedEntries?.length > 0
-          ? selectedEntries.map((e) => `https://tidal.com/browse/track/${e.id}`)
-          : [url];
+      // Videos download as .mp4/.ts, which the audio importer cannot read.
+      const { tracks, videoCount } = splitTidalCollectionEntries(resolved.entries);
+      const collectionTitle = resolved.title || title || id;
 
-      // Create playlist before starting download so tracks can be added progressively.
-      let playlistId = null;
-      if (existingPlaylistId) {
-        playlistId = existingPlaylistId;
-      } else if (newPlaylistName?.trim()) {
-        try {
-          const { id } = findOrCreatePlaylist(newPlaylistName.trim(), null, url);
-          playlistId = id;
-          send('playlists-updated');
-        } catch (err) {
-          console.error('[tidal] findOrCreatePlaylist failed:', err.message);
-        }
+      if (tracks.length === 0) {
+        return {
+          ok: false,
+          error:
+            videoCount > 0
+              ? `"${collectionTitle}" contains only video items. DjManager imports audio tracks only.`
+              : 'This collection has no downloadable tracks.',
+          videoCount,
+        };
       }
 
-      // Emit init event so the UI can render the full track list immediately.
-      if (selectedEntries?.length > 0) {
-        sendTrackUpdate({ type: 'init', tracks: selectedEntries });
+      if (global.mainWindow) {
+        global.mainWindow.webContents.send('tidal-progress', {
+          msg: `Downloading ${tracks.length} tracks from ${collectionTitle}...`,
+        });
       }
 
-      const trackIds = [];
-      // fileIndex tracks which selectedEntry corresponds to the next file reported by onFileReady.
-      // tdn downloads in the order we pass URLs, so positional matching is reliable.
-      let fileIndex = 0;
+      const res = await runTidalDownload({
+        url: tidalCollectionUrl(type, id),
+        selectedEntries: tracks,
+        linkTrackIds: [],
+        existingPlaylistId: existingPlaylistId ?? null,
+        newPlaylistName: newPlaylistName ?? collectionTitle,
+      });
 
-      const onFileReady = async (filePath) => {
-        const entry = selectedEntries?.[fileIndex] ?? null;
-        const idx = fileIndex;
-        fileIndex++;
-
-        if (entry) {
-          sendTrackUpdate({
-            index: idx,
-            title: entry.title,
-            artist: entry.artist,
-            status: 'importing',
-          });
-        } else {
-          // No entry info (e.g. mix download) — emit a generic update
-          sendTrackUpdate({
-            index: idx,
-            title: path.basename(filePath),
-            artist: '',
-            status: 'importing',
-          });
-        }
-
-        try {
-          const trackSourceUrl = entry?.id ? `https://tidal.com/browse/track/${entry.id}` : url;
-          const trackId = await importAudioFile(filePath, {
-            source_url: trackSourceUrl,
-            source_link: url !== trackSourceUrl ? url : null,
-            source_platform: 'tidal',
-          });
-          trackIds.push(trackId);
-          if (playlistId) {
-            addTrackToPlaylist(playlistId, trackId);
-            send('playlists-updated');
-          }
-          send('library-updated');
-          sendTrackUpdate({
-            index: idx,
-            title: entry?.title ?? path.basename(filePath),
-            artist: entry?.artist ?? '',
-            status: 'done',
-            trackId,
-          });
-        } catch (err) {
-          console.error('[tidal] importAudioFile failed:', err.message);
-          sendTrackUpdate({
-            index: idx,
-            title: entry?.title ?? path.basename(filePath),
-            artist: entry?.artist ?? '',
-            status: 'failed',
-            error: err.message,
-          });
-        }
-      };
-
-      sendProgress('Starting download…');
-
-      // Only call tdn if there are new tracks to download
-      const hasDownloads = selectedEntries?.length > 0 || !selectedEntries;
-      if (hasDownloads) {
-        const files = await downloadTidal(downloadUrls, tmpDir, sendProgress, { onFileReady });
-        if (files.length === 0 && trackIds.length === 0 && (linkTrackIds?.length ?? 0) === 0) {
-          send('tidal-progress', null);
-          return { ok: false, error: 'Download finished but no audio files were found.' };
-        }
-      }
-
-      // Link already-in-library tracks to the playlist (no re-download needed)
-      if (linkTrackIds?.length > 0 && playlistId) {
-        for (const tid of linkTrackIds) {
-          try {
-            addTrackToPlaylist(playlistId, tid);
-          } catch {
-            // ignore duplicate playlist entry errors
-          }
-        }
-        send('playlists-updated');
-      }
-
-      send('tidal-progress', null);
-      return { ok: true, trackIds, playlistId: playlistId ?? null };
+      return { ...res, videoCount };
     } catch (err) {
-      send('tidal-progress', null);
+      console.error('[tidal-download-collection] error:', err.message);
       return { ok: false, error: err.message };
     }
   }

--- a/src/preload.js
+++ b/src/preload.js
@@ -226,6 +226,8 @@ contextBridge.exposeInMainWorld('api', {
   tidalInstall: () => ipcRenderer.invoke('tidal-install'),
   tidalFetchInfo: (url) => ipcRenderer.invoke('tidal-fetch-info', url),
   tidalLogin: () => ipcRenderer.invoke('tidal-login'),
+  tidalListCollections: () => ipcRenderer.invoke('tidal-list-collections'),
+  tidalDownloadCollection: (opts) => ipcRenderer.invoke('tidal-download-collection', opts),
   cloudSearch: ({ source, query, types, limit }) =>
     ipcRenderer.invoke('cloud-search', { source, query, types, limit }),
   cloudSearchPreview: (payload) => ipcRenderer.invoke('cloud-search-preview', payload),

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -41,6 +41,8 @@ export default defineConfig({
             'src/__tests__/autoTagger.test.js',
             'src/__tests__/ytDlpManager.test.js',
             'src/__tests__/tidalDlManager.test.js',
+            'src/__tests__/tidalCollections.test.js',
+            'src/__tests__/tidalCollectionsScript.test.js',
             'src/__tests__/mediaServer.test.js',
             'src/__tests__/anlzWriter.test.js',
             'src/__tests__/waveformGenerator.test.js',


### PR DESCRIPTION
Closes #508

## What changed
- **Collections tree in the TIDAL view** (`renderer/src/TidalCollectionsPanel.jsx`, new): Playlists (favourited + created), Mixes and Radio (My Mix, My Daily Discovery, video mixes), Favorites (tracks / albums / artists / videos / mixes) with a per-collection download button, matching the tidal-dl-ng GUI layout.
- **IPC**: `tidal-list-collections` and `tidal-download-collection` (main + preload + the `window.api` test mock). They reuse the existing tdn OAuth token at `~/.config/tidal-dl-ng/token.json`, so there is no second login.
- **Engine** (`src/audio/tidalDlManager.js`): two embedded python scripts (`COLLECTIONS_SCRIPT`, `COLLECTION_TRACKS_SCRIPT`) run with the tdn interpreter, plus pure `buildCollectionsArgs` / `buildCollectionTracksArgs` / `parseTidalScriptOutput` / `normalizeTidalCollections` / `normalizeTidalCollectionTracks` / `reindexTidalEntries` / `splitTidalCollectionEntries` so the logic is testable without an account.
- `runTidalDownload()` is now the single routine shared by `tidal-download-url` and the collection handler.
- Video entries are deliberately flagged and skipped (tdn writes `.mp4`/`.ts`, which the audio library and USB export cannot ingest); the UI surfaces how many were skipped and a video-only collection returns a precise error.
- `HelpView` updated; two pre-existing wrong Help claims about a TIDAL selection step were corrected (grep-verified).

## Verification
- root `npx vitest run`: 22 files, 537 tests passed (new: `tidalCollections.test.js` 30, `tidalCollectionsScript.test.js` 12)
- renderer `npx vitest run src/__tests__`: 18 files, 210 tests passed (new: `TidalDownloadView.collections.test.jsx` 13)
- root and renderer lint: 0 errors (renderer keeps its 6 pre-existing warnings)
- `tidalCollectionsScript.test.js` executes the real embedded python against a stub `tidalapi` in a temp dir, so the script itself is exercised without network or credentials.

## Limits (stated, not hidden)
Live OAuth session validity, whether `session.mix(id)` resolves the ids this account returns, and the actual download/import of resolved URLs need a real TIDAL account and were not run. The optional HiRes quality picker from the issue was not implemented (downloads reuse `downloadTidal`, which takes quality from the tdn config).