### PR TITLE
feat(player): persist the playback history across restarts

### DIFF
--- a/renderer/src/HelpView.jsx
+++ b/renderer/src/HelpView.jsx
@@ -62,6 +62,7 @@ const SECTIONS = [
       'The volume icon opens a vertical slider on hover; clicking the icon mutes/unmutes. Output devices can be switched next to it.',
       'Click anywhere on the waveform to seek. The bar can be made taller by dragging its top edge; drag the thin separators to re-balance the zones.',
       'The clock icon opens playback history. Clicking the track title jumps to the list it is playing from: the playlist it belongs to, or the Music list scrolled to that track.',
+      'Playback history keeps the last 50 tracks and is remembered across restarts; replaying the same track back to back adds a single entry.',
       'Media keys of your OS (play/pause/next/previous) control the player as well.',
     ],
   },

--- a/renderer/src/PlayerContext.jsx
+++ b/renderer/src/PlayerContext.jsx
@@ -7,10 +7,9 @@ import {
   useEffect,
   useLayoutEffect,
 } from 'react';
+import { appendHistoryEntry, loadHistory, persistHistory } from './playbackHistory.js';
 
 const PlayerContext = createContext(null);
-
-const HISTORY_MAX = 50;
 
 export function PlayerProvider({ children }) {
   const audioRef = useRef(null);
@@ -42,9 +41,15 @@ export function PlayerProvider({ children }) {
   const [repeat, setRepeat] = useState('none'); // 'none' | 'all' | 'one'
   const [outputDeviceId, setOutputDeviceId] = useState('');
   const [volume, setVolumeState] = useState(1.0);
-  const [history, setHistory] = useState([]); // ring buffer, newest first
+  const [history, setHistory] = useState(loadHistory); // ring buffer, newest first, persisted (#507)
   const [playbackError, setPlaybackError] = useState(null); // { message } | null — surfaced by PlayerBar
   const [unavailableLinkedIds, setUnavailableLinkedIds] = useState(() => new Set());
+
+  // #507: keep the persisted copy in sync with the in-memory ring buffer. Runs
+  // on mount too, which rewrites exactly what was just hydrated - harmless.
+  useEffect(() => {
+    persistHistory(history);
+  }, [history]);
 
   // Port of the local HTTP media server (started in main process before window opens).
   const mediaPortRef = useRef(null);
@@ -229,12 +234,10 @@ export function PlayerProvider({ children }) {
       // Always ensure exactly one leading slash (Unix paths already start with '/', Windows 'C:/...' don't)
       const src = `http://127.0.0.1:${port}/${encodedPath.replace(/^\//, '')}?t=${gen}`; // cache-bust: same file reloaded = fresh pipeline
 
-      // Push currently playing track to history before switching
+      // Push currently playing track to history before switching (#507):
+      // no duplicate for a back-to-back replay, capped and persisted.
       if (currentTrackRef.current) {
-        setHistory((prev) => {
-          const next = [currentTrackRef.current, ...prev];
-          return next.length > HISTORY_MAX ? next.slice(0, HISTORY_MAX) : next;
-        });
+        setHistory((prev) => appendHistoryEntry(prev, currentTrackRef.current));
       }
       console.log('[diag] playAtIndex src =', src);
       // Build Web Audio graph on first play (must be inside user gesture so ctx starts running)

--- a/renderer/src/__tests__/PlayerContext.history.test.jsx
+++ b/renderer/src/__tests__/PlayerContext.history.test.jsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { PlayerProvider, usePlayer } from '../PlayerContext.jsx';
+import {
+  HISTORY_MAX,
+  HISTORY_STORAGE_KEY,
+  appendHistoryEntry,
+  loadHistory,
+  persistHistory,
+} from '../playbackHistory.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function track(id, extra = {}) {
+  return {
+    id,
+    title: `Track ${id}`,
+    artist: `Artist ${id}`,
+    file_path: `/music/${id}.mp3`,
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.api.getMediaPort.mockResolvedValue(19876);
+  localStorage.clear();
+});
+
+// ── appendHistoryEntry ────────────────────────────────────────────────────────
+
+describe('PlayerContext — appendHistoryEntry (#507)', () => {
+  it('prepends the new track (newest first)', () => {
+    const next = appendHistoryEntry([track(2), track(1)], track(3));
+    expect(next.map((t) => t.id)).toEqual([3, 2, 1]);
+  });
+
+  it('does not add a duplicate when the same track starts again back to back', () => {
+    const prev = [track(1), track(2)];
+    expect(appendHistoryEntry(prev, track(1))).toBe(prev);
+  });
+
+  it('still logs the same track again when another track played in between', () => {
+    const next = appendHistoryEntry([track(2), track(1)], track(1));
+    expect(next.map((t) => t.id)).toEqual([1, 2, 1]);
+  });
+
+  it('caps the ring buffer at HISTORY_MAX and drops the oldest entry', () => {
+    let history = [];
+    for (let id = 1; id <= HISTORY_MAX + 10; id += 1) {
+      history = appendHistoryEntry(history, track(id));
+    }
+    expect(history).toHaveLength(HISTORY_MAX);
+    expect(history[0].id).toBe(HISTORY_MAX + 10);
+    expect(history.at(-1).id).toBe(11);
+  });
+
+  it('ignores entries without an id', () => {
+    const prev = [track(1)];
+    expect(appendHistoryEntry(prev, null)).toBe(prev);
+    expect(appendHistoryEntry(prev, { title: 'no id' })).toBe(prev);
+  });
+});
+
+// ── persistence ───────────────────────────────────────────────────────────────
+
+describe('PlayerContext — history persistence (#507)', () => {
+  it('round-trips through localStorage', () => {
+    persistHistory([track(2), track(1)]);
+    expect(loadHistory().map((t) => t.id)).toEqual([2, 1]);
+  });
+
+  it('returns an empty history when nothing was stored', () => {
+    expect(loadHistory()).toEqual([]);
+  });
+
+  it('degrades to an empty history on corrupted JSON', () => {
+    localStorage.setItem(HISTORY_STORAGE_KEY, '{not json');
+    expect(loadHistory()).toEqual([]);
+  });
+
+  it('ignores a stored value that is not an array', () => {
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify({ ids: [1, 2] }));
+    expect(loadHistory()).toEqual([]);
+  });
+
+  it('does not persist the waveform BLOBs that track rows carry', () => {
+    const withBlobs = track(7, {
+      waveform_overview: new Uint8Array([1, 2, 3]),
+      waveform_detail_hires: new Uint8Array([4, 5, 6]),
+    });
+    persistHistory([withBlobs]);
+
+    const raw = localStorage.getItem(HISTORY_STORAGE_KEY);
+    expect(raw).not.toContain('waveform_overview');
+    expect(raw).not.toContain('waveform_detail_hires');
+    const [entry] = loadHistory();
+    expect(entry.id).toBe(7);
+    expect(entry.file_path).toBe('/music/7.mp3');
+    expect(entry.waveform_overview).toBeUndefined();
+  });
+
+  it('caps a hydrated history at HISTORY_MAX', () => {
+    const many = Array.from({ length: HISTORY_MAX + 5 }, (_, i) => track(i + 1));
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(many));
+    expect(loadHistory()).toHaveLength(HISTORY_MAX);
+  });
+});
+
+// ── provider integration ──────────────────────────────────────────────────────
+
+describe('PlayerProvider — history hydration (#507)', () => {
+  it('hydrates the history from localStorage on mount', async () => {
+    persistHistory([track(42), track(41)]);
+
+    const { result } = renderHook(() => usePlayer(), { wrapper: PlayerProvider });
+    await waitFor(() => expect(result.current).toBeTruthy());
+
+    expect(result.current.history.map((t) => t.id)).toEqual([42, 41]);
+  });
+
+  it('starts with an empty history when nothing is stored', async () => {
+    const { result } = renderHook(() => usePlayer(), { wrapper: PlayerProvider });
+    await waitFor(() => expect(result.current).toBeTruthy());
+
+    expect(result.current.history).toEqual([]);
+  });
+});

--- a/renderer/src/playbackHistory.js
+++ b/renderer/src/playbackHistory.js
@@ -1,0 +1,67 @@
+// Playback history ring buffer (#507).
+//
+// Kept in its own module so PlayerContext.jsx only exports components (the
+// react-refresh lint rule) and so the buffer logic is directly unit-testable.
+// The history is persisted to localStorage so the history control is useful
+// across restarts.
+
+export const HISTORY_MAX = 50;
+export const HISTORY_STORAGE_KEY = 'djman_playback_history';
+
+// Binary columns the track rows carry (`SELECT t.*` includes the waveform
+// BLOBs). They are useless for the history menu and would blow up localStorage
+// once serialised, so they never reach the persisted copy.
+const HISTORY_BINARY_KEYS = new Set(['waveform_overview', 'waveform_detail_hires']);
+
+/** Copy of a track with the binary payload dropped (for persistence only). */
+function slimHistoryTrack(track) {
+  if (!track || typeof track !== 'object') return null;
+  const slim = {};
+  for (const [key, value] of Object.entries(track)) {
+    if (HISTORY_BINARY_KEYS.has(key)) continue;
+    if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) continue;
+    slim[key] = value;
+  }
+  return slim;
+}
+
+/**
+ * Prepend `track` to the history ring buffer (returns a new array).
+ * The same track starting again back to back (repeat "one", or re-clicking the
+ * playing row) does not add a duplicate entry.
+ */
+export function appendHistoryEntry(history, track) {
+  if (!track || track.id == null) return history;
+  if (history[0]?.id === track.id) return history;
+  const next = [track, ...history];
+  return next.length > HISTORY_MAX ? next.slice(0, HISTORY_MAX) : next;
+}
+
+/** Read the persisted history. Never throws: corrupted or unavailable storage
+ *  (private mode, quota, no localStorage at all) degrades to an empty history. */
+export function loadHistory() {
+  try {
+    const raw = globalThis.localStorage?.getItem(HISTORY_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map(slimHistoryTrack)
+      .filter((entry) => entry && entry.id != null)
+      .slice(0, HISTORY_MAX);
+  } catch {
+    return [];
+  }
+}
+
+/** Write the history to localStorage; a failing store leaves it in memory. */
+export function persistHistory(history) {
+  try {
+    globalThis.localStorage?.setItem(
+      HISTORY_STORAGE_KEY,
+      JSON.stringify(history.map(slimHistoryTrack).filter(Boolean))
+    );
+  } catch {
+    // storage full or disabled - history simply stays session-only
+  }
+}


### PR DESCRIPTION
Closes #507

## What changed
- New `renderer/src/playbackHistory.js`: the ring buffer logic, kept out of `PlayerContext.jsx` so that file only exports components (the `react-refresh/only-export-components` lint rule) and so the buffer is directly unit-testable.
  - `appendHistoryEntry(history, track)` - newest first, capped at `HISTORY_MAX = 50`, and it does NOT add a duplicate when the same track (same id) starts again back to back (repeat one, or re-clicking the playing row), which is what the issue reported.
  - `loadHistory()` / `persistHistory(list)` against `localStorage['djman_playback_history']`. Corrupted JSON, a non-array value, or storage that is unavailable/disabled degrade to an empty history instead of throwing.
- `PlayerContext` hydrates with `useState(loadHistory)` and writes back on every change, so the clock menu survives a restart.
- The waveform BLOBs that track rows carry (`SELECT t.*` includes `waveform_overview` / `waveform_detail_hires`) are stripped before persisting - they are useless in the menu and would bloat the store. Everything else (id, title, artist, file_path, ...) is kept so playing an entry from the restored history still works.
- `HelpView` states the new behaviour.

## Verification
- renderer `npx vitest run src/__tests__`: 18 files, 210 tests passed (new `PlayerContext.history.test.jsx`: 13 tests - ordering, back-to-back duplicate, same id separated, the 50 cap, invalid entries, localStorage round trip, corrupted JSON, non-array value, blob stripping, hydration cap, provider hydration on mount)
- root `npx vitest run`: 20 files, 495 tests passed (no main-process change)
- root and renderer `npm run lint`: 0 errors (renderer keeps its 6 pre-existing warnings); `npx prettier --check .` clean

## Limits (stated, not hidden)
Verified with jsdom component tests and the unit tests above; no live `npm run dev` restart was performed in this change.