### PR TITLE
fix(explorer): make the context menu act on the whole selection

### DIFF
--- a/renderer/src/FileExplorerView.jsx
+++ b/renderer/src/FileExplorerView.jsx
@@ -4,6 +4,7 @@ import { usePlayer } from './PlayerContext.jsx';
 import { artworkUrl } from './artworkUrl.js';
 import TrackDetails from './TrackDetails.jsx';
 import BeatGridEditor from './BeatGridEditor.jsx';
+import { buildExplorerContextMenu } from './explorerContextMenu.js';
 import './MusicLibrary.css';
 import './FileExplorerView.css';
 
@@ -363,23 +364,29 @@ export default function FileExplorerView({ style }) {
     return unsub;
   }, []);
 
-  const addFavourite = useCallback((path) => {
-    const name = basename(path) || path;
+  // Single write path for favourites so a multi-selection update persists once
+  // (one setSetting) instead of once per folder.
+  const updateFavourites = useCallback((paths, add) => {
     setFavourites((prev) => {
-      if (prev.some((f) => f.path === path)) return prev;
-      const next = [...prev, { path, name }];
+      const current = new Set(prev.map((f) => f.path));
+      const next = add
+        ? [
+            ...prev,
+            ...paths
+              .filter((p) => !current.has(p))
+              .map((p) => ({ path: p, name: basename(p) || p })),
+          ]
+        : prev.filter((f) => !paths.includes(f.path));
+      if (next.length === prev.length) return prev;
       window.api.setSetting('explorer_favourites', JSON.stringify(next));
       return next;
     });
   }, []);
 
-  const removeFavourite = useCallback((path) => {
-    setFavourites((prev) => {
-      const next = prev.filter((f) => f.path !== path);
-      window.api.setSetting('explorer_favourites', JSON.stringify(next));
-      return next;
-    });
-  }, []);
+  const removeFavourite = useCallback(
+    (path) => updateFavourites([path], false),
+    [updateFavourites]
+  );
 
   // ── Background broken-link scan ──────────────────────────────────────────
 
@@ -639,10 +646,12 @@ export default function FileExplorerView({ style }) {
     });
   }, []);
 
+  // `silent` lets batch callers suppress the per-folder toast and report one
+  // aggregate result instead; it always returns the raw IPC result.
   const linkDir = useCallback(
-    async (dirPath, recursive, playlistId = null) => {
+    async (dirPath, recursive, playlistId = null, silent = false) => {
       const res = await window.api.linkDirectory(dirPath, recursive, playlistId);
-      showToast(`Linked ${res.linked}/${res.total} tracks`);
+      if (!silent) showToast(`Linked ${res.linked}/${res.total} tracks`);
       if (res.filePaths?.length) {
         const tracks = await window.api.getTracksByPaths(res.filePaths);
         setTracksMap((prev) => {
@@ -651,8 +660,111 @@ export default function FileExplorerView({ style }) {
           return next;
         });
       }
+      return res;
     },
     [showToast]
+  );
+
+  // Import every selected folder. Import, create-playlist and remap all apply
+  // per folder, so a multi-selection runs the action for each of them.
+  const importFolders = useCallback(
+    async (dirPaths, recursive) => {
+      if (dirPaths.length === 1) return linkDir(dirPaths[0], recursive);
+      let linked = 0;
+      let total = 0;
+      for (const dirPath of dirPaths) {
+        const res = await linkDir(dirPath, recursive, null, true);
+        linked += res?.linked ?? 0;
+        total += res?.total ?? 0;
+      }
+      showToast(`Linked ${linked}/${total} tracks`);
+    },
+    [linkDir, showToast]
+  );
+
+  const createPlaylistsForFolders = useCallback(
+    async (dirPaths, recursive) => {
+      const silent = dirPaths.length > 1;
+      let created = 0;
+      let linked = 0;
+      let total = 0;
+      for (const dirPath of dirPaths) {
+        const pl = await window.api.createPlaylist(basename(dirPath) || dirPath);
+        const res = await linkDir(dirPath, recursive, pl.id, silent);
+        linked += res?.linked ?? 0;
+        total += res?.total ?? 0;
+        created += 1;
+      }
+      if (silent) showToast(`Created ${created} playlists, linked ${linked}/${total} tracks`);
+    },
+    [linkDir, showToast]
+  );
+
+  const remapFolders = useCallback(
+    async (dirPaths) => {
+      let count = 0;
+      let failed = 0;
+      for (const dirPath of dirPaths) {
+        const res = await window.api.remapFolder(dirPath);
+        if (res?.ok) count += res.count ?? 0;
+        else failed += 1;
+      }
+      if (failed) showToast(`Remap failed for ${failed} folder(s)`, false);
+      else showToast(`Remapped ${count} track(s)`);
+    },
+    [showToast]
+  );
+
+  // Add every selected file to a playlist: unlinked files are linked first
+  // (one call), then all resulting track ids are added in a single request.
+  const addFilesToPlaylist = useCallback(
+    async (filePaths, playlist) => {
+      const isLinkedTrack = (p) => {
+        const t = tracksMap.get(p);
+        return t?.is_linked === 1 && typeof t.id === 'number';
+      };
+      const trackIds = filePaths.filter(isLinkedTrack).map((p) => tracksMap.get(p).id);
+      const toLink = filePaths.filter((p) => !isLinkedTrack(p));
+      if (toLink.length) {
+        const results = await linkFiles(toLink);
+        for (const r of results) if (typeof r.id === 'number') trackIds.push(r.id);
+      }
+      if (trackIds.length) await window.api.addTracksToPlaylist(playlist.id, trackIds);
+      showToast(`Added ${trackIds.length} track(s) to "${playlist.name}"`);
+    },
+    [tracksMap, linkFiles, showToast]
+  );
+
+  // Delete every selected linked file, behind one confirmation listing them all.
+  const removeFiles = useCallback(
+    (filePaths) => {
+      const items = filePaths
+        .map((p) => ({ path: p, id: tracksMap.get(p)?.id }))
+        .filter((x) => typeof x.id === 'number');
+      if (!items.length) return;
+      const names = items.map((x) => basename(x.path));
+      const many = items.length > 1;
+      const listed = `${names.slice(0, 3).join(', ')}${names.length > 3 ? ', …' : ''}`;
+      setConfirmDialog({
+        title: many ? `🗑️ Delete ${items.length} files?` : '🗑️ Delete file?',
+        body: `${
+          many ? `${items.length} files (${listed})` : `"${names[0]}"`
+        } will be permanently deleted from your disk and removed from the library.\n\nThis cannot be undone.`,
+        confirmLabel: many ? `Delete ${items.length} files` : 'Delete file',
+        onConfirm: async () => {
+          setConfirmDialog(null);
+          for (const it of items) await window.api.removeLinkedFile(it.id);
+          setTracksMap((prev) => {
+            const next = new Map(prev);
+            for (const it of items) next.delete(it.path);
+            return next;
+          });
+          if (many) showToast(`Deleted ${items.length} files`);
+          else showToast(`Deleted: ${names[0]}`);
+        },
+      });
+    },
+    [tracksMap, showToast]
   );
 
   const analyzeFolder = useCallback(
@@ -792,9 +904,167 @@ export default function FileExplorerView({ style }) {
   const menuFilename = menuItem ? basename(menuItem.path) : '';
   const menuBrokenMatch =
     menuItem && !menuIsLinked && !menuIsDir ? (brokenByFilename.get(menuFilename) ?? null) : null;
-  const menuLinkedBroken = menuIsLinked
-    ? (brokenTracks.find((b) => b.id === menuTrack?.id) ?? null)
-    : null;
+
+  // ── Context menu model ────────────────────────────────────────────────────
+  // Built from the whole selection (see explorerContextMenu.js): per-item
+  // actions target every selected folder/file with count-aware wording, while
+  // single-item-only actions stay visible but disabled behind a "<N> selected"
+  // header. Nothing below treats the clicked row specially - only its kind
+  // (folder vs file) decides which menu is shown.
+  const menuModel = useMemo(() => {
+    if (!contextMenu?.item) return null;
+    const clicked = contextMenu.item;
+    const isDir = clicked.type === 'dir';
+    const clickedTrack = tracksMap.get(clicked.path) ?? null;
+    const clickedLinked = clickedTrack?.is_linked === 1;
+    const selection = displayItems.filter((x) => selectedPaths.has(x.path));
+    const selectionPaths = selection.map((x) => x.path);
+    return buildExplorerContextMenu({
+      selection,
+      clickedItem: clicked,
+      favourites,
+      playlists: isDir ? [] : playlists,
+      linkedPaths: isDir ? [] : selectionPaths.filter((p) => tracksMap.get(p)?.is_linked === 1),
+      brokenDirPaths: isDir
+        ? selectionPaths.filter((p) => brokenTracks.some((b) => b.file_path.startsWith(p)))
+        : [],
+      brokenFileMatch:
+        !isDir && !clickedLinked ? (brokenByFilename.get(basename(clicked.path)) ?? null) : null,
+      clickedTrackMissing:
+        !isDir && clickedLinked && brokenTracks.some((b) => b.id === clickedTrack?.id),
+    });
+  }, [
+    contextMenu,
+    displayItems,
+    selectedPaths,
+    tracksMap,
+    favourites,
+    playlists,
+    brokenTracks,
+    brokenByFilename,
+  ]);
+
+  // Create a playlist named after the clicked file and link every target into it.
+  const createPlaylistAndLink = async (filePaths) => {
+    const pl = await window.api.createPlaylist(menuFilename);
+    await linkFiles(filePaths, pl.id);
+  };
+
+  const remapClickedFile = async (broken, filePath) => {
+    const r = await window.api.remapTrack(broken.id, filePath);
+    if (r.ok) {
+      setBrokenTracks((p) => p.filter((b) => b.id !== broken.id));
+      showToast(`Remapped: ${broken.title}`);
+    } else showToast('Remap failed', false);
+  };
+
+  // Every action reads its targets from the entry's `paths`, so a menu entry can
+  // never silently fall back to the clicked row.
+  const runMenuAction = (entry) => {
+    const paths = entry.paths ?? [];
+    closeMenu();
+    switch (entry.id) {
+      case 'favourite-add':
+        updateFavourites(paths, true);
+        if (paths.length > 1) showToast(`Added ${paths.length} folders to Favourites`);
+        break;
+      case 'favourite-remove':
+        updateFavourites(paths, false);
+        if (paths.length > 1) showToast(`Removed ${paths.length} folders from Favourites`);
+        break;
+      case 'import-flat':
+        importFolders(paths, false);
+        break;
+      case 'import-recursive':
+        importFolders(paths, true);
+        break;
+      case 'create-playlist-flat':
+        createPlaylistsForFolders(paths, false);
+        break;
+      case 'create-playlist-recursive':
+        createPlaylistsForFolders(paths, true);
+        break;
+      case 'remap-folders':
+        remapFolders(paths);
+        break;
+      case 'add-to-library':
+        linkFiles(paths);
+        break;
+      case 'playlist-new':
+        createPlaylistAndLink(paths);
+        break;
+      case 'playlist-existing':
+        addFilesToPlaylist(paths, { id: entry.playlistId, name: entry.label });
+        break;
+      case 'play':
+        if (menuItem) handleDoubleClick(menuItem);
+        break;
+      case 'edit-details':
+        if (menuTrack) setDetailsTrack(menuTrack);
+        break;
+      case 'prepare-track':
+        if (menuTrack) setBeatGridTrack(menuTrack);
+        break;
+      case 'reanalyze':
+        if (menuTrack) {
+          window.api.reanalyzeTrack(menuTrack.id);
+          showToast('Re-analysis started');
+        }
+        break;
+      case 'normalize':
+        if (menuTrack) {
+          window.api.normalizeTracksAudio({ trackIds: [menuTrack.id] });
+          showToast('Normalization started');
+        }
+        break;
+      case 'remap-track':
+        if (menuBrokenMatch && menuItem) remapClickedFile(menuBrokenMatch, menuItem.path);
+        break;
+      case 'remove-files':
+        removeFiles(paths);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const renderMenuEntry = (entry, key) => {
+    if (entry.type === 'separator') return <div key={key} className="context-menu-separator" />;
+    if (entry.type === 'header')
+      return (
+        <div key={key} className="context-menu-header">
+          {entry.label}
+        </div>
+      );
+    // A submenu parent only hosts children - clicking it must not close the menu.
+    const clickable = Boolean(entry.id) && !entry.submenu && !entry.disabled;
+    const classes = [
+      'context-menu-item',
+      entry.submenu ? 'context-menu-item--has-submenu' : '',
+      entry.disabled ? 'context-menu-item--disabled' : '',
+      entry.danger ? 'context-menu-item--danger' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    return (
+      <div
+        key={key}
+        className={classes}
+        title={entry.disabled ? entry.disabledReason : entry.title}
+        onClick={clickable ? () => runMenuAction(entry) : undefined}
+      >
+        {entry.color && <span style={{ color: entry.color }}>● </span>}
+        {entry.label}
+        {entry.submenu && !entry.disabled && (
+          <div
+            className={`context-submenu${entry.id === 'add-to-playlist' ? ' context-submenu--scrollable' : ''}`}
+          >
+            {entry.submenu.map((sub, i) => renderMenuEntry(sub, `${key}-${i}`))}
+          </div>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div
@@ -1009,274 +1279,7 @@ export default function FileExplorerView({ style }) {
               style={{ top: contextMenu.y + menuShift.y, left: contextMenu.x + menuShift.x }}
               onMouseDown={(e) => e.stopPropagation()}
             >
-              {menuIsDir ? (
-                <>
-                  {favourites.some((f) => f.path === menuItem.path) ? (
-                    <div
-                      className="context-menu-item"
-                      onClick={() => {
-                        closeMenu();
-                        removeFavourite(menuItem.path);
-                      }}
-                    >
-                      ★ Remove from Favourites
-                    </div>
-                  ) : (
-                    <div
-                      className="context-menu-item"
-                      onClick={() => {
-                        closeMenu();
-                        addFavourite(menuItem.path);
-                      }}
-                    >
-                      ⭐ Add to Favourites
-                    </div>
-                  )}
-                  <div className="context-menu-separator" />
-                  <div
-                    className="context-menu-item"
-                    onClick={() => {
-                      closeMenu();
-                      linkDir(menuItem.path, false);
-                    }}
-                  >
-                    📁 Import folder (flat)
-                  </div>
-                  <div
-                    className="context-menu-item"
-                    onClick={() => {
-                      closeMenu();
-                      linkDir(menuItem.path, true);
-                    }}
-                  >
-                    📁 Import folder (recursive)
-                  </div>
-                  <div className="context-menu-separator" />
-                  <div
-                    className="context-menu-item"
-                    onClick={async () => {
-                      closeMenu();
-                      const pl = await window.api.createPlaylist(menuItem.name);
-                      linkDir(menuItem.path, false, pl.id);
-                    }}
-                  >
-                    ➕ Create playlist (flat)
-                  </div>
-                  <div
-                    className="context-menu-item"
-                    onClick={async () => {
-                      closeMenu();
-                      const pl = await window.api.createPlaylist(menuItem.name);
-                      linkDir(menuItem.path, true, pl.id);
-                    }}
-                  >
-                    ➕ Create playlist (recursive)
-                  </div>
-                  {brokenTracks.some((b) => b.file_path.startsWith(menuItem.path)) && (
-                    <>
-                      <div className="context-menu-separator" />
-                      <div
-                        className="context-menu-item"
-                        onClick={async () => {
-                          closeMenu();
-                          const r = await window.api.remapFolder(menuItem.path);
-                          showToast(r.ok ? `Remapped ${r.count} track(s)` : 'Remap failed', r.ok);
-                        }}
-                      >
-                        🔗 Remap broken folder…
-                      </div>
-                    </>
-                  )}
-                </>
-              ) : (
-                <>
-                  {/* Add to library — unlinked files only */}
-                  {!menuIsLinked && (
-                    <>
-                      <div
-                        className="context-menu-item"
-                        onClick={() => {
-                          closeMenu();
-                          linkFiles([menuItem.path]);
-                        }}
-                      >
-                        ➕ Add to library
-                      </div>
-                      <div className="context-menu-separator" />
-                    </>
-                  )}
-
-                  {/* Add to playlist submenu */}
-                  <div className="context-menu-item context-menu-item--has-submenu">
-                    ➕ Add to playlist
-                    <div className="context-submenu context-submenu--scrollable">
-                      <div
-                        className="context-menu-item"
-                        onClick={async () => {
-                          closeMenu();
-                          const pl = await window.api.createPlaylist(menuFilename);
-                          await linkFiles([menuItem.path], pl.id);
-                        }}
-                      >
-                        ✚ New playlist…
-                      </div>
-                      {playlists.length > 0 && <div className="context-menu-separator" />}
-                      {playlists.map((pl) => (
-                        <div
-                          key={pl.id}
-                          className="context-menu-item"
-                          onClick={async () => {
-                            closeMenu();
-                            let trackId = menuTrack?.id;
-                            if (!menuIsLinked || typeof trackId === 'string') {
-                              const results = await linkFiles([menuItem.path]);
-                              trackId = results[0]?.id ?? null;
-                            }
-                            if (trackId && typeof trackId === 'number')
-                              await window.api.addTracksToPlaylist(pl.id, [trackId]);
-                            showToast(`Added to "${pl.name}"`);
-                          }}
-                        >
-                          {pl.color && <span style={{ color: pl.color }}>● </span>}
-                          {pl.name}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-
-                  <div className="context-menu-separator" />
-
-                  {/* Play */}
-                  <div
-                    className="context-menu-item"
-                    onClick={() => {
-                      closeMenu();
-                      handleDoubleClick(menuItem);
-                    }}
-                  >
-                    ▶ Play
-                  </div>
-
-                  {/* Edit / Prepare / Analysis — linked tracks only */}
-                  {menuIsLinked && menuTrack && (
-                    <>
-                      <div className="context-menu-separator" />
-                      <div
-                        className="context-menu-item"
-                        onClick={() => {
-                          closeMenu();
-                          setDetailsTrack(menuTrack);
-                        }}
-                      >
-                        ✏️ Edit Details
-                      </div>
-                      <div
-                        className="context-menu-item"
-                        onClick={() => {
-                          closeMenu();
-                          setBeatGridTrack(menuTrack);
-                        }}
-                      >
-                        🎛 Prepare Track…
-                      </div>
-                      <div className="context-menu-item context-menu-item--has-submenu">
-                        🔬 Analysis
-                        <div className="context-submenu">
-                          <div
-                            className="context-menu-item"
-                            onClick={() => {
-                              closeMenu();
-                              window.api.reanalyzeTrack(menuTrack.id);
-                              showToast('Re-analysis started');
-                            }}
-                          >
-                            🔄 Re-analyze
-                          </div>
-                          <div className="context-menu-separator" />
-                          <div
-                            className="context-menu-item"
-                            onClick={() => {
-                              closeMenu();
-                              window.api.normalizeTracksAudio({ trackIds: [menuTrack.id] });
-                              showToast('Normalization started');
-                            }}
-                          >
-                            🔊 Normalize
-                          </div>
-                        </div>
-                      </div>
-                    </>
-                  )}
-
-                  {/* Remap — only when broken link detected */}
-                  {(menuBrokenMatch || menuLinkedBroken) && (
-                    <>
-                      <div className="context-menu-separator" />
-                      {menuBrokenMatch && (
-                        <div
-                          className="context-menu-item"
-                          title={`Remap broken track: ${menuBrokenMatch.title}`}
-                          onClick={async () => {
-                            closeMenu();
-                            const r = await window.api.remapTrack(
-                              menuBrokenMatch.id,
-                              menuItem.path
-                            );
-                            if (r.ok) {
-                              setBrokenTracks((p) => p.filter((b) => b.id !== menuBrokenMatch.id));
-                              showToast(`Remapped: ${menuBrokenMatch.title}`);
-                            } else showToast('Remap failed', false);
-                          }}
-                        >
-                          🔗 Remap &ldquo;{menuBrokenMatch.title}&rdquo; to this file
-                        </div>
-                      )}
-                      {menuLinkedBroken && (
-                        <div
-                          className="context-menu-item context-menu-item--disabled"
-                          title="This track's file is missing from disk"
-                        >
-                          ⚠️ Broken link — file missing
-                        </div>
-                      )}
-                    </>
-                  )}
-
-                  {/* Remove file */}
-                  {menuIsLinked && (
-                    <>
-                      <div className="context-menu-separator" />
-                      <div
-                        className="context-menu-item context-menu-item--danger"
-                        onClick={() => {
-                          const { path: itemPath, id: trackId } = {
-                            path: menuItem.path,
-                            id: menuTrack.id,
-                          };
-                          closeMenu();
-                          setConfirmDialog({
-                            title: '🗑️ Delete file?',
-                            body: `"${basename(itemPath)}" will be permanently deleted from your disk and removed from the library.\n\nThis cannot be undone.`,
-                            confirmLabel: 'Delete file',
-                            onConfirm: async () => {
-                              setConfirmDialog(null);
-                              await window.api.removeLinkedFile(trackId);
-                              setTracksMap((prev) => {
-                                const next = new Map(prev);
-                                next.delete(itemPath);
-                                return next;
-                              });
-                              showToast(`Deleted: ${basename(itemPath)}`);
-                            },
-                          });
-                        }}
-                      >
-                        🗑️ Remove file
-                      </div>
-                    </>
-                  )}
-                </>
-              )}
+              {menuModel?.entries.map((entry, i) => renderMenuEntry(entry, `menu-${i}`))}
             </div>
           </>
         )}

--- a/renderer/src/HelpView.jsx
+++ b/renderer/src/HelpView.jsx
@@ -87,9 +87,11 @@ const SECTIONS = [
   },
   {
     title: 'Explorer & linked files',
-    keywords: 'filesystem drives usb folder link reference unavailable',
+    keywords: 'filesystem drives usb folder link reference unavailable multi selection count',
     items: [
       'Explorer browses the filesystem: select a folder or files with audio and Add to Library to link them (kept in place), or manage linked files and their availability.',
+      'Select several rows (Ctrl/Cmd+click, Shift+click for a range, Ctrl+A for everything) and right-click: import, create playlist and favourite actions run on every selected folder, with count-aware labels such as Import 3 folders (flat).',
+      'Actions that only make sense on a single row (Play, Edit Details, Prepare Track, Analysis) are shown disabled behind a "3 folders selected" header while several rows are selected, instead of silently acting on the row you clicked.',
       'Removable drives are listed separately, which keeps USB workflow quick. Linked tracks on a disconnected drive show as unavailable rather than disappearing.',
     ],
   },

--- a/renderer/src/MusicLibrary.css
+++ b/renderer/src/MusicLibrary.css
@@ -333,6 +333,18 @@
   background: transparent;
 }
 
+/* Count header shown when a multi-selection includes single-item-only actions */
+.context-menu-header {
+  padding: 6px 16px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8a8a8a;
+  cursor: default;
+  white-space: nowrap;
+}
+
 .context-menu-separator {
   height: 1px;
   background: #3a3a3a;

--- a/renderer/src/__tests__/FileExplorerView.multiselect.test.jsx
+++ b/renderer/src/__tests__/FileExplorerView.multiselect.test.jsx
@@ -1,0 +1,417 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import FileExplorerView from '../FileExplorerView.jsx';
+import { buildExplorerContextMenu, SINGLE_SELECTION_REASON } from '../explorerContextMenu.js';
+
+// Render every virtualized row inline so rows are clickable in jsdom.
+vi.mock('react-window', () => ({
+  List: ({ rowComponent, rowProps, rowCount }) => {
+    const Item = rowComponent;
+    return (
+      <div data-testid="virtual-list">
+        {Array.from({ length: rowCount }, (_, i) => (
+          <Item key={i} index={i} style={{}} {...rowProps} />
+        ))}
+      </div>
+    );
+  },
+}));
+
+vi.mock('../PlayerContext.jsx', () => ({
+  usePlayer: () => ({
+    play: vi.fn(),
+    currentTrack: null,
+    mediaPort: 19876,
+    patchCurrentTrack: vi.fn(),
+  }),
+}));
+
+globalThis.ResizeObserver =
+  globalThis.ResizeObserver ||
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+// ── Model helpers ─────────────────────────────────────────────────────────────
+
+const dir = (name, base = '/home/user') => ({ path: `${base}/${name}`, name, type: 'dir' });
+const file = (name, base = '/home/user/music') => ({
+  path: `${base}/${name}`,
+  name,
+  type: 'file',
+});
+
+const labelsOf = (model) => model.entries.filter((e) => e.type === 'item').map((e) => e.label);
+
+// Searches top-level entries and submenu children.
+const itemOf = (model, id) => {
+  const walk = (entries) => {
+    for (const entry of entries) {
+      if (entry.type === 'item' && entry.id === id) return entry;
+      if (entry.submenu) {
+        const found = walk(entry.submenu);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  };
+  return walk(model.entries);
+};
+
+// ── Pure menu-model tests (#502) ──────────────────────────────────────────────
+
+describe('buildExplorerContextMenu - folders', () => {
+  it('keeps the singular labels and no header for a single folder', () => {
+    const clicked = dir('Alpha');
+    const model = buildExplorerContextMenu({
+      selection: [clicked],
+      clickedItem: clicked,
+    });
+
+    expect(model.kind).toBe('folders');
+    expect(model.count).toBe(1);
+    expect(model.headers).toEqual([]);
+    expect(labelsOf(model)).toEqual([
+      '⭐ Add to Favourites',
+      '📁 Import folder (flat)',
+      '📁 Import folder (recursive)',
+      '➕ Create playlist (flat)',
+      '➕ Create playlist (recursive)',
+    ]);
+    expect(itemOf(model, 'import-flat').paths).toEqual([clicked.path]);
+  });
+
+  it('counts the whole selection and targets every selected folder', () => {
+    const dirs = [dir('Alpha'), dir('Beta'), dir('Gamma')];
+    const model = buildExplorerContextMenu({
+      selection: dirs,
+      clickedItem: dirs[1],
+    });
+
+    expect(model.count).toBe(3);
+    expect(model.headers).toEqual(['3 folders selected']);
+    expect(labelsOf(model)).toEqual([
+      '⭐ Add 3 to Favourites',
+      '📁 Import 3 folders (flat)',
+      '📁 Import 3 folders (recursive)',
+      '➕ Create 3 playlists (flat)',
+      '➕ Create 3 playlists (recursive)',
+    ]);
+    expect(itemOf(model, 'import-flat').paths).toEqual(dirs.map((d) => d.path));
+    expect(itemOf(model, 'import-recursive').paths).toEqual(dirs.map((d) => d.path));
+    expect(itemOf(model, 'create-playlist-flat').paths).toEqual(dirs.map((d) => d.path));
+    expect(itemOf(model, 'create-playlist-recursive').paths).toEqual(dirs.map((d) => d.path));
+  });
+
+  it('splits Add/Remove Favourites into count-aware entries per state', () => {
+    const dirs = [dir('Alpha'), dir('Beta'), dir('Gamma')];
+    const model = buildExplorerContextMenu({
+      selection: dirs,
+      clickedItem: dirs[0],
+      favourites: [{ path: dirs[2].path, name: 'Gamma' }],
+    });
+
+    const add = itemOf(model, 'favourite-add');
+    const remove = itemOf(model, 'favourite-remove');
+    expect(add.label).toBe('⭐ Add 2 to Favourites');
+    expect(add.paths).toEqual([dirs[0].path, dirs[1].path]);
+    expect(remove.label).toBe('★ Remove from Favourites');
+    expect(remove.paths).toEqual([dirs[2].path]);
+  });
+
+  it('offers remap for every selected folder holding broken links', () => {
+    const dirs = [dir('Alpha'), dir('Beta'), dir('Gamma')];
+    const model = buildExplorerContextMenu({
+      selection: dirs,
+      clickedItem: dirs[0],
+      brokenDirPaths: [dirs[0].path, dirs[2].path],
+    });
+
+    const remap = itemOf(model, 'remap-folders');
+    expect(remap.label).toBe('🔗 Remap 2 broken folders…');
+    expect(remap.paths).toEqual([dirs[0].path, dirs[2].path]);
+    expect(remap.disabled).toBeFalsy();
+  });
+
+  it('hides the remap entry when no selected folder has broken links', () => {
+    const dirs = [dir('Alpha'), dir('Beta')];
+    const model = buildExplorerContextMenu({ selection: dirs, clickedItem: dirs[0] });
+    expect(itemOf(model, 'remap-folders')).toBeUndefined();
+  });
+
+  it('ignores selected files when the clicked row is a folder', () => {
+    const dirs = [dir('Alpha'), dir('Beta')];
+    const model = buildExplorerContextMenu({
+      selection: [...dirs, file('one.mp3'), file('two.mp3')],
+      clickedItem: dirs[1],
+    });
+
+    expect(model.kind).toBe('folders');
+    expect(model.count).toBe(2);
+    expect(model.headers).toEqual(['2 folders selected']);
+    expect(itemOf(model, 'import-flat').paths).toEqual(dirs.map((d) => d.path));
+  });
+});
+
+describe('buildExplorerContextMenu - files', () => {
+  it('keeps the singular labels and enables single-item actions for one file', () => {
+    const clicked = file('one.mp3');
+    const model = buildExplorerContextMenu({
+      selection: [clicked],
+      clickedItem: clicked,
+      linkedPaths: [clicked.path],
+      playlists: [{ id: 7, name: 'Warmup' }],
+    });
+
+    expect(model.kind).toBe('files');
+    expect(model.headers).toEqual([]);
+    expect(itemOf(model, 'play').disabled).toBeFalsy();
+    expect(itemOf(model, 'edit-details').disabled).toBeFalsy();
+    expect(itemOf(model, 'prepare-track').disabled).toBeFalsy();
+    expect(itemOf(model, 'analysis').disabled).toBeFalsy();
+    expect(itemOf(model, 'remove-files').label).toBe('🗑️ Remove file');
+    expect(itemOf(model, 'remove-files').paths).toEqual([clicked.path]);
+    expect(itemOf(model, 'remove-files').danger).toBe(true);
+    expect(itemOf(model, 'playlist-existing').playlistId).toBe(7);
+  });
+
+  it('acts on all selected files and disables single-item-only actions', () => {
+    const files = [file('one.mp3'), file('two.mp3'), file('three.mp3')];
+    const model = buildExplorerContextMenu({
+      selection: files,
+      clickedItem: files[1],
+      playlists: [{ id: 7, name: 'Warmup' }],
+    });
+
+    expect(model.headers).toEqual(['3 files selected']);
+    const addLibrary = itemOf(model, 'add-to-library');
+    expect(addLibrary.label).toBe('➕ Add 3 files to library');
+    expect(addLibrary.paths).toEqual(files.map((f) => f.path));
+
+    const playlist = itemOf(model, 'add-to-playlist');
+    expect(playlist.label).toBe('➕ Add 3 files to playlist');
+    expect(itemOf(model, 'playlist-new').paths).toEqual(files.map((f) => f.path));
+    expect(itemOf(model, 'playlist-existing').paths).toEqual(files.map((f) => f.path));
+
+    for (const id of ['play']) {
+      expect(itemOf(model, id).disabled).toBe(true);
+      expect(itemOf(model, id).disabledReason).toBe(SINGLE_SELECTION_REASON);
+    }
+    // Edit/analysis surfaces are single-track only: hidden while files differ.
+    expect(itemOf(model, 'edit-details')).toBeUndefined();
+  });
+
+  it('disables detail/analysis entries for a multi-selection of linked files', () => {
+    const files = [file('one.mp3'), file('two.mp3')];
+    const model = buildExplorerContextMenu({
+      selection: files,
+      clickedItem: files[0],
+      linkedPaths: files.map((f) => f.path),
+    });
+
+    for (const id of ['play', 'edit-details', 'prepare-track', 'analysis']) {
+      expect(itemOf(model, id).disabled).toBe(true);
+      expect(itemOf(model, id).disabledReason).toBe(SINGLE_SELECTION_REASON);
+    }
+    expect(itemOf(model, 'remove-files').label).toBe('🗑️ Remove 2 files');
+    expect(itemOf(model, 'remove-files').paths).toEqual(files.map((f) => f.path));
+    // Disabled parents never expose their submenu.
+    expect(itemOf(model, 'analysis').submenu && itemOf(model, 'analysis').disabled).toBe(true);
+  });
+
+  it('only offers Add to library for the unlinked part of the selection', () => {
+    const files = [file('one.mp3'), file('two.mp3'), file('three.mp3')];
+    const model = buildExplorerContextMenu({
+      selection: files,
+      clickedItem: files[0],
+      linkedPaths: [files[0].path],
+    });
+
+    const addLibrary = itemOf(model, 'add-to-library');
+    expect(addLibrary.label).toBe('➕ Add 2 files to library');
+    expect(addLibrary.paths).toEqual([files[1].path, files[2].path]);
+    expect(itemOf(model, 'remove-files').paths).toEqual([files[0].path]);
+  });
+
+  it('never renders a leading, duplicate or trailing separator', () => {
+    const dirs = [dir('Alpha'), dir('Beta')];
+    const variants = [
+      buildExplorerContextMenu({ selection: dirs, clickedItem: dirs[0] }),
+      buildExplorerContextMenu({
+        selection: [file('one.mp3')],
+        clickedItem: file('one.mp3'),
+        linkedPaths: [file('one.mp3').path],
+      }),
+      buildExplorerContextMenu({
+        selection: [file('one.mp3'), file('two.mp3')],
+        clickedItem: file('one.mp3'),
+      }),
+    ];
+
+    for (const model of variants) {
+      const types = model.entries.map((e) => e.type);
+      expect(types[0]).not.toBe('separator');
+      expect(types[types.length - 1]).not.toBe('separator');
+      for (let i = 1; i < types.length; i += 1) {
+        expect(`${types[i - 1]}|${types[i]}`).not.toBe('separator|separator');
+      }
+    }
+  });
+
+  it('keeps the broken-file remap single-item only', () => {
+    const files = [file('one.mp3'), file('two.mp3')];
+    const single = buildExplorerContextMenu({
+      selection: [files[0]],
+      clickedItem: files[0],
+      brokenFileMatch: { title: 'Lost Track' },
+    });
+    expect(itemOf(single, 'remap-track').label).toBe('🔗 Remap “Lost Track” to this file');
+    expect(itemOf(single, 'remap-track').disabled).toBeFalsy();
+
+    const multi = buildExplorerContextMenu({
+      selection: files,
+      clickedItem: files[0],
+      brokenFileMatch: { title: 'Lost Track' },
+    });
+    expect(itemOf(multi, 'remap-track').disabled).toBe(true);
+    expect(itemOf(multi, 'remap-track').disabledReason).toBe(SINGLE_SELECTION_REASON);
+  });
+
+  it('marks a missing linked file as a disabled informational entry', () => {
+    const clicked = file('one.mp3');
+    const model = buildExplorerContextMenu({
+      selection: [clicked],
+      clickedItem: clicked,
+      linkedPaths: [clicked.path],
+      clickedTrackMissing: true,
+    });
+
+    const broken = model.entries.find((e) => e.label === '⚠️ Broken link - file missing');
+    expect(broken.disabled).toBe(true);
+    expect(broken.id).toBeNull();
+    expect(broken.disabledReason).toBe("This track's file is missing from disk");
+  });
+});
+
+// ── Mounted integration tests ─────────────────────────────────────────────────
+
+const DIRS = ['Alpha', 'Beta', 'Gamma'].map((n) => ({ name: n, path: `/home/user/${n}` }));
+const FILES = ['one.mp3', 'two.mp3', 'three.mp3'].map((n) => ({
+  name: n,
+  path: `/home/user/music/${n}`,
+}));
+
+function renderExplorer({ dirs = DIRS, files = [], linkedTracks = [] } = {}) {
+  window.api.browseDirectory.mockResolvedValue({ dirs, files });
+  window.api.getTracksByPaths.mockResolvedValue(linkedTracks);
+  return render(<FileExplorerView />);
+}
+
+async function waitForRows(selector, count) {
+  await waitFor(() => expect(document.querySelectorAll(selector)).toHaveLength(count));
+  return [...document.querySelectorAll(selector)];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cleanup();
+});
+
+describe('FileExplorerView context menu with a multi-selection (#502)', () => {
+  it('shows count-aware folder labels and imports every selected folder', async () => {
+    renderExplorer();
+    const rows = await waitForRows('.explorer-dir-row', 3);
+
+    // Plain click selects one row, Shift+click extends the range to all three.
+    fireEvent.click(rows[0]);
+    fireEvent.click(rows[2], { shiftKey: true });
+    fireEvent.contextMenu(rows[1]);
+
+    expect(screen.getByText('3 folders selected')).toBeInTheDocument();
+    const importFlat = screen.getByText('📁 Import 3 folders (flat)');
+    expect(screen.getByText('➕ Create 3 playlists (flat)')).toBeInTheDocument();
+
+    fireEvent.click(importFlat);
+
+    await waitFor(() => expect(window.api.linkDirectory).toHaveBeenCalledTimes(3));
+    const called = window.api.linkDirectory.mock.calls.map((c) => c[0]);
+    expect(new Set(called)).toEqual(new Set(DIRS.map((d) => d.path)));
+    // The menu closes after an action.
+    expect(screen.queryByText('3 folders selected')).not.toBeInTheDocument();
+  });
+
+  it('creates one playlist per selected folder', async () => {
+    renderExplorer();
+    const rows = await waitForRows('.explorer-dir-row', 3);
+
+    fireEvent.click(rows[0]);
+    fireEvent.click(rows[2], { shiftKey: true });
+    fireEvent.contextMenu(rows[2]);
+    fireEvent.click(screen.getByText('➕ Create 3 playlists (flat)'));
+
+    await waitFor(() => expect(window.api.createPlaylist).toHaveBeenCalledTimes(3));
+    expect(window.api.createPlaylist.mock.calls.map((c) => c[0])).toEqual([
+      'Alpha',
+      'Beta',
+      'Gamma',
+    ]);
+    await waitFor(() => expect(window.api.linkDirectory).toHaveBeenCalledTimes(3));
+    await waitFor(() =>
+      expect(screen.getByText('Created 3 playlists, linked 0/0 tracks')).toBeInTheDocument()
+    );
+  });
+
+  it('labels a single right-clicked folder in the singular', async () => {
+    renderExplorer();
+    const rows = await waitForRows('.explorer-dir-row', 3);
+
+    fireEvent.contextMenu(rows[1]);
+
+    expect(screen.queryByText(/folders selected/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('📁 Import folder (flat)'));
+    await waitFor(() => expect(window.api.linkDirectory).toHaveBeenCalledTimes(1));
+    expect(window.api.linkDirectory.mock.calls[0][0]).toBe(DIRS[1].path);
+  });
+
+  it('keeps file menu actions on all selected files and disables Play', async () => {
+    renderExplorer({ dirs: [], files: FILES });
+    const rows = await waitForRows('.row:not(.explorer-dir-row)', 3);
+
+    fireEvent.click(rows[0]);
+    fireEvent.click(rows[2], { shiftKey: true });
+    fireEvent.contextMenu(rows[1]);
+
+    expect(screen.getByText('3 files selected')).toBeInTheDocument();
+    const play = screen.getByText('▶ Play').closest('.context-menu-item');
+    expect(play.className).toContain('context-menu-item--disabled');
+    expect(play.title).toBe(SINGLE_SELECTION_REASON);
+
+    fireEvent.click(screen.getByText('➕ Add 3 files to library'));
+    await waitFor(() => expect(window.api.linkAudioFiles).toHaveBeenCalledTimes(1));
+    expect(window.api.linkAudioFiles.mock.calls[0][0]).toEqual(FILES.map((f) => f.path));
+  });
+
+  it('removes every selected linked file behind one confirmation', async () => {
+    const linkedTracks = FILES.map((f, i) => ({
+      id: i + 1,
+      file_path: f.path,
+      is_linked: 1,
+      title: f.name,
+    }));
+    renderExplorer({ dirs: [], files: FILES, linkedTracks });
+    const rows = await waitForRows('.row:not(.explorer-dir-row)', 3);
+    // Wait for the linked state to land in tracksMap (drives the menu labels).
+    await waitFor(() => expect(screen.getAllByTitle('In library')).toHaveLength(3));
+
+    fireEvent.click(rows[0]);
+    fireEvent.click(rows[2], { shiftKey: true });
+    fireEvent.contextMenu(rows[1]);
+
+    fireEvent.click(screen.getByText('🗑️ Remove 3 files'));
+    fireEvent.click(await screen.findByText('Delete 3 files'));
+    await waitFor(() => expect(window.api.removeLinkedFile).toHaveBeenCalledTimes(3));
+    expect(window.api.removeLinkedFile.mock.calls.map((c) => c[0]).sort()).toEqual([1, 2, 3]);
+  });
+});

--- a/renderer/src/explorerContextMenu.js
+++ b/renderer/src/explorerContextMenu.js
@@ -1,0 +1,244 @@
+/**
+ * Pure menu-model builder for the File Explorer context menu.
+ *
+ * The Explorer keeps its multi-selection when an already-selected row is
+ * right-clicked, so every label and every action target must be derived from
+ * the whole selection instead of the clicked row alone.
+ *
+ * Rules implemented here:
+ * - actions that can be applied per item (import, create playlist, add to
+ *   favourites, remap, add to library/playlist, remove file) target EVERY
+ *   selected item of the matching kind, with count-aware wording;
+ * - actions that only make sense on one item (play, edit details, prepare
+ *   track, analysis, remap-this-file) are rendered disabled with a
+ *   "<N> folders selected" / "<N> files selected" header for N > 1, so they
+ *   never silently act on the clicked row only.
+ *
+ * Entries are plain data so the component renders straight from the model:
+ *   { type: 'separator' }
+ *   { type: 'header', label }
+ *   { type: 'item', id, label, paths, disabled, disabledReason, danger,
+ *     title, color, playlistId, submenu }
+ * An item is clickable only when it has an `id` and is not disabled.
+ */
+
+/** Reason attached to entries that only support a single-item selection. */
+export const SINGLE_SELECTION_REASON = 'Available for a single selection only';
+
+function countPhrase(n, singular, plural) {
+  return n === 1 ? singular : plural;
+}
+
+/**
+ * Build the context menu model.
+ *
+ * @param {object} args
+ * @param {Array<{path: string, name: string, type: 'dir'|'file'}>} args.selection
+ *   every currently selected item (the clicked one included)
+ * @param {{path: string, name: string, type: 'dir'|'file'}} args.clickedItem
+ *   the right-clicked row
+ * @param {Array<{path: string}>} [args.favourites] saved favourite folders
+ * @param {string[]} [args.linkedPaths] selected file paths that are linked tracks
+ * @param {string[]} [args.brokenDirPaths] selected dirs holding broken links
+ * @param {{title: string}|null} [args.brokenFileMatch] broken track matching the clicked file name
+ * @param {boolean} [args.clickedTrackMissing] clicked file is a linked track with a missing file
+ * @param {Array<{id: number|string, name: string, color?: string}>} [args.playlists]
+ * @returns {{kind: 'folders'|'files', count: number, headers: string[], entries: Array<object>}}
+ */
+export function buildExplorerContextMenu({
+  selection = [],
+  clickedItem = null,
+  favourites = [],
+  linkedPaths = [],
+  brokenDirPaths = [],
+  brokenFileMatch = null,
+  clickedTrackMissing = false,
+  playlists = [],
+} = {}) {
+  const isDirMenu = clickedItem?.type === 'dir';
+  const ofType = selection.filter((i) => i.type === (isDirMenu ? 'dir' : 'file'));
+  // The clicked row is always part of the selection (handleContextMenu keeps an
+  // existing multi-selection), but fall back to it if it somehow is not.
+  const targets = ofType.length ? ofType : clickedItem ? [clickedItem] : [];
+  const paths = targets.map((t) => t.path);
+  const n = paths.length;
+  const single = n === 1;
+
+  const entries = [];
+  let sepPending = false;
+  const sep = () => {
+    sepPending = true;
+  };
+  const add = (entry) => {
+    if (sepPending && entries.length && entries[entries.length - 1].type !== 'separator') {
+      entries.push({ type: 'separator' });
+    }
+    sepPending = false;
+    entries.push(entry);
+  };
+  const item = (id, label, targetPaths, extra = {}) =>
+    add({ type: 'item', id, label, paths: targetPaths, ...extra });
+
+  const headers = [];
+  if (!single) {
+    const label = isDirMenu ? `${n} folders selected` : `${n} files selected`;
+    headers.push(label);
+    add({ type: 'header', label });
+  }
+
+  if (isDirMenu) {
+    const favPaths = new Set(favourites.map((f) => f.path));
+    const notFav = paths.filter((p) => !favPaths.has(p));
+    const fav = paths.filter((p) => favPaths.has(p));
+
+    if (notFav.length) {
+      item(
+        'favourite-add',
+        `⭐ Add ${countPhrase(notFav.length, 'to Favourites', `${notFav.length} to Favourites`)}`,
+        notFav
+      );
+    }
+    if (fav.length) {
+      item(
+        'favourite-remove',
+        `★ Remove ${countPhrase(fav.length, 'from Favourites', `${fav.length} from Favourites`)}`,
+        fav
+      );
+    }
+
+    sep();
+    item(
+      'import-flat',
+      `📁 Import ${countPhrase(n, 'folder (flat)', `${n} folders (flat)`)}`,
+      paths
+    );
+    item(
+      'import-recursive',
+      `📁 Import ${countPhrase(n, 'folder (recursive)', `${n} folders (recursive)`)}`,
+      paths
+    );
+
+    sep();
+    item(
+      'create-playlist-flat',
+      `➕ Create ${countPhrase(n, 'playlist (flat)', `${n} playlists (flat)`)}`,
+      paths
+    );
+    item(
+      'create-playlist-recursive',
+      `➕ Create ${countPhrase(n, 'playlist (recursive)', `${n} playlists (recursive)`)}`,
+      paths
+    );
+
+    if (brokenDirPaths.length) {
+      sep();
+      item(
+        'remap-folders',
+        `🔗 Remap ${countPhrase(brokenDirPaths.length, 'broken folder…', `${brokenDirPaths.length} broken folders…`)}`,
+        brokenDirPaths
+      );
+    }
+
+    return { kind: 'folders', count: n, headers, entries };
+  }
+
+  // ── File menu ──────────────────────────────────────────────────────────────
+  const linkedSet = new Set(linkedPaths);
+  const unlinked = paths.filter((p) => !linkedSet.has(p));
+  const linked = paths.filter((p) => linkedSet.has(p));
+
+  if (unlinked.length) {
+    item(
+      'add-to-library',
+      `➕ Add ${countPhrase(unlinked.length, 'to library', `${unlinked.length} files to library`)}`,
+      unlinked
+    );
+    sep();
+  }
+
+  // A submenu parent is never clickable on its own; it only hosts its children.
+  add({
+    type: 'item',
+    id: 'add-to-playlist',
+    label: `➕ Add ${countPhrase(n, 'to playlist', `${n} files to playlist`)}`,
+    paths,
+    submenu: [
+      { type: 'item', id: 'playlist-new', label: '✚ New playlist…', paths },
+      ...(playlists.length ? [{ type: 'separator' }] : []),
+      ...playlists.map((pl) => ({
+        type: 'item',
+        id: 'playlist-existing',
+        label: pl.name,
+        color: pl.color,
+        playlistId: pl.id,
+        paths,
+      })),
+    ],
+  });
+
+  sep();
+  item('play', '▶ Play', paths, {
+    disabled: !single,
+    disabledReason: SINGLE_SELECTION_REASON,
+  });
+
+  // Detail editing / analysis always open a single-track surface, so for a
+  // multi-selection they stay visible but disabled (never act on one row).
+  if (linked.length === n && n > 0) {
+    sep();
+    item('edit-details', '✏️ Edit Details', paths, {
+      disabled: !single,
+      disabledReason: SINGLE_SELECTION_REASON,
+    });
+    item('prepare-track', '🎛 Prepare Track…', paths, {
+      disabled: !single,
+      disabledReason: SINGLE_SELECTION_REASON,
+    });
+    add({
+      type: 'item',
+      id: 'analysis',
+      label: '🔬 Analysis',
+      paths,
+      disabled: !single,
+      disabledReason: SINGLE_SELECTION_REASON,
+      submenu: [
+        { type: 'item', id: 'reanalyze', label: '🔄 Re-analyze', paths },
+        { type: 'separator' },
+        { type: 'item', id: 'normalize', label: '🔊 Normalize', paths },
+      ],
+    });
+  }
+
+  if (brokenFileMatch || clickedTrackMissing) {
+    sep();
+    if (brokenFileMatch) {
+      item('remap-track', `🔗 Remap “${brokenFileMatch.title}” to this file`, paths, {
+        disabled: !single,
+        disabledReason: SINGLE_SELECTION_REASON,
+        title: `Remap broken track: ${brokenFileMatch.title}`,
+      });
+    }
+    if (clickedTrackMissing) {
+      add({
+        type: 'item',
+        id: null,
+        label: '⚠️ Broken link - file missing',
+        paths,
+        disabled: true,
+        disabledReason: "This track's file is missing from disk",
+      });
+    }
+  }
+
+  if (linked.length) {
+    sep();
+    item(
+      'remove-files',
+      `🗑️ Remove ${countPhrase(linked.length, 'file', `${linked.length} files`)}`,
+      linked,
+      { danger: true }
+    );
+  }
+
+  return { kind: 'files', count: n, headers, entries };
+}


### PR DESCRIPTION
Closes #502

## What changed
- New `renderer/src/explorerContextMenu.js`: a pure menu-model builder (`buildExplorerContextMenu`). The clicked row only decides folder-vs-file; targets and labels come from the whole selection of that kind, with an `N folders selected` / `N files selected` header shown for N > 1.
- Actions that apply per item now target every selected item, with count-aware labels:
  - folders: add/remove favourites (split by current state: "Add 2 to Favourites" / "Remove from Favourites"), "Import N folders (flat/recursive)", "Create N playlists (flat/recursive)", "Remap N broken folders…" (only over the selected dirs that actually hold broken links)
  - files: "Add N files to library" (unlinked subset), "Add N files to playlist" (new or existing, linked in one call), "Remove N files" (one confirmation listing them)
- Single-item surfaces stay visible but disabled with the reason "Available for a single selection only": Play, Edit Details, Prepare Track, Analysis, and the single-broken-file "Remap … to this file". Their single-track surfaces are hidden when the selection mixes linked/unlinked files. Nothing silently acts on the clicked row any more.
- `FileExplorerView` renders directly from the model and dispatches with the entry's own `paths`; aggregated actions report one combined toast. Existing selection behaviour is unchanged (right-clicking an already-selected row keeps the multi-selection).
- `HelpView` documents the count-aware behaviour.

## Verification
- renderer `npx vitest run src/__tests__`: 18 files, 215 tests passed (new `FileExplorerView.multiselect.test.jsx`: 18 tests - 13 pure model, 5 mounted-component: Ctrl+click/Shift+click selection, count labels, `linkDirectory` called for all 3 folders, `createPlaylist` x3, Play disabled, `linkAudioFiles` with all 3 paths, 3x `removeLinkedFile` behind one confirm)
- root `npx vitest run`: 20 files, 495 tests passed (no main-process change; no new IPC channel was needed)
- root and renderer `npm run lint`: 0 errors (renderer keeps its 6 pre-existing warnings); `npx prettier --check .` clean

## Limits (stated, not hidden)
Verified with jsdom component tests and the pure model; no live `npm run dev` run in this change.